### PR TITLE
157 woocommerce mollie tuotantokäyttöönotto ja hyväksymistestaus

### DIFF
--- a/docs/woocommerce-mollie-go-live.md
+++ b/docs/woocommerce-mollie-go-live.md
@@ -1,0 +1,132 @@
+# WooCommerce: Mollie dev-live käyttöönotto ja hyväksymistestaus
+
+Tämä dokumentti kuvaa `#157`-tiketin käyttöönotto- ja hyväksymistestausmallin.
+
+## Rajaus
+
+Tässä vaiheessa käyttöönotto tehdään ensisijaisesti osoitteessa `dev.rytkoset.net`.
+
+Tämä dokumentti ei tarkoita vielä lopullista `rytkoset.net`-cutoveria, koska tuotantodomain on edelleen vanhassa Joomla-ympäristössä.
+
+Tässä vaiheessa ei toteuteta:
+
+- `MobilePay`-käyttöönottoa
+- lopullista tuotantodomainin Apple Pay -validaatiota
+- kirjanpitointegraatioita
+- omia maksulogiikoita virallisen Mollie-lisäosan ohi
+
+`MobilePay` kuuluu erilliseen tikettiin `#156`.
+
+## Lähtötila
+
+Tämän session aikana varmistettiin:
+
+- `dev.rytkoset.net` on julkisesti saavutettavissa HTTPS:llä
+- julkinen kauppasivu `https://dev.rytkoset.net/kauppa/` näyttää edelleen WooCommercen `coming soon` -näkymän
+- `https://dev.rytkoset.net/wp-admin/` ohjautuu tässä sessiossa WordPressin kirjautumissivulle
+- tästä sessiosta ei ole käytössä dev-ympäristön WordPress-admin-kirjautumista
+- tästä sessiosta ei ole käytössä Mollien live-API-avaimia
+
+Näistä syistä varsinainen live-avainten vaihto, maksutapojen aktivointi, oikeat maksut ja refund-testit eivät ole toteutettavissa pelkästään repoa muokkaamalla.
+
+## Ennen käyttöönottoa
+
+Varmista ennen dev-liveen siirtymistä:
+
+- Mollien `website profile` on hyväksytty live-maksuja varten
+- dev-sivuston WooCommerce-kauppa on oikeasti julkisesti käytettävissä eikä `coming soon` estä kassaa
+- `Mollie Payments for WooCommerce` on jo asennettu ja toimiva testimoodissa
+- WooPayments ei ole käytössä rinnakkaisena verkkomaksuna
+- `Tilisiirto` on edelleen käytössä fallback-maksutapana
+
+Mollien virallisen WooCommerce-ohjeen mukaan liveen siirtyminen tapahtuu lisäämällä live-API-avain ja vaihtamalla `Mollie Payment Mode` arvoon `Live API`.
+
+## Dev-live käyttöönotto
+
+Tee nämä vaiheet WordPress-adminissa dev-ympäristössä:
+
+1. Avaa `WooCommerce -> Settings -> Mollie Settings`.
+2. Lisää `Live API key` vain adminiin.
+3. Vaihda `Mollie Payment Mode` arvoon `Live API`.
+4. Tallenna muutokset.
+5. Aktivoi Mollie Dashboardissa ja WooCommerce-gatewayissa vähintään:
+   - `Pay by Bank`
+   - korttimaksut
+   - `Google Pay`, jos se on käytettävissä tilillä ja tuetussa selaimessa
+   - `Apple Pay`, vain jos dev-domain voidaan validoida ja testilaite/selain tukee sitä
+6. Varmista, että `Tilisiirto` jää näkyviin fallbackiksi.
+7. Varmista, ettei WooPaymentsin maksutapoja näy kassalla.
+
+## Live-testituote
+
+Hyväksymistestejä varten käytä erillistä matala-arvoista tuotetta devissä:
+
+- nimi: `Mollie live testituote`
+- hinta: `1,00 €`
+- tyyppi: `Simple product`
+- `Virtual`: kyllä
+- `Downloadable`: ei
+- näkyvyys rajataan testikäyttöön
+
+Tuotteen tarkoitus on erottaa hyväksymistestit jäsenmaksu- ja tapahtumatuotteista.
+
+## Hyväksymistestaus
+
+Tee vähintään seuraavat oikeat live-testit:
+
+1. `Pay by Bank` onnistunut maksu
+2. korttimaksu tai `Google Pay` onnistunut maksu
+3. peruttu tai keskeytetty maksu
+4. vähintään yksi refund WooCommerce-administa tai Mollien hallinnasta
+
+Varmista jokaisessa testissä:
+
+- tilausnumero syntyy oikein
+- maksutapa tallentuu oikein
+- asiakas palaa maksun jälkeen oikeaan vahvistus- tai virhenäkymään
+- webhook päivittää WooCommerce-tilauksen tilan oikein
+- epäonnistunut tai peruttu maksu ei jää virheellisesti maksetuksi
+- refund näkyy oikein sekä WooCommercessa että Molliessa
+
+## Testitulosten kirjausmalli
+
+Kirjaa devissä vähintään nämä tiedot:
+
+| Testi | Maksutapa | Tulos | WooCommerce-tilaus | Mollie payment ID | Huomio |
+| --- | --- | --- | --- | --- | --- |
+| Onnistunut maksu 1 | Pay by Bank | Pending |  |  |  |
+| Onnistunut maksu 2 | Kortti / Google Pay | Pending |  |  |  |
+| Peruttu maksu | Valittu maksutapa | Pending |  |  |  |
+| Refund | Alkuperäinen maksutapa | Pending |  |  |  |
+
+Merkitse `Pending`-arvon tilalle toteutunut tulos vasta oikean testin jälkeen.
+
+## Apple Pay ja Google Pay
+
+Mollien virallisen dokumentaation mukaan:
+
+- `Apple Pay Direct` toimii vain tuotantoympäristössä, test- tai live-tilassa, Apple-laitteella tai Safarissa
+- Apple Payn näyttäminen edellyttää, että verkkokaupan palvelimella on Apple validation file
+- `Google Pay` voi näkyä Mollien Hosted Checkout -polussa ilman että se näkyy erillisenä gatewayna WooCommercessa
+
+Jos `Apple Pay` tai `Google Pay` ei ole testattavissa devissä tilin, laitteen, selaimen tai domain-validaation vuoksi, este dokumentoidaan eikä sitä kierretä tässä tiketissä omalla teknisellä ratkaisulla.
+
+## Lopullinen tuotantocutover myöhemmin
+
+Kun WordPress siirretään osoitteeseen `rytkoset.net`, tee erillinen viimeinen cutover-checklist:
+
+- lisää oikeat live-avaimet tuotantoon
+- varmista webhookit tuotantodomainille
+- tee Apple Payn lopullinen domain-validointi tuotannossa
+- tee vähintään yksi oikea tuotantomaksu pienellä summalla
+- varmista refund-polku tuotannossa
+- pidä `Tilisiirto` fallbackina käyttöönoton ajan
+
+## Lähteet
+
+- Mollie WooCommerce: Test and go live  
+  https://docs.mollie.com/docs/woo-test-and-go-live
+- Mollie WooCommerce: Set up payment options  
+  https://docs.mollie.com/docs/woo-set-up-payment-options
+- Mollie go-live checklist  
+  https://docs.mollie.com/docs/go-live-checklist

--- a/docs/woocommerce-mollie-payments.md
+++ b/docs/woocommerce-mollie-payments.md
@@ -2,6 +2,8 @@
 
 Tämä dokumentti kuvaa #145-tiketin paikallisen Mollie-käyttöönoton ja testimallin.
 
+Varsinainen dev-live käyttöönotto ja oikeiden hyväksymistestien malli on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-go-live.md`.
+
 ## Rajaus
 
 Tässä vaiheessa Mollie otetaan käyttöön vain paikallisessa/testimoodin käyttöönotossa.

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -53,6 +53,7 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Tampere 2026 -osallistujalistan CSV-vienti on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-participants-csv-export.md`.
 - Tampere 2026 -järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
 - Mollie-maksutapojen paikallinen testikäyttöönotto on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-payments.md`.
+- Mollien dev-live käyttöönotto ja hyväksymistestaus on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-go-live.md`.
 - Fyysisten tuotteiden perustuki on dokumentoitu erikseen tiedostossa `docs/woocommerce-physical-products.md`.
 - `Rytkösten sukulainen nro 9` -ennakkotilaustuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-rytkosten-sukulainen-product.md`.
 - Checkoutin sisällöllinen ja saavutettava hienosäätö.

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -827,6 +827,47 @@ function rytkoset_theme_login_finnish_strings( $translated, $original, $domain )
 add_filter( 'gettext', 'rytkoset_theme_login_finnish_strings', 10, 3 );
 
 /**
+ * Kääntää valitut Mollie WooCommerce -tekstit suomeksi.
+ *
+ * @param string $translated Alkuperäinen käännös.
+ * @param string $original   Lähdeteksti.
+ * @param string $domain     Tekstidomain.
+ * @return string
+ */
+function rytkoset_theme_mollie_finnish_strings( $translated, $original, $domain ) {
+	if ( 'mollie-payments-for-woocommerce' !== $domain ) {
+		return $translated;
+	}
+
+	$locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+
+	if ( 0 !== strpos( (string) $locale, 'fi' ) ) {
+		return $translated;
+	}
+
+	$map = array(
+		', payment pending.' => ', maksu odottaa vahvistusta.',
+		'Please complete your payment by transferring the total amount to the following bank account:' => 'Viimeistele maksu siirtämällä koko summa seuraavalle pankkitilille:',
+		'Beneficiary: %s' => 'Saaja: %s',
+		'Payment reference: %s' => 'Viite: %s',
+		'Please provide the payment reference <strong>%s</strong>' => 'Käytä maksussa viitettä <strong>%s</strong>',
+		'The payment will expire on <strong>%s</strong>.' => 'Maksu vanhenee <strong>%s</strong>.',
+		'The payment will expire on <strong>%s</strong>. Please make sure you transfer the total amount before this date.' => 'Maksu vanhenee <strong>%s</strong>. Varmista, että siirrät koko summan ennen tätä päivää.',
+		'Payment completed by <strong>%1$s</strong> (IBAN (last 4 digits): %2$s, BIC: %3$s)' => 'Maksu suoritettu tililtä <strong>%1$s</strong> (IBAN, 4 viimeistä merkkiä: %2$s, BIC: %3$s)',
+		'%1$s payment pending (%2$s).' => '%1$s: maksu odottaa vahvistusta (%2$s).',
+		'%1$s payment still pending (%2$s) but customer already returned to the store. Status should be updated automatically in the future, if it doesn\'t this might indicate a communication issue between the site and Mollie.' => '%1$s: maksu odottaa edelleen vahvistusta (%2$s), vaikka asiakas on jo palannut kauppaan. Tilan pitäisi päivittyä automaattisesti myöhemmin. Jos näin ei käy, sivuston ja Mollien välillä voi olla yhteysongelma.',
+		'test mode' => 'testitila',
+	);
+
+	if ( isset( $map[ $original ] ) ) {
+		return $map[ $original ];
+	}
+
+	return $translated;
+}
+add_filter( 'gettext', 'rytkoset_theme_mollie_finnish_strings', 10, 3 );
+
+/**
  * Varmistetaan, että back-linkki on suomeksi, vaikka gettext ei osuisi.
  */
 function rytkoset_theme_login_backlink_text() {


### PR DESCRIPTION
## Summary

Translate remaining Mollie bank transfer and pending-payment texts to Finnish in the theme layer.

## What Changed

- added a targeted `gettext` filter in `functions.php`
- translated key customer-facing Mollie strings for Finnish locale
- avoided direct edits to the Mollie plugin

## Covered Texts

- `payment pending`
- bank transfer payment instructions
- beneficiary label
- payment reference text
- expiry text
- selected Mollie admin/order note strings

## Notes

- the fix is limited to the `mollie-payments-for-woocommerce` text domain
- plugin files were not modified
- this should be retested on dev with the SEPA bank transfer flow

## Refs

- #157