### PR TITLE
docs: document physical product support

### DIFF
--- a/docs/woocommerce-physical-products.md
+++ b/docs/woocommerce-physical-products.md
@@ -1,0 +1,119 @@
+# WooCommerce: fyysiset tuotteet
+
+Tämä dokumentti kuvaa #146-tiketin fyysisten tuotteiden MVP-mallin.
+
+## Rajaus
+
+Fyysisten tuotteiden perustuki tehdään WooCommercen omilla asetuksilla ilman uusia lisäosia tai teemakoodia.
+
+Tässä vaiheessa tuetaan yksinkertaisia fyysisiä tuotteita, kuten:
+
+- painettu `Rytkösten sukulainen` -lehti
+- sukulehdet
+- sukukirjat
+- muut pienet painotuotteet
+
+Tässä vaiheessa ei toteuteta:
+
+- paino- tai kokoperusteisia toimitushintoja
+- monimutkaista varastonhallintaa
+- t-paitojen koko- ja värivariaatioita
+- ulkoista logistiikka- tai varastointegraatiota
+- print-on-demand-mallia
+
+## Toimitusmalli
+
+MVP:n toimitusmalli on `Postitus + nouto`.
+
+WooCommercen toimitusalue:
+
+- nimi: `Suomi`
+- maa: `Finland`
+
+Toimitustavat:
+
+- `Postitus`
+  - tyyppi: `Flat rate`
+  - hinta: `5,90 €`
+- `Nouto tapahtumasta / sovitusti`
+  - tyyppi: `Local pickup`
+  - hinta: `0 €`
+
+Postitus rajataan tässä vaiheessa Suomeen. Nouto tarkoittaa käytännössä tapahtumanoutoa tai erikseen sovittua luovutusta, ei jatkuvaa myymälänoutoa.
+
+Kiinteä `5,90 €` on väliaikainen MVP-postikulu pienille painotuotteille. Hinta pitää tarkistaa ennen oikeiden tuotteiden julkaisua.
+
+## Fyysisen tuotteen luonti
+
+Luo uusi fyysinen tuote WooCommerce-adminissa:
+
+1. Avaa `Products -> Add new product`.
+2. Anna tuotteelle selkeä nimi.
+3. Valitse tuotetyypiksi `Simple product`.
+4. Älä valitse `Virtual`.
+5. Älä valitse `Downloadable`.
+6. Lisää hinta.
+7. Valitse sopiva tuotekategoria, esimerkiksi `Muut tuotteet`, `Sukulehdet` tai `Sukukirjat`.
+8. Lisää kuvaus, jossa kerrotaan toimitus- ja noutomahdollisuudesta.
+9. Julkaise tuote.
+
+Varastonhallintaa ei oteta MVP:ssä käyttöön oletuksena. Jos tuotteen määrä on rajallinen, määrä hallitaan aluksi manuaalisesti tai otetaan WooCommercen oma varastosaldo käyttöön tuotekohtaisesti.
+
+## Paikallinen testituote
+
+Paikalliseen ympäristöön on luotu testituote:
+
+- nimi: `Fyysinen testituote`
+- SKU: `FYYSINEN-TESTI`
+- tyyppi: `Simple product`
+- hinta: `1,00 €`
+- kategoria: `Muut tuotteet`
+- ei `Virtual`
+- ei `Downloadable`
+
+Testituote on paikallista WooCommerce-sisältöä. Sitä ei tallenneta repoon.
+
+## Testaus
+
+Fyysisen tuotteen testipolku:
+
+1. Lisää `Fyysinen testituote` ostoskoriin.
+2. Siirry kassalle.
+3. Varmista, että kassalla näkyy toimitusosoite.
+4. Valitse toimitustavaksi `Postitus`.
+5. Varmista, että loppusummaan lisätään `5,90 €`.
+6. Valitse toimitustavaksi `Nouto tapahtumasta / sovitusti`.
+7. Varmista, ettei toimituskulua lisätä.
+8. Tee testitilaus `Tilisiirto`-maksutavalla.
+9. Varmista WooCommerce-adminissa, että tilauksella näkyy fyysinen tuote ja valittu toimitustapa.
+
+Regressiotestit:
+
+- Digitaalinen ladattava tuote ei saa toimitusvalintaa.
+- Jäsenmaksutuotteet eivät saa toimitusvalintaa.
+- Tampere 2026 -virtuaalituote ei saa toimitusvalintaa.
+- Mollie-maksutapojen näkyvyys ei muutu tämän mallin takia.
+
+## Paikallisen testin tulos
+
+Paikallisessa ympäristössä 19.4.2026 varmistettiin:
+
+- `Suomi`-toimitusalue on olemassa.
+- `Postitus` näkyy kassalla hinnalla `5,90 €`.
+- `Nouto tapahtumasta / sovitusti` näkyy kassalla maksuttomana toimitustapana.
+- `Fyysinen testituote` näyttää kassalla toimitusosoitteen ja toimitustavan valinnan.
+- `Postitus` nostaa `1,00 €` testituotteen loppusumman arvoon `6,90 €`.
+- `Nouto tapahtumasta / sovitusti` pitää `1,00 €` testituotteen loppusumman arvossa `1,00 €`.
+- `Tilisiirto`-testitilaus onnistuu ja tilaukselle tallentuu valittu toimitustapa.
+- Digitaalinen testituote ei näytä toimitusvalintoja.
+- Jäsenmaksutuotteet ja Tampere 2026 -osallistumismaksu ovat edelleen virtuaalisia tuotteita.
+
+## Jatko
+
+Myöhempiin tiketteihin jäävät:
+
+- oikea `Rytkösten sukulainen` -lehden tilaustuote
+- postikulun vahvistaminen oikeiden tuotteiden perusteella
+- mahdolliset tuotevariantit, kuten t-paitojen koot ja värit
+- tuotekohtainen varastosaldo, jos tuotteita on rajattu määrä
+- toimitusmallin tarkennus, jos myyntiä halutaan Suomen ulkopuolelle

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -53,9 +53,10 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Tampere 2026 -osallistujalistan CSV-vienti on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-participants-csv-export.md`.
 - Tampere 2026 -järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
 - Mollie-maksutapojen paikallinen testikäyttöönotto on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-payments.md`.
+- Fyysisten tuotteiden perustuki on dokumentoitu erikseen tiedostossa `docs/woocommerce-physical-products.md`.
 - Checkoutin sisällöllinen ja saavutettava hienosäätö.
 - Sähköpostien sisällön ja ulkoasun tarkempi viimeistely.
-- Verot, toimitukset ja muut myyntilogiikan asetukset.
+- Verot, painoperusteiset toimitukset ja muut tarkemmat myyntilogiikan asetukset.
 
 ## Huomio
 


### PR DESCRIPTION
## Summary

Toteutetaan #146:n mukainen fyysisten tuotteiden perustuki WooCommercen omilla asetuksilla.

MVP-mallina on `Postitus + nouto`: Suomessa toimitettaville fyysisille tuotteille tarjotaan kiinteähintainen postitus sekä maksuton nouto tapahtumasta tai erikseen sovitusti. Repoon lisätään ylläpitodokumentaatio, mutta paikallinen WooCommerce-tuote ja toimitusasetukset jäävät WordPressin tietokantasisällöksi.

## Changes

- Määritetty paikalliseen WooCommerceen toimitusalue `Suomi`.
- Lisätty toimitustavat:
  - `Postitus`, flat rate, `5,90 €`
  - `Nouto tapahtumasta / sovitusti`, local pickup, `0 €`
- Luotu paikallinen fyysinen testituote:
  - `Fyysinen testituote`
  - SKU `FYYSINEN-TESTI`
  - `Simple product`
  - hinta `1,00 €`
  - ei `Virtual`
  - ei `Downloadable`
  - kategoria `Muut tuotteet`
- Lisätty fyysisten tuotteiden ylläpitodokumentti:
  - `docs/woocommerce-physical-products.md`
- Päivitetty WooCommerce-setup-dokumentti viittaamaan fyysisten tuotteiden dokumentaatioon.

## Testing

- Varmistettu tietokannasta, että `Suomi`-toimitusalue on olemassa ja rajattu maahan `FI`.
- Varmistettu, että toimitustavat ovat käytössä:
  - `Postitus`
  - `Nouto tapahtumasta / sovitusti`
- Varmistettu, että `Fyysinen testituote` on julkaistu ja sen metatiedot ovat oikein.
- Testattu checkout Playwrightilla:
  - fyysinen tuote näyttää toimitusosoitteen
  - fyysinen tuote näyttää toimitustapavalinnan
  - `Postitus` nostaa `1,00 €` testituotteen loppusumman arvoon `6,90 €`
  - `Nouto tapahtumasta / sovitusti` pitää loppusumman arvossa `1,00 €`
  - `Tilisiirto`-testitilaus onnistuu ja menee `on-hold`-tilaan
  - tilaukselle tallentuu valittu toimitustapa
- Varmistettu regressiot:
  - digitaalinen ladattava tuote ei näytä toimitusvalintoja
  - jäsenmaksutuotteet ovat edelleen virtuaalisia
  - Tampere 2026 -osallistumismaksu on edelleen virtuaalinen
- `git diff --check` ajettu muutetuille dokumentaatiotiedostoille.

## Notes

WooCommerce Blocks / Mollie näytti ensimmäisellä checkout-latauksella hetkellisen vanhan `There are no payment methods available` -ilmoituksen, mutta reloadin jälkeen maksutavat näkyivät oikein. Tämä havainto ei vaikuttanut liittyvän fyysisten tuotteiden toimitusasetuksiin.

`Store coming soon` kytkettiin paikallisesti testin ajaksi pois päältä ja palautettiin testin jälkeen takaisin päälle.
