### PR TITLE
feat: add event custom post type

### DIFF
--- a/wp-content/themes/rytkoset-theme/archive-event.php
+++ b/wp-content/themes/rytkoset-theme/archive-event.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Tapahtuma-arkisto.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+?>
+
+<section class="section">
+	<div class="container section__narrow">
+		<header class="section__header">
+			<h1 class="section__title"><?php post_type_archive_title(); ?></h1>
+			<?php if ( get_the_archive_description() ) : ?>
+				<div class="section__description"><?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?></div>
+			<?php endif; ?>
+		</header>
+
+		<?php if ( have_posts() ) : ?>
+			<div class="article-list">
+				<?php
+				while ( have_posts() ) :
+					the_post();
+					?>
+					<article <?php post_class( 'article' ); ?>>
+						<?php if ( has_post_thumbnail() ) : ?>
+							<a href="<?php the_permalink(); ?>" aria-label="<?php echo esc_attr( get_the_title() ); ?>">
+								<?php the_post_thumbnail( 'large' ); ?>
+							</a>
+						<?php endif; ?>
+
+						<header class="article__header">
+							<h2 class="article__title">
+								<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+							</h2>
+						</header>
+
+						<div class="article__content">
+							<p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 32 ) ); ?></p>
+						</div>
+					</article>
+					<?php
+				endwhile;
+				?>
+			</div>
+
+			<?php
+			the_posts_pagination(
+				array(
+					'prev_text' => __( 'Edelliset', 'rytkoset-theme' ),
+					'next_text' => __( 'Seuraavat', 'rytkoset-theme' ),
+				)
+			);
+			?>
+		<?php else : ?>
+			<p><?php esc_html_e( 'Tapahtumia ei ole vielä julkaistu.', 'rytkoset-theme' ); ?></p>
+		<?php endif; ?>
+	</div>
+</section>
+
+<?php
+get_footer();

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once get_template_directory() . '/inc/social-links.php';
 require_once get_template_directory() . '/inc/share.php';
 require_once get_template_directory() . '/inc/gallery-albums.php';
+require_once get_template_directory() . '/inc/events.php';
 
 if ( ! function_exists( 'rytkoset_theme_get_attachment_display_caption_text' ) ) {
 	/**

--- a/wp-content/themes/rytkoset-theme/inc/events.php
+++ b/wp-content/themes/rytkoset-theme/inc/events.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tapahtumat.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'rytkoset_theme_register_event_cpt' ) ) {
+	/**
+	 * Rekisteröi tapahtumien CPT:n.
+	 */
+	function rytkoset_theme_register_event_cpt() {
+		$labels = array(
+			'name'               => __( 'Tapahtumat', 'rytkoset-theme' ),
+			'singular_name'      => __( 'Tapahtuma', 'rytkoset-theme' ),
+			'menu_name'          => __( 'Tapahtumat', 'rytkoset-theme' ),
+			'name_admin_bar'     => __( 'Tapahtuma', 'rytkoset-theme' ),
+			'add_new'            => __( 'Lisää uusi', 'rytkoset-theme' ),
+			'add_new_item'       => __( 'Lisää uusi tapahtuma', 'rytkoset-theme' ),
+			'new_item'           => __( 'Uusi tapahtuma', 'rytkoset-theme' ),
+			'edit_item'          => __( 'Muokkaa tapahtumaa', 'rytkoset-theme' ),
+			'view_item'          => __( 'Näytä tapahtuma', 'rytkoset-theme' ),
+			'all_items'          => __( 'Kaikki tapahtumat', 'rytkoset-theme' ),
+			'search_items'       => __( 'Etsi tapahtumia', 'rytkoset-theme' ),
+			'not_found'          => __( 'Tapahtumia ei löytynyt.', 'rytkoset-theme' ),
+			'not_found_in_trash' => __( 'Roskakorissa ei ole tapahtumia.', 'rytkoset-theme' ),
+		);
+
+		$args = array(
+			'labels'        => $labels,
+			'public'        => true,
+			'has_archive'   => true,
+			'menu_icon'     => 'dashicons-calendar-alt',
+			'show_in_rest'  => true,
+			'supports'      => array( 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ),
+			'rewrite'       => array(
+				'slug'       => 'tapahtumat',
+				'with_front' => false,
+			),
+		);
+
+		register_post_type( 'event', $args );
+	}
+}
+add_action( 'init', 'rytkoset_theme_register_event_cpt' );

--- a/wp-content/themes/rytkoset-theme/single-event.php
+++ b/wp-content/themes/rytkoset-theme/single-event.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Yksittäinen tapahtuma.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+global $post;
+
+get_header();
+?>
+
+<section class="section">
+	<div class="container section__narrow">
+		<?php
+		if ( have_posts() ) :
+			while ( have_posts() ) :
+				the_post();
+				?>
+				<article <?php post_class( 'article' ); ?>>
+					<header class="article__header">
+						<h1 class="article__title"><?php the_title(); ?></h1>
+					</header>
+
+					<?php if ( has_post_thumbnail() ) : ?>
+						<div class="article__image">
+							<?php the_post_thumbnail( 'large' ); ?>
+						</div>
+					<?php endif; ?>
+
+					<div class="article__content">
+						<?php the_content(); ?>
+					</div>
+
+					<?php
+					rytkoset_theme_share_buttons(
+						array(
+							'heading' => __( 'Jaa tapahtuma', 'rytkoset-theme' ),
+							'post_id' => $post->ID,
+						)
+					);
+					?>
+				</article>
+				<?php
+			endwhile;
+		endif;
+		?>
+	</div>
+</section>
+
+<?php
+get_footer();


### PR DESCRIPTION
## Summary

Adds the first MVP version of the `event` custom post type for managing sukuseura events in WordPress.

This creates the technical foundation needed before linking events to WooCommerce products in #138.

## Changes

- Registers a new `event` custom post type
- Adds the `Tapahtumat` admin menu
- Enables Gutenberg support for events
- Enables event titles, content, excerpts, featured images, and custom fields
- Adds public event URLs under `/tapahtumat/{slug}/`
- Adds an event archive at `/tapahtumat/`
- Adds lightweight templates for:
  - event archive
  - single event page
- Wires the event CPT into the theme through `inc/events.php`

## Scope

This PR intentionally does not add:
- event date, location, price, or registration fields
- WooCommerce product linking
- event registration logic
- payment logic

Those belong to later tickets, especially #138 and #64.

## Testing

- Verified PHP syntax for the new event files and `functions.php`
- Verified that WordPress registers the `event` post type
- Created a local test event
- Verified that the event admin menu appears
- Verified that the public event page works after refreshing permalinks
- Confirmed that permalink refresh via `Settings > Permalinks > Save Changes` is needed after adding the CPT

## Related Issue

Closes #40
