### PR TITLE
docs: document Mollie payment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ wp-config.php
 # Codex local browser/profile artifacts
 .codex-artifacts/
 
+# Playwright CLI local snapshots/logs
+.playwright-cli/
+
 # htaccess
 /.htaccess
 

--- a/docs/woocommerce-mollie-payments.md
+++ b/docs/woocommerce-mollie-payments.md
@@ -1,0 +1,109 @@
+# WooCommerce: Mollie-maksutavat
+
+Tämä dokumentti kuvaa #145-tiketin paikallisen Mollie-käyttöönoton ja testimallin.
+
+## Rajaus
+
+Tässä vaiheessa Mollie otetaan käyttöön vain paikallisessa/testimoodin käyttöönotossa.
+
+Ei tehdä tässä tiketissä:
+
+- live-avaimia
+- oikeita maksuja
+- MobilePay-käyttöönottoa
+- tuotantodomainin Apple Pay -validointia
+- omaa maksupalveluintegraatiota virallisen Mollie-lisäosan ohi
+
+MobilePay käsitellään erillisessä tiketissä #156. Tuotantokäyttöönotto ja oikeat maksut käsitellään erillisessä tiketissä #157.
+
+## Asennus
+
+Mollie asennetaan WordPress Adminin kautta:
+
+1. Avaa `Plugins -> Add New`.
+2. Hae `Mollie Payments for WooCommerce`.
+3. Valitse virallinen lisäosa: `Mollie Payments for WooCommerce` by `Mollie`.
+4. Paina `Install Now`.
+5. Paina `Activate`.
+
+Pluginia ei lisätä versionhallintaan. `wp-content/plugins/*` on rajattu `.gitignore`ssa pois, joten paikallinen plugin-asennus ei kuulu commitattaviin muutoksiin.
+
+## Asetukset
+
+Mollien asetukset tehdään WooCommercen hallinnassa:
+
+1. Avaa `WooCommerce -> Settings`.
+2. Avaa `Mollie Settings`.
+3. Aseta maksutilaksi `Test API`.
+4. Lisää Mollien test API key.
+5. Tallenna asetukset.
+
+API-avainta ei saa tallentaa dokumentaatioon, koodiin tai GitHubiin.
+
+Mollie Dashboardissa aktivoidaan tämän vaiheen maksutavat, jos tilin ja profiilin ehdot täyttyvät:
+
+- `Pay by Bank`
+- korttimaksut
+- `Apple Pay`
+- `Google Pay`
+
+`Tilisiirto` pidetään WooCommercessa päällä fallback-maksutapana.
+
+WooPaymentsia ei käytetä tässä toteutuksessa. Jos WooPaymentsin maksutapoja näkyy kassalla, ne poistetaan käytöstä WooCommercen maksuasetuksista.
+
+## Paikallinen tila
+
+Paikallisessa ympäristössä 19.4.2026 tarkistettu:
+
+- `Mollie Payments for WooCommerce` on aktiivinen.
+- Mollien testimoodi on päällä.
+- Mollien test API key on asetettu.
+- `Pay by Bank` on käytössä Mollien gateway-asetuksissa.
+- Korttimaksut ovat käytössä Mollien gateway-asetuksissa.
+- `Apple Pay` on käytössä Mollien gateway-asetuksissa.
+- `Tilisiirto` on edelleen käytössä.
+- WooPayments ei ole aktiivinen WordPress-plugin.
+
+`Google Pay` ei näy välttämättä erillisenä WooCommerce-gatewayna. Mollien dokumentaation mukaan Google Pay näkyy Mollie Hosted Checkout -polussa, jos selain, laite ja maksuprofiilin asetukset tukevat sitä.
+
+## Testaus
+
+Testaa paikallisessa ympäristössä vähintään:
+
+1. Lisää ostoskoriin Tampere 2026 -osallistumismaksu tai jäsenmaksutuote.
+2. Siirry kassalle.
+3. Varmista, että Mollie-maksutapa näkyy.
+4. Varmista, että korttimaksun kentät latautuvat testimoodissa.
+5. Tee testitilaus `Tilisiirto`-maksutavalla.
+6. Varmista, että tilisiirto toimii edelleen fallbackina.
+
+Testaa julkisella dev- tai tuotantodomainilla ennen live-käyttöönottoa:
+
+1. Tee Mollien testimaksu onnistuneella maksutilalla.
+2. Varmista, että WooCommerce-tilauksen tila päivittyy oikein.
+3. Tee toinen testitilaus perutulla tai epäonnistuneella maksutilalla.
+4. Varmista, ettei epäonnistunut maksu merkitse tilausta maksetuksi.
+
+## Paikallisen testin tulos
+
+Paikallisessa testissä 19.4.2026 varmistettiin:
+
+- `Tilisiirto` toimii edelleen fallback-maksutapana ja luo tilauksen `on-hold`-tilaan.
+- Mollien korttimaksu näkyy kassalla ja korttikentät latautuvat testimoodissa.
+- WooCommerce Blocks -checkout ei näytä maksutapojen latauksen jälkeen virheellistä "no payment methods" -ilmoitusta.
+- WooPayments ei näy kassalla rinnakkaisena maksupalveluna.
+
+Varsinaista onnistunutta Mollie-testimaksua ei voi vahvistaa pelkässä `localhost`-ympäristössä ilman julkista webhook-osoitetta. Mollie hylkää paikallisen maksun luonnin, koska webhook-osoite `localhost:8000` ei ole Mollien palvelimilta saavutettavissa.
+
+Tämä ei tarkoita, että WooCommerce-checkout tai Mollie-lisäosan paikallinen peruskonfiguraatio olisi rikki. Se tarkoittaa, että maksun onnistunut läpivienti, peruutettu maksu, epäonnistunut maksu ja webhookien statuspäivitykset pitää testata #157-vaiheessa julkisella dev- tai tuotantodomainilla, tai erillisellä tunnelilla, jonka webhook-URL Mollie pystyy tavoittamaan.
+
+Localhost-ympäristössä `Store coming soon` -tila voi estää vierailijakassan näkyvyyden. Jos kassaa testataan ilman kirjautumista, tila pitää kytkeä paikallisesti väliaikaisesti pois ja palauttaa testin jälkeen.
+
+## Lähteet
+
+- Mollie WooCommerce plugin: https://wordpress.org/plugins/mollie-payments-for-woocommerce/
+- Mollie WooCommerce test/go-live: https://docs.mollie.com/docs/woo-test-and-go-live
+- Mollie WooCommerce payment options: https://docs.mollie.com/docs/woo-set-up-payment-options
+- Mollie Apple Pay activation: https://help.mollie.com/hc/en-us/articles/360022855933-How-do-I-activate-Apple-Pay
+- Mollie Google Pay: https://docs.mollie.com/docs/google-pay
+- Mollie Pay by Bank: https://docs.mollie.com/docs/pay-by-bank

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -52,10 +52,11 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Tampere 2026 -osallistujalista adminissa on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-participants-admin.md`.
 - Tampere 2026 -osallistujalistan CSV-vienti on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-participants-csv-export.md`.
 - Tampere 2026 -järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
+- Mollie-maksutapojen paikallinen testikäyttöönotto on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-payments.md`.
 - Checkoutin sisällöllinen ja saavutettava hienosäätö.
 - Sähköpostien sisällön ja ulkoasun tarkempi viimeistely.
 - Verot, toimitukset ja muut myyntilogiikan asetukset.
 
 ## Huomio
 
-`Tilisiirto` on nyt käytössä paikallisessa ympäristössä. Ennen tuotantokäyttöä asetukset ja pankkitiedot on vielä tarkistettava dev- ja tuotantoympäristöissä erikseen.
+`Tilisiirto` on käytössä paikallisessa ympäristössä fallback-maksutapana. Mollie on dokumentoitu erillisenä testikäyttöönottona, mutta ennen tuotantokäyttöä asetukset, maksutavat, webhookit ja pankkitiedot on vielä tarkistettava dev- ja tuotantoympäristöissä erikseen.


### PR DESCRIPTION
## Summary

Toteutetaan #145:n mukainen Mollie-maksutapojen paikallinen/testimoodin käyttöönoton dokumentointi WooCommerceen.

Varsinainen Mollie-plugin on asennettu ja aktivoitu paikallisesti WordPress Adminin kautta, eikä pluginin tiedostoja lisätä repoon. `Tilisiirto` säilyy fallback-maksutapana.

## Changes

- Lisätty dokumentti `docs/woocommerce-mollie-payments.md`.
- Dokumentoitu Mollien paikallinen asennus- ja testimalli.
- Dokumentoitu testimoodin rajaus:
  - ei live-avaimia
  - ei oikeita maksuja
  - ei MobilePayta tässä vaiheessa
  - ei tuotantodomainin Apple Pay -validointia tässä tiketissä
- Dokumentoitu käytettävät maksutavat:
  - Pay by Bank
  - korttimaksut
  - Apple Pay
  - Google Pay mahdollisuuksien mukaan Mollien kautta
  - Tilisiirto fallbackina
- Päivitetty `docs/woocommerce-setup.md` viittaamaan Mollie-dokumenttiin.
- Lisätty `.playwright-cli/` `.gitignore`en paikallisia selaintestauksen snapshotteja ja logeja varten.

## Testing

- Varmistettu paikallisesta tietokannasta, että `Mollie Payments for WooCommerce` on aktiivinen.
- Varmistettu, että Mollien testimoodi on päällä ja test API key on asetettu.
- Varmistettu, että `Pay by Bank`, korttimaksu ja `Apple Pay` ovat käytössä Mollien gateway-asetuksissa.
- Varmistettu, että `Tilisiirto` on edelleen käytössä.
- Varmistettu, että WooPayments ei ole aktiivinen.
- Testattu checkout Playwrightilla:
  - Mollie-korttimaksu näkyy kassalla.
  - Korttikentät latautuvat testimoodissa.
  - `Tilisiirto` näkyy fallback-maksutapana.
  - `Tilisiirto`-testitilaus onnistuu ja menee `on-hold`-tilaan.
- `git diff --check` ajettu muutetuille tiedostoille.

## Notes

Onnistunutta Mollie-testimaksua ei voi vahvistaa pelkällä `localhost`-ympäristöllä, koska Mollie ei pysty tavoittamaan paikallista webhook-osoitetta `localhost:8000`. Tämä on dokumentoitu jatkotestauksen rajauksena.

Varsinainen live-käyttöönotto, webhookien varmistus, onnistunut Mollie-maksu, peruttu maksu ja epäonnistunut maksu kuuluvat erilliseen tuotantokäyttöönoton tikettiin.
