### PR TITLE
feat: add WooCommerce membership products checkout guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Kaikki merkittavat muutokset tahan projektiin kirjataan tahan tiedostoon.
 
 ### Added
 - Dokumentaatio WooCommercen ensimmaisesta peruskonfiguraatiosta: `docs/woocommerce-setup.md`
+- Dokumentaatio WooCommercen jasenmaksutuotteista: `docs/woocommerce-membership-products.md`
+- WooCommerceen vuosijasenmaksutuotteet `Yksityishenkilo` ja `Perhe`
+- Kassalle jasenmaksuohje silloin, kun korissa on jasenmaksutuote
 
 ---
 

--- a/docs/woocommerce-membership-products.md
+++ b/docs/woocommerce-membership-products.md
@@ -1,0 +1,45 @@
+# WooCommerce: jasenmaksutuotteet
+
+Tama dokumentti kuvaa ensimmaisen jasenmaksu-slicen paikallisessa Docker-ymparistossa.
+
+## Tehty nyt
+
+- Luotu kaksi WooCommerce-tuotetta:
+  - `Vuosijasenmaksu - Yksityishenkilo`, 30 EUR
+  - `Vuosijasenmaksu - Perhe`, 35 EUR
+- Molemmat tuotteet on toteutettu:
+  - `Simple product`
+  - `Virtual`
+  - `Sold individually`
+- Molemmat tuotteet on sijoitettu kategoriaan `Muut tuotteet`.
+- Tuotteille on lisatty selkeat nimet, hinnat ja kuvaukset.
+- Tuotekuvauksissa kerrotaan:
+  - jasenyys on voimassa sukukokousten valisen ajan
+  - nykyinen kausi on `2023 - 2026`
+- Kassalle on lisatty ohjeteksti tilanteisiin, joissa korissa on jasenmaksutuote:
+  - kaikkien jasenten nimet tulee kirjoittaa `Lisatietoja`-kenttaan
+  - tiedot voidaan kirjata jasenrekisteriin
+
+## Tekniset huomiot
+
+- Jasenmaksutuotteet on merkitty omalla tuotemetadata-lipulla:
+  - `_rytkoset_member_names_required = yes`
+- Teema nayttaa kassaoheen vain silloin, kun korissa on tuote, jolla tuo metadata on kaytossa.
+- Kassaoheen renderointi tehdaan teemassa, koska WooCommerce Block Checkout ei nayttanyt luotettavasti normaalia sivusisaltoa nykyisessa teemassa.
+
+## Testattu nyt
+
+- Molemmat tuotteet ovat olemassa WooCommercessa oikeilla hinnoilla.
+- Molemmat tuotteet ovat virtuaalisia ja myydaan yksittain.
+- Tuote voidaan lisata ostoskoriin.
+- `Kassa`-sivu latautuu jasenmaksutuotteen kanssa.
+- Kassasivulle syotetaan teeman kautta jasenmaksuohje oikeassa sessiossa.
+
+## Jatetaan seuraaviin tiketteihin
+
+- `Ainaisjasenmaksu`, 100 EUR
+- Jasenyyden uusintalogiikka
+- Mahdollinen jasenkategoria tai oma tuoteryhma jasenmaksuille
+- Jasenrekisteri-integraatio
+- Automaattiset merkinnat tai kasittelysaannot tilauksille
+- Mahdollinen erillinen kuittaus- tai sahkopostiviesti jasenmaksuille

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -15,11 +15,13 @@ Tama dokumentti kuvaa ensimmaisen WooCommerce-slicen paikallisessa Docker-ympari
 - Kaupan perusasetukset varmistettu:
   - valuutta `EUR`
   - maa `FI`
+- Kaupan osoitetiedot taydennetty wp-adminissa.
 - Sahkopostin minimiasetukset varmistettu:
   - lahettajan nimi `Rytkosten sukuseura`
   - lahettajan osoite `ilkka@rytkoset.net`
 - Ensimmainen maksutapa otettu kayttoon:
   - `Tilisiirto`
+- Tilisiirron pankkitiedot taydennetty wp-adminissa.
 - Tuotekategoriat luotu:
   - `Sukulehdet`
   - `Sukukirjat`
@@ -36,24 +38,17 @@ Tama dokumentti kuvaa ensimmaisen WooCommerce-slicen paikallisessa Docker-ympari
 
 ## Jatetaan seuraaviin tiketteihin
 
-- Kaupan katuosoite, kaupunki ja postinumero.
-  Osoite on asetetettu wp-administa.
-- Tilisiirron oikeat pankkitiedot on asetettu:
-  - tilinomistaja
-  - IBAN
-  - BIC
-  - mahdollinen viitenumerokaytanto
 - Lasku maksutapana, jos se halutaan erillisena vaihtoehtona.
 - Tuotepohjat ja WooCommerce-layoutin sovitus teemaan.
 - Oikeat tuotteet:
-  - jasenmaksut
   - sukulehdet
   - sukukirjat
   - digitaaliset tuotteet
+- Jasenmaksutuotteet on dokumentoitu erikseen tiedostossa `docs/woocommerce-membership-products.md`.
 - Checkoutin sisallollinen ja saavutettava hienosaato.
 - Sahkopostien sisallon ja ulkoasun tarkempi viimeistely.
 - Verot, toimitukset ja muut myyntilogiikan asetukset.
 
 ## Huomio
 
-`Tilisiirto` on otettu kayttoon minimikonfiguraatiolla, mutta sita ei voi ottaa oikeaan tuotantokayttoon ennen pankkitietojen taydentamista.
+`Tilisiirto` on nyt kaytossa paikallisessa ymparistossa. Ennen tuotantokayttoa asetukset ja pankkitiedot on viela tarkistettava dev- ja tuotantoymparistoissa erikseen.

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -88,6 +88,18 @@
   gap: 1rem;
 }
 
+.rytkoset-checkout-note {
+  margin: 0 0 1.5rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface-alt);
+}
+
+.rytkoset-checkout-note p {
+  margin: 0;
+}
+
 /* Share */
 .share {
   border-top: 1px solid var(--color-border-neutral);

--- a/wp-content/themes/rytkoset-theme/assets/js/main.js
+++ b/wp-content/themes/rytkoset-theme/assets/js/main.js
@@ -407,3 +407,39 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 })();
+
+(function () {
+  const config = window.rytkosetCheckoutConfig;
+
+  if (!config || !config.showMembershipNote || !config.membershipNoteHtml) {
+    return;
+  }
+
+  const insertMembershipNote = () => {
+    const checkoutRoot = document.querySelector('.wp-block-woocommerce-checkout, .wc-block-checkout');
+
+    if (!checkoutRoot || document.querySelector('.rytkoset-checkout-note')) {
+      return false;
+    }
+
+    checkoutRoot.insertAdjacentHTML('beforebegin', config.membershipNoteHtml);
+    return true;
+  };
+
+  if (insertMembershipNote()) {
+    return;
+  }
+
+  const observer = new MutationObserver(() => {
+    if (insertMembershipNote()) {
+      observer.disconnect();
+    }
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+
+  window.setTimeout(() => observer.disconnect(), 10000);
+})();

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -358,6 +358,19 @@ function rytkoset_theme_scripts() {
         true // footer
     );
 
+	if ( function_exists( 'is_checkout' ) && is_checkout() ) {
+		wp_add_inline_script(
+			'rytkoset-theme-main',
+			'window.rytkosetCheckoutConfig = ' . wp_json_encode(
+				array(
+					'showMembershipNote' => rytkoset_theme_cart_requires_member_names(),
+					'membershipNoteHtml' => rytkoset_theme_get_membership_checkout_notice_markup(),
+				)
+			) . ';',
+			'before'
+		);
+	}
+
     // Load PhotoSwipe on album archive, single albums, and fallback query var (plain permalinks).
     if (
         is_post_type_archive( 'gallery_album' )
@@ -818,4 +831,51 @@ function rytkoset_theme_login_backlink_text() {
 	<?php
 }
 add_action( 'login_footer', 'rytkoset_theme_login_backlink_text' );
+
+/**
+ * Returns true when the current cart contains a membership product
+ * that requires member names in the order note.
+ *
+ * @return bool
+ */
+function rytkoset_theme_cart_requires_member_names() {
+	if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+		return false;
+	}
+
+	foreach ( WC()->cart->get_cart() as $cart_item ) {
+		$product = isset( $cart_item['data'] ) ? $cart_item['data'] : null;
+
+		if ( ! $product instanceof WC_Product ) {
+			continue;
+		}
+
+		$requires_member_names = $product->get_meta( '_rytkoset_member_names_required', true );
+
+		if ( 'yes' === $requires_member_names ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Builds the checkout notice shown for membership payments.
+ *
+ * @return string
+ */
+function rytkoset_theme_get_membership_checkout_notice_markup() {
+	$notice_text = html_entity_decode(
+		'<strong>J&auml;sen- ja perhej&auml;senmaksu:</strong> Kirjoita kaikkien j&auml;senten nimet kassalla Lis&auml;tietoja-kentt&auml;&auml;n, jotta tiedot voidaan kirjata j&auml;senrekisteriin.',
+		ENT_QUOTES,
+		'UTF-8'
+	);
+
+	return sprintf(
+		'<div class="rytkoset-checkout-note" role="note"><p>%s</p></div>',
+		wp_kses_post( $notice_text )
+	);
+}
+
 


### PR DESCRIPTION
## Summary

This PR adds the first WooCommerce membership payment slice for the Rytköset site.

It introduces two membership products:
- `Vuosijäsenmaksu – Yksityishenkilö` (`30 €`)
- `Vuosijäsenmaksu – Perhe` (`35 €`)

It also adds a checkout note that tells customers to write all member names into the `Lisätietoja` field so the information can be recorded in the membership register.

## Changes

- added WooCommerce membership products for individual and family payments
- marked membership products as virtual and sold individually
- added conditional checkout guidance for membership orders in the theme
- added styling for the checkout notice
- updated WooCommerce setup documentation
- added separate documentation for membership products
- updated changelog

## Testing

Tested locally in Docker:
- membership products exist with correct prices
- products can be added to cart
- checkout loads correctly
- bank transfer is available as payment method
- membership note is shown on checkout when a membership product is in cart

## Follow-up

Not included in this PR:
- `Ainaisjäsenmaksu`
- membership renewal logic
- membership register integration
- further checkout localization / Finnish language cleanup
