### PR TITLE
feat: add Tampere 2026 participant fields to WooCommerce checkout

### DIFF
--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -45,6 +45,8 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
   - sukukirjat
   - digitaaliset tuotteet
 - Jäsenmaksutuotteet on dokumentoitu erikseen tiedostossa `docs/woocommerce-membership-products.md`.
+- Tampere 2026 -osallistumismaksutuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-product.md`.
+- Tampere 2026 -checkout-kentät on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-checkout-fields.md`.
 - Checkoutin sisällöllinen ja saavutettava hienosäätö.
 - Sähköpostien sisällön ja ulkoasun tarkempi viimeistely.
 - Verot, toimitukset ja muut myyntilogiikan asetukset.

--- a/docs/woocommerce-tampere-2026-checkout-fields.md
+++ b/docs/woocommerce-tampere-2026-checkout-fields.md
@@ -1,0 +1,57 @@
+# WooCommerce: Tampere 2026 checkout-kentät
+
+Tämä dokumentti kuvaa tiketin `#140` toteutusmallin.
+
+## Tavoite
+
+Yksi maksaja voi ilmoittaa samalla tilauksella useamman osallistujan Tampereen sukukokoukseen.
+
+Mallissa:
+
+- yhteyshenkilön tiedot tulevat WooCommercen normaalista checkoutista
+- yksi kappale `Tampere 2026 osallistumismaksu` -tuotetta vastaa yhtä osallistujaa
+- osallistujakohtaiset kentät generoidaan tuotteen kappalemäärän mukaan
+
+## Kerättävät tiedot
+
+### Yhteyshenkilö
+
+WooCommercen normaalit checkout-kentät:
+
+- nimi
+- osoite
+- puhelinnumero
+- sähköposti
+
+### Osallistujat
+
+Jokaiselle osallistujalle kerätään:
+
+- nimi
+- ruokarajoitteet / allergiat
+
+## Tekninen toteutus
+
+- Checkout-kentät rekisteröidään WooCommerce Blocks -kassan lisäkenttärajapinnalla
+- Kentät aktivoituvat vain, jos ostoskorissa on Tampere 2026 -tuote
+- Kenttien määrä perustuu Tampere 2026 -tuotteen kappalemäärään
+- Tunnistus tehdään ensisijaisesti tuotteen SKU:lla `tampere-2026-osallistumismaksu`
+- Kentät tallentuvat tilauksen lisäkentiksiin order-metana
+- Osallistujatiedot näytetään myös WooCommerce-adminissa tilauksen yhteydessä
+
+## Rajaus tässä vaiheessa
+
+- ei osallistujakohtaista jäsenmaksun tilaa
+- ei avec-kenttää erillisenä käsitteenä
+- ei illallisen tai majoituksen lisävalintoja
+- ei erillistä osallistujaraporttia
+- ei erillistä tapahtumarekisteriä
+
+## Testaus
+
+- Lisää Tampere 2026 -tuotetta ostoskoriin 2 kappaletta
+- Varmista, että kassalla näkyy 2 osallistujan kentät
+- Täytä molempien osallistujien nimet
+- Lisää toiselle ruokarajoite
+- Tee testitilaus loppuun
+- Varmista administa, että molemmat osallistujat näkyvät tilauksella luettavasti

--- a/docs/woocommerce-tampere-2026-product.md
+++ b/docs/woocommerce-tampere-2026-product.md
@@ -1,0 +1,64 @@
+# WooCommerce: Tampere 2026 osallistumismaksutuote
+
+Tämä dokumentti kuvaa tiketin `#139` tavoitetilan ja toteutusmallin paikallisessa WordPress-ympäristössä.
+
+## Rajaus tässä vaiheessa
+
+- Tuote koskee vain sukukokouksen varsinaista juhlapäivää `29.8.2026`
+- Perjantain `28.8.2026` iltaohjelmaa ei huomioida tässä vaiheessa
+- Tuote kattaa vain osallistumisen lauantain ohjelmaan
+- Illallinen, majoitus, verkkomaksuintegraatio ja osallistujakohtaiset checkout-kentät jäävät myöhempiin tiketteihin
+
+## Tuotemalli
+
+- Tuotteen nimi: `Tampere 2026 osallistumismaksu`
+- Suositeltu SKU: `tampere-2026-osallistumismaksu`
+- Tuotetyyppi: `Simple product`
+- Virtuaalituote: `Kyllä`
+- Ladattava tuote: `Ei`
+- Hinta: `49 € / henkilö`
+- `Sold individually`: `Ei`
+
+## Myyntilogiikka
+
+- Yksi kappale tuotetta vastaa yhtä osallistujaa
+- Samalla tilauksella voidaan ostaa useampi kappale
+- Tuotteen kappalemäärä kertoo osallistujien lukumäärän
+- Maksutapana riittää tässä vaiheessa nykyinen `Tilisiirto`
+- Checkoutin osallistujakentät tunnistavat tuotteen ensisijaisesti SKU:lla `tampere-2026-osallistumismaksu`
+
+## Tuotekuvauksen minimitiedot
+
+Tuotekuvauksessa pitää kertoa vähintään:
+
+- tapahtuma: `Rytkösten sukukokous 29.8.2026`
+- että osallistumismaksu koskee lauantain ohjelmaa
+- että hinta sisältää buffetlounaan ja iltapäiväkahvin
+- että ilmoittautumisen määräpäivä on `30.7.2026`
+- että ostoskoriin lisätään yhtä monta kappaletta kuin osallistujia
+
+## Esimerkkikuvaus
+
+`Tampere 2026 osallistumismaksu` on Rytkösten sukukokouksen osallistumismaksu lauantaille `29.8.2026`.
+
+Hinta on `49 € / henkilö` ja sisältää buffetlounaan sekä iltapäiväkahvin.
+
+Lisää ostoskoriin yhtä monta kappaletta kuin osallistujia. Ilmoittautumisen määräpäivä on `30.7.2026`.
+
+## Testaus
+
+- Tuote näkyy WooCommerce-adminissa oikealla nimellä
+- Tuotteen hinta on `49 €`
+- Tuote on `Simple product`
+- Tuote on `Virtual`
+- Tuotetta voi lisätä ostoskoriin useamman kappaleen
+- Ostoskorin summa muuttuu oikein kappalemäärän mukaan
+- `Kassa` toimii tuotteen kanssa nykyisellä maksupolulla
+
+## Jätetään seuraaviin tiketteihin
+
+- osallistujakohtaiset tiedot kassalla (`#140`)
+- tapahtuman linkitys maksutuotteeseen (`#138`)
+- määräpäivän ja kapasiteetin hallinta (`#141`)
+- varsinainen verkkomaksuintegraatio (`#145`)
+- perjantain `28.8.2026` iltaohjelman mahdollinen myyntipolku

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -890,4 +890,434 @@ function rytkoset_theme_get_membership_checkout_notice_markup() {
 	);
 }
 
+/**
+ * Returns the SKU used to identify the Tampere 2026 registration product.
+ *
+ * @return string
+ */
+function rytkoset_theme_get_tampere_2026_registration_sku() {
+	return 'tampere-2026-osallistumismaksu';
+}
+
+/**
+ * Returns true when a product is the Tampere 2026 registration product.
+ *
+ * @param WC_Product|null $product WooCommerce product object.
+ * @return bool
+ */
+function rytkoset_theme_is_tampere_2026_registration_product( $product ) {
+	if ( ! $product instanceof WC_Product ) {
+		return false;
+	}
+
+	$registration_mode = $product->get_meta( '_rytkoset_registration_mode', true );
+
+	if ( 'tampere_2026' === $registration_mode ) {
+		return true;
+	}
+
+	return rytkoset_theme_get_tampere_2026_registration_sku() === (string) $product->get_sku();
+}
+
+/**
+ * Returns the Tampere 2026 participant count from the current cart.
+ *
+ * @return int
+ */
+function rytkoset_theme_get_tampere_2026_participant_count() {
+	if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+		return 0;
+	}
+
+	$participant_count = 0;
+
+	foreach ( WC()->cart->get_cart() as $cart_item ) {
+		$product = isset( $cart_item['data'] ) ? $cart_item['data'] : null;
+
+		if ( ! rytkoset_theme_is_tampere_2026_registration_product( $product ) ) {
+			continue;
+		}
+
+		$participant_count += isset( $cart_item['quantity'] ) ? (int) $cart_item['quantity'] : 0;
+	}
+
+	return max( 0, $participant_count );
+}
+
+/**
+ * Returns the maximum number of Tampere 2026 participants supported in one order.
+ *
+ * @return int
+ */
+function rytkoset_theme_get_tampere_2026_max_participants() {
+	return 10;
+}
+
+/**
+ * Returns a JSON Schema fragment that matches when the Tampere 2026 product is in cart.
+ *
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_get_tampere_2026_cart_presence_schema() {
+	$product_id = wc_get_product_id_by_sku( rytkoset_theme_get_tampere_2026_registration_sku() );
+
+	if ( ! $product_id ) {
+		return array(
+			'type' => 'object',
+			'not'  => array(),
+		);
+	}
+
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'cart' => array(
+				'properties' => array(
+					'items' => array(
+						'contains' => array(
+							'const' => (int) $product_id,
+						),
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * Returns a JSON Schema fragment that matches when the Tampere 2026 product is not in cart.
+ *
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_get_tampere_2026_cart_absence_schema() {
+	return array(
+		'not' => rytkoset_theme_get_tampere_2026_cart_presence_schema(),
+	);
+}
+
+/**
+ * Returns a JSON Schema fragment that matches when cart item count is at least the given threshold.
+ *
+ * This MVP assumes the Tampere registration product is purchased on its own,
+ * so total cart quantity is used as the participant count.
+ *
+ * @param int $minimum Minimum item count.
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_get_cart_items_count_minimum_schema( $minimum ) {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'cart' => array(
+				'properties' => array(
+					'items_count' => array(
+						'minimum' => (int) $minimum,
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * Returns a JSON Schema fragment that matches when cart item count is below the given threshold.
+ *
+ * @param int $minimum Minimum item count expected for the field to be relevant.
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_get_cart_items_count_below_schema( $minimum ) {
+	return array(
+		'type'       => 'object',
+		'properties' => array(
+			'cart' => array(
+				'properties' => array(
+					'items_count' => array(
+						'maximum' => max( 0, (int) $minimum - 1 ),
+					),
+				),
+			),
+		),
+	);
+}
+
+/**
+ * Returns a JSON Schema fragment that matches when the participant field should be required.
+ *
+ * @param int $index Participant index starting from 1.
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_get_tampere_2026_participant_required_schema( $index ) {
+	return array(
+		'allOf' => array(
+			rytkoset_theme_get_tampere_2026_cart_presence_schema(),
+			rytkoset_theme_get_cart_items_count_minimum_schema( $index ),
+		),
+	);
+}
+
+/**
+ * Returns a JSON Schema fragment that matches when the participant field should be hidden.
+ *
+ * @param int $index Participant index starting from 1.
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_get_tampere_2026_participant_hidden_schema( $index ) {
+	return array(
+		'anyOf' => array(
+			rytkoset_theme_get_tampere_2026_cart_absence_schema(),
+			rytkoset_theme_get_cart_items_count_below_schema( $index ),
+		),
+	);
+}
+
+/**
+ * Registers participant fields for the Tampere 2026 registration checkout flow.
+ *
+ * Uses WooCommerce Blocks' additional checkout fields API so the fields are
+ * always registered for Store API submissions and then conditionally shown.
+ *
+ * @return void
+ */
+function rytkoset_theme_register_tampere_2026_checkout_fields() {
+	if ( ! function_exists( 'woocommerce_register_additional_checkout_field' ) ) {
+		return;
+	}
+
+	$product_id = wc_get_product_id_by_sku( rytkoset_theme_get_tampere_2026_registration_sku() );
+
+	if ( ! $product_id ) {
+		return;
+	}
+
+	for ( $index = 1; $index <= rytkoset_theme_get_tampere_2026_max_participants(); $index++ ) {
+		$name_field_id = sprintf( 'rytkoset/participant_%d_name', $index );
+		$diet_field_id = sprintf( 'rytkoset/participant_%d_diet', $index );
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                => $name_field_id,
+				'label'             => sprintf( __( 'Osallistuja %d: nimi', 'rytkoset-theme' ), $index ),
+				'location'          => 'order',
+				'type'              => 'text',
+				'required'          => rytkoset_theme_get_tampere_2026_participant_required_schema( $index ),
+				'hidden'            => rytkoset_theme_get_tampere_2026_participant_hidden_schema( $index ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'attributes'        => array(
+					'autocomplete'   => sprintf( 'section-participant-%d-name new-password', $index ),
+					'data-lpignore'  => 'true',
+					'data-1p-ignore' => 'true',
+					'maxLength'      => 200,
+				),
+			)
+		);
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                => $diet_field_id,
+				'label'             => sprintf( __( 'Osallistuja %d: ruokarajoitteet tai allergiat', 'rytkoset-theme' ), $index ),
+				'optionalLabel'     => sprintf( __( 'Osallistuja %d: ruokarajoitteet tai allergiat (valinnainen)', 'rytkoset-theme' ), $index ),
+				'location'          => 'order',
+				'type'              => 'text',
+				'required'          => false,
+				'hidden'            => rytkoset_theme_get_tampere_2026_participant_hidden_schema( $index ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'attributes'        => array(
+					'autocomplete'   => sprintf( 'section-participant-%d-diet new-password', $index ),
+					'data-lpignore'  => 'true',
+					'data-1p-ignore' => 'true',
+					'maxLength'      => 200,
+				),
+			)
+		);
+	}
+}
+add_action( 'woocommerce_init', 'rytkoset_theme_register_tampere_2026_checkout_fields' );
+
+/**
+ * Reads an additional checkout field value from an order.
+ *
+ * @param WC_Order $order    WooCommerce order object.
+ * @param string   $field_id Additional checkout field ID.
+ * @return string
+ */
+function rytkoset_theme_get_order_additional_checkout_field_value( $order, $field_id ) {
+	if ( ! $order instanceof WC_Order ) {
+		return '';
+	}
+
+	if (
+		class_exists( '\Automattic\WooCommerce\Blocks\Package' )
+		&& class_exists( '\Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields' )
+	) {
+		$checkout_fields = \Automattic\WooCommerce\Blocks\Package::container()->get(
+			\Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields::class
+		);
+
+		if ( is_object( $checkout_fields ) && method_exists( $checkout_fields, 'get_all_fields_from_object' ) ) {
+			$fields = $checkout_fields->get_all_fields_from_object( $order, 'other', true );
+
+			if ( isset( $fields[ $field_id ] ) ) {
+				return (string) $fields[ $field_id ];
+			}
+		}
+	}
+
+	return (string) $order->get_meta( '_wc_other/' . $field_id, true );
+}
+
+/**
+ * Returns Tampere 2026 participant data saved on an order.
+ *
+ * @param WC_Order $order WooCommerce order object.
+ * @return array<int, array<string, string>>
+ */
+function rytkoset_theme_get_tampere_2026_order_participants( $order ) {
+	if ( ! $order instanceof WC_Order ) {
+		return array();
+	}
+
+	$participant_count = 0;
+
+	foreach ( $order->get_items() as $item ) {
+		$product = $item->get_product();
+
+		if ( ! rytkoset_theme_is_tampere_2026_registration_product( $product ) ) {
+			continue;
+		}
+
+		$participant_count += (int) $item->get_quantity();
+	}
+
+	if ( $participant_count < 1 ) {
+		return array();
+	}
+
+	$participants = array();
+
+	for ( $index = 1; $index <= $participant_count; $index++ ) {
+		$name = trim(
+			rytkoset_theme_get_order_additional_checkout_field_value(
+				$order,
+				sprintf( 'rytkoset/participant_%d_name', $index )
+			)
+		);
+		$diet = trim(
+			rytkoset_theme_get_order_additional_checkout_field_value(
+				$order,
+				sprintf( 'rytkoset/participant_%d_diet', $index )
+			)
+		);
+
+		if ( '' === $name && '' === $diet ) {
+			continue;
+		}
+
+		$participants[] = array(
+			'name' => $name,
+			'diet' => $diet,
+		);
+	}
+
+	return $participants;
+}
+
+/**
+ * Returns an order object from a meta box callback parameter.
+ *
+ * @param mixed $post_or_order_object Either a WP_Post or WC_Order.
+ * @return WC_Order|false
+ */
+function rytkoset_theme_get_order_from_admin_screen_object( $post_or_order_object ) {
+	if ( $post_or_order_object instanceof WC_Order ) {
+		return $post_or_order_object;
+	}
+
+	if ( $post_or_order_object instanceof WP_Post ) {
+		return wc_get_order( $post_or_order_object->ID );
+	}
+
+	return false;
+}
+
+/**
+ * Registers the Tampere 2026 participants metabox for order admin screens.
+ *
+ * Uses a dedicated metabox so the participant list is visible in both legacy
+ * and HPOS order editors.
+ *
+ * @return void
+ */
+function rytkoset_theme_register_tampere_2026_order_metabox() {
+	if ( ! function_exists( 'wc_get_page_screen_id' ) || ! function_exists( 'wc_get_container' ) ) {
+		add_meta_box(
+			'rytkoset-tampere-2026-participants',
+			__( 'Tampere 2026 osallistujat', 'rytkoset-theme' ),
+			'rytkoset_theme_render_tampere_2026_order_participants_metabox',
+			'shop_order',
+			'side',
+			'default'
+		);
+
+		return;
+	}
+
+	$screen = 'shop_order';
+
+	if ( class_exists( '\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController' ) ) {
+		$controller = wc_get_container()->get( \Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class );
+		$screen     = $controller->custom_orders_table_usage_is_enabled()
+			? wc_get_page_screen_id( 'shop-order' )
+			: 'shop_order';
+	}
+
+	add_meta_box(
+		'rytkoset-tampere-2026-participants',
+		__( 'Tampere 2026 osallistujat', 'rytkoset-theme' ),
+		'rytkoset_theme_render_tampere_2026_order_participants_metabox',
+		$screen,
+		'side',
+		'default'
+	);
+}
+add_action( 'add_meta_boxes', 'rytkoset_theme_register_tampere_2026_order_metabox' );
+
+/**
+ * Renders participant details inside the order admin metabox.
+ *
+ * @param mixed $post_or_order_object Either a WP_Post or WC_Order.
+ * @return void
+ */
+function rytkoset_theme_render_tampere_2026_order_participants_metabox( $post_or_order_object ) {
+	$order = rytkoset_theme_get_order_from_admin_screen_object( $post_or_order_object );
+
+	if ( ! $order instanceof WC_Order ) {
+		echo '<p>' . esc_html__( 'Tilausta ei voitu lukea.', 'rytkoset-theme' ) . '</p>';
+		return;
+	}
+
+	$participants = rytkoset_theme_get_tampere_2026_order_participants( $order );
+
+	if ( empty( $participants ) ) {
+		echo '<p>' . esc_html__( 'Tälle tilaukselle ei löytynyt osallistujatietoja.', 'rytkoset-theme' ) . '</p>';
+		return;
+	}
+
+	echo '<p><strong>' . esc_html__( 'Osallistujia:', 'rytkoset-theme' ) . '</strong> ' . esc_html( (string) count( $participants ) ) . '</p>';
+	echo '<ol>';
+
+	foreach ( $participants as $participant ) {
+		echo '<li>';
+		echo '<strong>' . esc_html( $participant['name'] ) . '</strong>';
+
+		if ( '' !== $participant['diet'] ) {
+			echo '<br>';
+			echo esc_html__( 'Ruokarajoitteet / allergiat:', 'rytkoset-theme' ) . ' ' . esc_html( $participant['diet'] );
+		}
+
+		echo '</li>';
+	}
+
+	echo '</ol>';
+}
+
 


### PR DESCRIPTION
## Kuvaus

Tämä PR toteuttaa Tampere 2026 -sukutapahtuman ilmoittautumisen WooCommerce-kassalla niin, että yksi tilaaja voi ilmoittaa samalla tilauksella useita osallistujia.

Tuotteen määrä toimii osallistujamääränä, ja kassalle näytetään sen perusteella osallistujakohtaiset kentät nimille sekä ruokarajoitteille / allergioille. Tiedot tallentuvat tilaukselle ja näkyvät myös WooCommerce-adminissa järjestäjien käyttöä varten.

## Mitä muuttui

- lisätty Tampere 2026 -tuotteen tunnistus SKU:lla `tampere-2026-osallistumismaksu`
- lisätty WooCommerce Blocks -kassaan osallistujakohtaiset lisäkentät
- osallistujakentät näytetään tuotemäärän perusteella
- osallistujien tiedot tallennetaan tilaukselle
- osallistujatiedot näytetään WooCommerce-adminissa erillisessä `Tampere 2026 osallistujat` -laatikossa
- korjattu selain-autofillin aiheuttama virhe, jossa nimi saattoi täyttyä ruokarajoitekenttiin
- dokumentoitu tuotteen perustaminen ja kassakenttien toiminta

## Muutetut tiedostot

- `wp-content/themes/rytkoset-theme/functions.php`
- `docs/woocommerce-setup.md`
- `docs/woocommerce-tampere-2026-product.md`
- `docs/woocommerce-tampere-2026-checkout-fields.md`

## Testaus

- luotu Tampere 2026 -osallistumismaksutuote WooCommerceen
- lisätty tuote ostoskoriin määrällä 2
- varmistettu, että kassalla näkyy 2 osallistujan kentät
- täytetty osallistujien nimet ja ruokarajoitteet
- tehty testitilaus tilisiirrolla
- varmistettu, että tiedot näkyvät kiitossivulla
- varmistettu, että tiedot näkyvät WooCommerce-adminin tilaussivulla

## Huomiot

- osallistujatiedot näkyvät tällä hetkellä adminissa kahdessa kohdassa:
  - WooCommercen tilaustiedoissa
  - erillisessä `Tampere 2026 osallistujat` -laatikossa
- tämä on toistaiseksi hyväksytty ratkaisu
- osallistujalistan koonti, CSV-vienti ja järjestäjäilmoitukset on erotettu jatkotiketteihin
