### PR TITLE
feat: add digital product support documentation

### DIFF
--- a/docs/woocommerce-digital-products.md
+++ b/docs/woocommerce-digital-products.md
@@ -1,0 +1,84 @@
+# WooCommerce: digitaaliset tuotteet
+
+Tämä dokumentti kuvaa digitaalisten WooCommerce-tuotteiden ensimmäisen MVP-toteutuksen paikallisessa ympäristössä.
+
+## Toteutusmalli
+
+Digitaaliset tuotteet toteutetaan WooCommercen omalla ladattavan tuotteen mallilla:
+
+- tuotetyyppi: `Simple product`
+- `Virtual`: kyllä
+- `Downloadable`: kyllä
+- tiedosto: PDF WordPressin mediakirjastosta
+- maksutapa: nykyinen `Tilisiirto`
+
+Tässä vaiheessa ei rakenneta omaa digitaalista kirjastoa, vesileimoja, jäsenkohtaisia käyttöoikeuksia tai erillistä tiedostonhallintaa.
+
+## Testituote
+
+Paikalliseen WooCommerceen luodaan testituote:
+
+- nimi: `Digitaalinen testijulkaisu (PDF)`
+- SKU: `DIGI-TEST-PDF`
+- hinta: `1,00 €`
+- kategoria: `Sukukirjat`
+- tiedosto: `digitaalinen-testijulkaisu.pdf`
+- lataustiedoston nimi: `Digitaalinen testijulkaisu`
+
+Testitiedosto on tarkoitettu vain paikalliseen perustestaukseen. Sitä ei käytetä oikeana sukuseuran julkaisuna.
+
+## Latausoikeus
+
+Tilisiirron vuoksi latausoikeutta ei anneta heti tilauksen jälkeen.
+
+WooCommercen asetus `Grant access to downloadable products after payment` on käytössä. Käytännössä tämä tarkoittaa, että `processing`-tilaan siirretty tilaus saa latausoikeuden. `on-hold`-tilassa latausoikeutta ei anneta.
+
+Oletettu ylläpitomalli:
+
+1. Asiakas ostaa digitaalisen tuotteen kassalla.
+2. Tilaus siirtyy tilaan `on-hold`.
+3. Ylläpito tarkistaa maksun saapumisen pankkitililtä.
+4. Ylläpito merkitsee tilauksen käsitellyksi tai valmiiksi.
+5. WooCommerce antaa latausoikeuden normaalin ladattavan tuotteen logiikan kautta.
+
+Tämä on turvallisempi malli kuin latauksen avaaminen heti ennen tilisiirtomaksun vahvistumista.
+
+## Tekniset huomiot
+
+- WooCommercen approved download directories -suojaus on käytössä.
+- Testi-PDF:n upload-hakemisto on lisätty WooCommercen hyväksyttyihin lataushakemistoihin paikallisessa ympäristössä.
+- Testituotteen SKU on pysyvä tunniste: `DIGI-TEST-PDF`.
+- Testitiedosto sijaitsee WordPressin uploads-hakemistossa, jota ei commitata repoon.
+
+## Testattu nyt
+
+- Testituote on `Virtual` ja `Downloadable`.
+- Testituotteella on yksi PDF-lataustiedosto.
+- Testituote kuuluu kategoriaan `Sukukirjat`.
+- Paikallisessa testitilauksessa `on-hold`-tila ei luonut latausoikeutta.
+- Sama testitilaus loi latausoikeuden, kun tilaus siirrettiin `processing`-tilaan.
+- Paikallisessa ympäristössä sähköpostin lähetys ei onnistunut, koska kontissa ei ole `sendmail`-palvelua. Tämä ei estänyt latausoikeuden syntymisen testausta.
+
+## Uuden digitaalisen tuotteen lisääminen
+
+1. Lisää PDF WordPressin mediakirjastoon.
+2. Luo WooCommerce-tuote.
+3. Valitse tuotetyypiksi `Simple product`.
+4. Merkitse tuote `Virtual` ja `Downloadable`.
+5. Lisää PDF tuotteen `Downloadable files` -kohtaan.
+6. Lisää tuotteelle selkeä nimi, kuvaus, hinta ja SKU.
+7. Sijoita tuote sopivaan tuotekategoriaan, esimerkiksi `Sukukirjat` tai `Sukulehdet`.
+8. Testaa ostoskori, kassa ja latausoikeuden syntyminen ennen julkaisua.
+
+## Rajaukset
+
+Tämä MVP ei sisällä:
+
+- erillistä digitaalisten julkaisujen katalogia
+- oikeuksien hallintaa WooCommercen oletuksia pidemmälle
+- vesileimoja
+- PDF-tiedostojen erillistä suojausratkaisua
+- jäsenkohtaisia alennuksia
+- erillistä teemaan rakennettua digitaalista kirjastonäkymää
+
+Nämä voidaan tehdä myöhemmissä tiketeissä, jos tarve tarkentuu.

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -45,6 +45,7 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
   - sukukirjat
   - digitaaliset tuotteet
 - Jäsenmaksutuotteet on dokumentoitu erikseen tiedostossa `docs/woocommerce-membership-products.md`.
+- Digitaaliset tuotteet on dokumentoitu erikseen tiedostossa `docs/woocommerce-digital-products.md`.
 - Tampere 2026 -osallistumismaksutuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-product.md`.
 - Tampere 2026 -checkout-kentät on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-checkout-fields.md`.
 - Tampere 2026 -tapahtumamaksun hallinta on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-management.md`.


### PR DESCRIPTION
## Summary

- Lisää digitaalisten tuotteiden perustuen WooCommercen omilla ladattavan tuotteen ominaisuuksilla
- Luo paikalliseen ympäristöön testattavan PDF-tuotteen digitaalisten tuotteiden smoke-testaukseen
- Dokumentoi ylläpitomallin, latausoikeuden syntymisen ja tämän MVP:n rajaukset

## Changes

- Luotu paikalliseen WooCommerceen ladattava testituote:
  - `Digitaalinen testijulkaisu (PDF)`
  - SKU `DIGI-TEST-PDF`
  - hinta `1,00 €`
  - kategoria `Sukukirjat`
  - `Simple product`, `Virtual`, `Downloadable`
- Lisätty paikallinen testipdf WordPressin mediakirjastoon.
- Liitetty PDF testituotteen `Downloadable files` -kohtaan.
- Varmistettu, että WooCommercen latausoikeus avautuu vasta maksun vahvistuksen jälkeen.
- Lisätty WooCommercen approved download directories -asetuksiin testipdf:n upload-hakemisto paikallisessa ympäristössä.
- Lisätty dokumentti `docs/woocommerce-digital-products.md`.
- Päivitetty `docs/woocommerce-setup.md` viittaamaan digitaalisten tuotteiden dokumenttiin.

## Testing

- Varmistettu, että testituote on `Virtual` ja `Downloadable`.
- Varmistettu, että tuotteella on yksi PDF-lataustiedosto.
- Varmistettu, että tuote kuuluu kategoriaan `Sukukirjat`.
- Tehty paikallinen testitilaus:
  - `on-hold`-tilassa latausoikeuksia ei syntynyt
  - `processing`-tilaan siirrettäessä latausoikeus syntyi
- Varmistettu, että WooCommercen asetus `Grant access to downloadable products after payment` on käytössä.

## Notes

- Tämä PR ei lisää omaa digitaalista kirjastoa, watermarkkeja, jäsenkohtaisia oikeuksia tai teemaan rakennettua kataloginäkymää.
- Testituote ja testipdf ovat paikallista WordPress-dataa eivätkä tule mukaan versionhallintaan.
- Paikallisessa Docker-ympäristössä sähköpostin lähetys ei onnistunut, koska kontissa ei ole `sendmail`-palvelua. Tämä ei estänyt latausoikeuden testausta.
