### PR TITLE
Improve mobile menu escape and submenu handling

### DIFF
--- a/wp-content/themes/rytkoset-theme/assets/css/nav.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.css
@@ -133,14 +133,48 @@
 
 /* Mobiilivalikko */
 
+.mobile-menu-layer {
+  position: relative;
+}
+
+.mobile-menu__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(12, 23, 36, 0.65);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 8;
+}
+
+.mobile-menu__overlay.is-active {
+  opacity: 1;
+  visibility: visible;
+}
+
 .mobile-menu {
-  display: none;
+  position: fixed;
+  inset: 0 0 0 auto;
+  width: min(80vw, 380px);
   background: var(--color-primary-dark);
-  border-top: 1px solid var(--color-border-light);
+  border-left: 1px solid var(--color-border-light);
+  box-shadow: -6px 0 18px rgba(0, 0, 0, 0.2);
+  transform: translateX(100%);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: transform 0.3s ease, opacity 0.3s ease, visibility 0.3s ease;
+  z-index: 10;
+  display: block;
+  outline: none;
+  overflow-y: auto;
 }
 
 .mobile-menu--open {
-  display: block;
+  transform: translateX(0);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 .mobile-menu ul {
@@ -161,6 +195,36 @@
 
 .mobile-menu a:hover {
   text-decoration: underline;
+}
+
+.mobile-menu .sub-menu {
+  margin-top: 0.4rem;
+  padding-left: 1rem;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.mobile-submenu-toggle {
+  background: none;
+  border: none;
+  color: var(--color-text-inverted);
+  margin-left: 0.35rem;
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: var(--radius-small);
+}
+
+.mobile-submenu-toggle:focus-visible {
+  outline: 2px solid var(--color-highlight);
+  outline-offset: 2px;
+}
+
+.mobile-submenu-toggle__icon {
+  display: inline-block;
+  transition: transform 0.25s ease;
+}
+
+.submenu-open > .mobile-submenu-toggle .mobile-submenu-toggle__icon {
+  transform: rotate(180deg);
 }
 
 /* Pieni ruutu: desktop-nav piiloon, mobiili esiin */

--- a/wp-content/themes/rytkoset-theme/assets/css/responsive.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/responsive.css
@@ -20,4 +20,8 @@
   .mobile-menu {
     display: none !important;
   }
+
+  .mobile-menu__overlay {
+    display: none !important;
+  }
 }

--- a/wp-content/themes/rytkoset-theme/assets/js/main.js
+++ b/wp-content/themes/rytkoset-theme/assets/js/main.js
@@ -15,23 +15,177 @@
 document.addEventListener('DOMContentLoaded', () => {
   const toggleButton = document.querySelector('.mobile-menu-toggle');
   const mobileMenu = document.getElementById('mobile-menu');
+  const overlay = document.querySelector('.mobile-menu__overlay');
+
+  const focusableSelectors = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
 
   if (!toggleButton || !mobileMenu) return;
 
+  let lastFocusedElement = null;
+
+  const trapFocus = (event) => {
+    if (!mobileMenu.classList.contains('mobile-menu--open') || event.key !== 'Tab') {
+      return;
+    }
+
+    const focusableElements = mobileMenu.querySelectorAll(focusableSelectors);
+    if (!focusableElements.length) {
+      return;
+    }
+
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      last.focus();
+      event.preventDefault();
+    }
+
+    if (!event.shiftKey && document.activeElement === last) {
+      first.focus();
+      event.preventDefault();
+    }
+  };
+
+  const resetSubmenus = () => {
+    const openItems = mobileMenu.querySelectorAll('.menu-item-has-children.submenu-open');
+
+    openItems.forEach((item) => {
+      const toggle = item.querySelector(':scope > .mobile-submenu-toggle');
+      const submenu = item.querySelector(':scope > .sub-menu');
+
+      if (!toggle || !submenu) return;
+
+      toggle.setAttribute('aria-expanded', 'false');
+      submenu.hidden = true;
+      item.classList.remove('submenu-open');
+    });
+  };
+
+  const closeMenu = () => {
+    toggleButton.setAttribute('aria-expanded', 'false');
+    mobileMenu.classList.remove('mobile-menu--open');
+    mobileMenu.setAttribute('aria-hidden', 'true');
+    mobileMenu.setAttribute('aria-expanded', 'false');
+    overlay?.classList.remove('is-active');
+    overlay?.setAttribute('hidden', '');
+
+    resetSubmenus();
+
+    document.removeEventListener('keydown', trapFocus);
+    document.removeEventListener('keydown', handleEscape);
+
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  };
+
+  const openMenu = () => {
+    lastFocusedElement = document.activeElement;
+    toggleButton.setAttribute('aria-expanded', 'true');
+    mobileMenu.classList.add('mobile-menu--open');
+    mobileMenu.setAttribute('aria-hidden', 'false');
+    mobileMenu.setAttribute('aria-expanded', 'true');
+    overlay?.classList.add('is-active');
+    overlay?.removeAttribute('hidden');
+
+    mobileMenu.focus();
+
+    document.addEventListener('keydown', trapFocus);
+    document.addEventListener('keydown', handleEscape);
+  };
+
   const toggleMenu = (open) => {
     const isOpen = open !== undefined ? open : !mobileMenu.classList.contains('mobile-menu--open');
-    toggleButton.setAttribute('aria-expanded', String(isOpen));
-    mobileMenu.classList.toggle('mobile-menu--open', isOpen);
+    if (isOpen) {
+      openMenu();
+    } else {
+      closeMenu();
+    }
   };
 
   toggleButton.addEventListener('click', () => {
     toggleMenu();
   });
 
-  // Esc-näppäin sulkee mobiilivalikon
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      toggleMenu(false);
+  const handleEscape = (event) => {
+    if (event.key !== 'Escape') return;
+
+    const activeSubmenuItem = mobileMenu.querySelector('.menu-item-has-children.submenu-open');
+    if (activeSubmenuItem) {
+      const toggle = activeSubmenuItem.querySelector(':scope > .mobile-submenu-toggle');
+      const submenu = activeSubmenuItem.querySelector(':scope > .sub-menu');
+
+      if (toggle && submenu) {
+        toggle.setAttribute('aria-expanded', 'false');
+        submenu.hidden = true;
+        activeSubmenuItem.classList.remove('submenu-open');
+        toggle.focus();
+        return;
+      }
     }
-  });
+
+    toggleMenu(false);
+  };
+
+  if (overlay) {
+    overlay.addEventListener('click', () => toggleMenu(false));
+  }
+
+  const initSubmenuToggles = () => {
+    const submenuItems = mobileMenu.querySelectorAll('.menu-item-has-children');
+
+    submenuItems.forEach((item, index) => {
+      const submenu = item.querySelector(':scope > .sub-menu');
+      if (!submenu) return;
+
+      const submenuId = submenu.id || `mobile-submenu-${index}`;
+      submenu.id = submenuId;
+
+      const toggle = document.createElement('button');
+      toggle.type = 'button';
+      toggle.className = 'mobile-submenu-toggle';
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.setAttribute('aria-controls', submenuId);
+      toggle.innerHTML = `
+        <span class="screen-reader-text">
+          ${toggleButton.getAttribute('data-submenu-label') || 'Avaa alavalikko'}
+        </span>
+        <span aria-hidden="true" class="mobile-submenu-toggle__icon">▾</span>
+      `;
+
+      const link = item.querySelector(':scope > a');
+      if (link) {
+        link.insertAdjacentElement('afterend', toggle);
+      } else {
+        item.prepend(toggle);
+      }
+
+      submenu.hidden = true;
+
+      toggle.addEventListener('click', () => {
+        const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!isExpanded));
+        submenu.hidden = isExpanded;
+        item.classList.toggle('submenu-open', !isExpanded);
+      });
+
+      toggle.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') return;
+
+        toggle.setAttribute('aria-expanded', 'false');
+        submenu.hidden = true;
+        item.classList.remove('submenu-open');
+      });
+    });
+  };
+
+  initSubmenuToggles();
 });

--- a/wp-content/themes/rytkoset-theme/header.php
+++ b/wp-content/themes/rytkoset-theme/header.php
@@ -75,8 +75,10 @@
             <button class="mobile-menu-toggle"
                     type="button"
                     aria-expanded="false"
-                    aria-controls="mobile-menu">
-                <span class="mobile-menu-toggle__icon" aria-hidden="true"></span>
+                    aria-controls="mobile-menu"
+                    aria-haspopup="true"
+                    data-submenu-label="<?php esc_attr_e( 'Avaa alavalikko', 'rytkoset-theme' ); ?>">
+                <span class="mobile-menu-toggle__icon" aria-hidden="true"><span></span></span>
                 <span class="mobile-menu-toggle__label">
                     <?php esc_html_e( 'Valikko', 'rytkoset-theme' ); ?>
                 </span>
@@ -107,20 +109,26 @@
     </div><!-- .site-header__inner -->
 
     <!-- Varsinainen mobiilivalikko (placeholder, logiikka lisätään myöhemmin) -->
-    <nav id="mobile-menu"
-        class="mobile-menu"
-        aria-label="<?php esc_attr_e( 'Mobiilivalikko', 'rytkoset-theme' ); ?>">
-        <?php
-        wp_nav_menu(
-            array(
-                'theme_location' => 'primary',
-                'menu_class'     => 'mobile-menu__list',
-                'container'      => false,
-                'fallback_cb'    => false,
-            )
-        );
-        ?>
-    </nav>
+    <div class="mobile-menu-layer">
+        <div class="mobile-menu__overlay" aria-hidden="true" hidden></div>
+        <nav id="mobile-menu"
+            class="mobile-menu"
+            aria-label="<?php esc_attr_e( 'Mobiilivalikko', 'rytkoset-theme' ); ?>"
+            aria-hidden="true"
+            aria-expanded="false"
+            tabindex="-1">
+            <?php
+            wp_nav_menu(
+                array(
+                    'theme_location' => 'primary',
+                    'menu_class'     => 'mobile-menu__list',
+                    'container'      => false,
+                    'fallback_cb'    => false,
+                )
+            );
+            ?>
+        </nav>
+    </div>
 
 </header>
 


### PR DESCRIPTION
## Summary
- reset open mobile submenus when the mobile menu is closed to keep ARIA state consistent
- allow Escape to collapse an active submenu before closing the entire mobile menu
- return focus to the submenu toggle after closing via Escape for better keyboard navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69284cf9dcd8832c9ae5b9766a1e5179)