### PR TITLE
docs: document Rytkösten sukulainen preorder product

### DIFF
--- a/docs/woocommerce-physical-products.md
+++ b/docs/woocommerce-physical-products.md
@@ -110,9 +110,10 @@ Paikallisessa ympäristössä 19.4.2026 varmistettiin:
 
 ## Jatko
 
+`Rytkösten sukulainen nro 9` -ennakkotilaustuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-rytkosten-sukulainen-product.md`.
+
 Myöhempiin tiketteihin jäävät:
 
-- oikea `Rytkösten sukulainen` -lehden tilaustuote
 - postikulun vahvistaminen oikeiden tuotteiden perusteella
 - mahdolliset tuotevariantit, kuten t-paitojen koot ja värit
 - tuotekohtainen varastosaldo, jos tuotteita on rajattu määrä

--- a/docs/woocommerce-rytkosten-sukulainen-product.md
+++ b/docs/woocommerce-rytkosten-sukulainen-product.md
@@ -1,0 +1,88 @@
+# WooCommerce: Rytkösten sukulainen nro 9 -ennakkotilaustuote
+
+Tämä dokumentti kuvaa #142-tiketin tuotemallin painetulle `Rytkösten sukulainen` -lehdelle.
+
+## Rajaus
+
+Tässä vaiheessa lehti toteutetaan WooCommercen normaalina fyysisenä tuotteena ja pidetään luonnoksena, kunnes julkaisu voidaan hyväksyä.
+
+Toteutus ei sisällä:
+
+- kestotilausta
+- automaattista uusintalaskutusta
+- erillistä lehtitilausjärjestelmää
+- varastosaldon automaatiota
+- teemakoodin muutoksia
+
+Vanhan nro 8 tilaussivun sisältöä voi käyttää referenssinä, mutta sitä ei kopioida sellaisenaan uuden tuotteen lopulliseksi sisällöksi.
+
+## Paikallinen tuote
+
+Paikalliseen WooCommerceen on luotu luonnostilainen tuote:
+
+- nimi: `Rytkösten sukulainen nro 9 – ennakkotilaus`
+- SKU: `RYTKOSTEN-SUKULAINEN-9-ENNAKKO`
+- tyyppi: `Simple product`
+- hinta: `15,00 €`
+- status: `Draft`
+- kategoria: `Sukulehdet`
+- ei `Virtual`
+- ei `Downloadable`
+- varastonhallinta pois päältä MVP-vaiheessa
+
+Tuote on paikallista WooCommerce-sisältöä. Sitä ei tallenneta repoon.
+
+## Tuotekuvaus
+
+Tuotekuvauksen pitää kertoa selkeästi, että kyse on painetun lehden ennakkotilauksesta.
+
+Minimisisältö:
+
+- kyseessä on painettu `Rytkösten sukulainen nro 9`
+- tuote on ennakkotilaus
+- toimitus tapahtuu painatuksen jälkeen
+- asiakas voi valita postituksen tai noudon tapahtumasta / sovitusti
+- lopullinen sisältö, hinta ja julkaisuajankohta vahvistetaan ennen julkaisua
+
+## Toimitusmalli
+
+Tuote käyttää fyysisten tuotteiden MVP-toimitusmallia:
+
+- `Postitus`, hinta `5,90 €`
+- `Nouto tapahtumasta / sovitusti`, hinta `0 €`
+
+Toimitusmalli on dokumentoitu tarkemmin tiedostossa `docs/woocommerce-physical-products.md`.
+
+## Julkaisun tarkistuslista
+
+Ennen kuin tuote muutetaan luonnoksesta julkaistuksi:
+
+- hallitus tai sovittu vastuuhenkilö vahvistaa hinnan
+- painatusaikataulu ja arvioitu toimitusaika ovat tiedossa
+- tuotekuvaus viimeistellään asiakkaalle ymmärrettäväksi
+- toimitus- ja noutoteksti tarkistetaan
+- mahdollinen tuotekuva lisätään
+- postikulu `5,90 €` vahvistetaan oikealle painotuotteelle sopivaksi
+- tuotteen status muutetaan `Draft` -> `Published` vasta hyväksynnän jälkeen
+
+## Testaus
+
+Paikallinen smoke-testi voidaan tehdä näin:
+
+1. Muuta tuote väliaikaisesti julkaistuksi.
+2. Lisää tuote ostoskoriin.
+3. Siirry kassalle.
+4. Varmista, että kassalla näkyy toimitusosoite.
+5. Valitse `Postitus` ja varmista, että loppusummaan lisätään `5,90 €`.
+6. Valitse `Nouto tapahtumasta / sovitusti` ja varmista, ettei toimituskulua lisätä.
+7. Varmista, että `Tilisiirto` toimii fallback-maksutapana.
+8. Palauta tuotteen status testin jälkeen takaisin luonnokseksi.
+
+## Jatko
+
+Mahdolliset myöhemmät tarkennukset:
+
+- tuotteen lopullinen kansikuva
+- varastosaldo, jos painosmäärä on rajallinen
+- tarkempi toimitusviesti tilausvahvistukseen
+- mahdollinen kampanjateksti Tampere 2026 -sukujuhlan yhteyteen

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -54,6 +54,7 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Tampere 2026 -järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
 - Mollie-maksutapojen paikallinen testikäyttöönotto on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-payments.md`.
 - Fyysisten tuotteiden perustuki on dokumentoitu erikseen tiedostossa `docs/woocommerce-physical-products.md`.
+- `Rytkösten sukulainen nro 9` -ennakkotilaustuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-rytkosten-sukulainen-product.md`.
 - Checkoutin sisällöllinen ja saavutettava hienosäätö.
 - Sähköpostien sisällön ja ulkoasun tarkempi viimeistely.
 - Verot, painoperusteiset toimitukset ja muut tarkemmat myyntilogiikan asetukset.


### PR DESCRIPTION
## Summary

Documents the preorder product model for `Rytkösten sukulainen nro 9` and links it into the existing WooCommerce setup docs.

## What Changed

- added `docs/woocommerce-rytkosten-sukulainen-product.md`
  - defines the product as a simple physical WooCommerce preorder product
  - documents the agreed starting price `15,00 €`
  - documents delivery model: `Postitus 5,90 €` / `Nouto tapahtumasta / sovitusti 0 €`
  - adds a publication checklist for moving the product from draft to published
  - documents the local smoke-test flow
- updated `docs/woocommerce-physical-products.md`
  - linked the magazine preorder product doc
  - removed the outdated note that the real magazine product was still entirely pending
- updated `docs/woocommerce-setup.md`
  - added a reference to the magazine preorder product documentation

## Local WooCommerce Content

The actual WooCommerce product was also created locally in WordPress as draft content:

- product: `Rytkösten sukulainen nro 9 – ennakkotilaus`
- SKU: `RYTKOSTEN-SUKULAINEN-9-ENNAKKO`
- price: `15,00 €`
- category: `Sukulehdet`
- status: `Draft`

Note: this product lives in the local WordPress database and is not part of the git diff.

## Testing

- verified the local WooCommerce product exists as a draft physical simple product
- temporarily published the product for a local checkout smoke test
- confirmed `Postitus` adds `5,90 €` and `Nouto tapahtumasta / sovitusti` remains free
- confirmed `Tilisiirto` still works as fallback
- restored the product back to `Draft`
- restored `woocommerce_coming_soon` back to its previous value after testing

## Refs

- #142
