### PR TITLE
Clarify single-language scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Projektia seurataan GitHub-issuilla ja epiceillä. Pääepicit:
 6. **EPIC 6 — Saavutettavuus (WCAG 2.1 AA)**
    - Kontrastit, näppäimistökäyttö, ARIA, lomakkeet, dev-testaus
 
+### Rajaukset
+- Sivusto on yksikielinen (suomi). Monikielisyys ja kieliversioita hyödyntävät lisäosat (esim. Polylang, MultilingualPress) eivät ole osa projektin laajuutta eikä niitä ole tarkoitus asentaa.
+
 ---
 
 ### Sisällönhallinnan muistilaput

--- a/docs/menu-structure.md
+++ b/docs/menu-structure.md
@@ -2,6 +2,8 @@
 
 Tämän ohjeen avulla päivität teeman päävalikon ("Primary menu") vaatimusten mukaiseen rakenteeseen ja varmistat, että sama rakenne näkyy sekä desktop- että mobiilinavigaatiossa.
 
+> **Huom.** Sivusto on yksikielinen (suomi). Älä luo kieliversiokohtaisia valikoita tai käytä monikielisyyslisäosia tämän valikon kanssa.
+
 ## 1) Avaa päävalikko
 1. Kirjaudu WordPressin ylläpitoon.
 2. Siirry kohtaan **Appearance → Menus**.


### PR DESCRIPTION
## Summary
- Document that the project remains single-language (Finnish) and multilingual plugins are out of scope
- Note in the menu structure guide that language-specific menus or multilingual plugins should not be used

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692830ca9868832c8741791fe45aa8e2)