### PR TITLE
170 valikon refaktorointi kauppa  tapahtuma  ja ostoskoripolut

### DIFF
--- a/docs/menu-structure.md
+++ b/docs/menu-structure.md
@@ -1,46 +1,63 @@
-# Ensisijaisen valikon päivitys (Appearance → Menus)
+# Ensisijaisen valikon rakenne
 
-Tämän ohjeen avulla päivität teeman päävalikon ("Primary menu") vaatimusten mukaiseen rakenteeseen ja varmistat, että sama rakenne näkyy sekä desktop- että mobiilinavigaatiossa.
+Tämä ohje kuvaa Rytköset-sivuston päävalikon tavoiterakenteen. Valikko ylläpidetään WordPressin adminissa, koska navigaation kohteet ovat WordPressin tietokantasisältöä eivätkä teeman versionoitua koodia.
 
-> **Huom.** Sivusto on yksikielinen (suomi). Älä luo kieliversiokohtaisia valikoita tai käytä monikielisyyslisäosia tämän valikon kanssa.
+## Päätason järjestys
 
-## 1) Avaa päävalikko
-1. Kirjaudu WordPressin ylläpitoon.
-2. Siirry kohtaan **Appearance → Menus**.
-3. Valitse **Primary menu** (tai vastaava päävalikko), ja varmista, että valinta **Display location → Primary menu** on päällä.
+Päävalikon suositeltu järjestys:
 
-## 2) Rakenna valikko vaatimusten mukaan
-Lisää alla oleva perusrakenne ja täydennä linkit sivuihin/tuotekategorioihin, jotka vastaavat projektin vaatimuslistaa.
+1. Sukuseura
+2. Albumit
+3. Tapahtumat
+4. Kauppa
+5. Foorumi
+6. Blogi
 
-- **Etusivu** – linkitä etusivulle (`/`).
-- **Sukuseura** (alavalikko)
-  - *Sukuseuran esittely* (esim. `/sukuseura/sukuseura`)
-  - *Jäsenyys* (esim. `/sukuseura/jaesenyys`)
-  - *Tapahtumat* (esim. `/sukuseura/tapahtumat`)
-- **Valokuvat** (alavalikko)
-  - *Galleria/albumit* (esim. `/valokuvat` tai albumikohtaiset sivut)
-  - *Sukukokousvuodet* (lisää jokaiselle vuodelle oma lapsikohde tarpeen mukaan)
-- **Kauppa** (alavalikko)
-  - *Jäsenmaksut* (WooCommerce-tuote tai kategoria)
-  - *Tuotteet* (pääkategoria tai erilliset tuoteryhmät)
-- **Blogi / Ajankohtaista** – linkitä uutis- tai blogilistaukseen (esim. `/kategoriat/ajankohtaista`).
-- **Yhteystiedot** – linkitä yhteydenotto-/hallitus-sivuun.
+## Kauppa-valikon alasivut
 
-> Täydennä mahdolliset lisäkohteet vaatimuslistan perusteella. Yllä olevat alavalikot ovat minimissään käytössä Sukuseura-, Valokuvat- ja Kauppa-osioissa.
+`Kauppa` toimii alasivullisena valikkokohtana. Lisää sen alle vähintään:
 
-### Lapsikohteiden luominen
-1. Lisää uusi menu item **Add menu items** -paneelista.
-2. Vedä kohde hieman sisennettynä sen yläpuolisen valikkokohteen alle → WordPress luo alavalikon.
-3. Toista, kunnes kaikki alavalikot on rakennettu.
+- Kauppa: `/kauppa/`
+- Ostoskori: `/ostoskori/`
+- Kassa: `/kassa/`
+- Oma tili: `/oma-tili/`
 
-## 3) Tallenna ja julkaise
-1. Napsauta **Save Menu**.
-2. Varmista, että valikko on edelleen julkaistu **Primary menu** -sijaintiin.
+Lisää WooCommercen tuoteryhmät mukaan, kun niiden julkiset polut ovat devissä ja tuotannossa valmiit:
 
-## 4) Testaa näkyminen desktop- ja mobiilinäkymissä
-- **Desktop:** avaa sivusto selaimessa, tarkista, että päävalikko näkyy headerissa ja että alavalikot avautuvat hoverilla/fokuksella.
-- **Mobiili:** avaa sivusto kapealla selaimella tai devtoolsin mobiilitilassa, avaa **Valikko**-painike ja varmista, että samat kohteet ja alavalikot ovat näkyvissä ja avautuvat.
-- Jos valikko ei näy mobiilissa, tarkista, että Primary-valikkoon on liitetty sisältöä; mobiilivalikko käyttää samaa `primary`-sijaintia kuin desktop (`header.php`).
+- Sukulehdet
+- Sukukirjat
+- Muut tuotteet
 
-## 5) Dokumentoi tehdyt muutokset
-Kirjaa muutoksesi projektin muistiinpanoihin tai tikettiin (esim. mitä kohteita lisättiin/muutettiin), jotta muut näkevät, miten valikko vastaa vaatimuslistaa.
+## Albumit ja tapahtumat
+
+- `Albumit` ohjaa valokuva-albumien arkistoon: `/albumit/`
+- `Tapahtumat` ohjaa tapahtuma-arkistoon: `/tapahtumat/`
+
+Älä käytä julkisessa valikossa enää `Valokuvat`-otsikkoa, koska sivuston kuvakokonaisuus on albumipohjainen.
+
+## Ostoskorin pikalinkki
+
+Teema näyttää erillisen `Ostoskori`-pikalinkin headerissa, jos WooCommerce on käytössä.
+
+- Desktopissa pikalinkki näkyy päävalikon vieressä.
+- Mobiilissa pikalinkki näkyy `Valikko`-painikkeen rinnalla.
+- Tuotemäärä näkyy badgena sivun latauksen jälkeen, jos ostoskorissa on tuotteita.
+
+Pikalinkki ei korvaa `Kauppa`-alasivun `Ostoskori`-linkkiä, vaan varmistaa, että ostoskori löytyy nopeasti myös mobiilissa.
+
+## Päivitys WordPress Adminissa
+
+1. Avaa `Ulkoasu -> Valikot`.
+2. Valitse päävalikko ja varmista, että sen sijainti on `Päävalikko`.
+3. Järjestä päätason kohteet yllä olevan järjestyksen mukaisesti.
+4. Nimeä vanha `Valokuvat`-kohde muotoon `Albumit` ja osoita se `/albumit/`-arkistoon.
+5. Lisää `Tapahtumat` ja osoita se `/tapahtumat/`-arkistoon.
+6. Tee `Kauppa`-kohdasta alasivullinen ja lisää kaupan keskeiset polut sen alle.
+7. Tallenna valikko.
+
+## Testaus
+
+- Desktopissa alavalikot avautuvat hoverilla ja näppäimistöfokuksella.
+- Mobiilissa sama valikkorakenne näkyy `Valikko`-paneelissa.
+- `Ostoskori`-pikalinkki näkyy mobiiliheaderissa ja vie `/ostoskori/`-sivulle.
+- `Albumit`, `Tapahtumat`, `Kauppa`, `Ostoskori`, `Kassa` ja `Oma tili` avautuvat ilman 404-virheitä.

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -56,6 +56,7 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Mollien dev-live käyttöönotto ja hyväksymistestaus on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-go-live.md`.
 - Fyysisten tuotteiden perustuki on dokumentoitu erikseen tiedostossa `docs/woocommerce-physical-products.md`.
 - `Rytkösten sukulainen nro 9` -ennakkotilaustuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-rytkosten-sukulainen-product.md`.
+- Kaupan, tapahtumien, albumien ja ostoskorin valikkorakenne on dokumentoitu erikseen tiedostossa `docs/menu-structure.md`.
 - Checkoutin sisällöllinen ja saavutettava hienosäätö.
 - Sähköpostien sisällön ja ulkoasun tarkempi viimeistely.
 - Verot, painoperusteiset toimitukset ja muut tarkemmat myyntilogiikan asetukset.

--- a/wp-content/themes/rytkoset-theme/assets/css/gallery.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/gallery.css
@@ -19,6 +19,12 @@
     transition: transform 150ms ease, box-shadow 150ms ease;
 }
 
+.album-card:only-child {
+    justify-self: start;
+    width: 100%;
+    max-width: calc((1200px - 1.75rem) / 2);
+}
+
 .album-card:hover {
     transform: translateY(-4px);
     box-shadow: 0 16px 40px rgba(0, 0, 0, 0.12);

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
@@ -160,6 +160,68 @@
   background: var(--nav-hover-bg);
 }
 
+.site-header__mobile-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.site-cart-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.65rem;
+  padding: 0.5rem 0.8rem;
+  border-radius: var(--radius-nav);
+  border: 1px solid var(--color-nav-border);
+  background: rgba(251, 191, 36, 0.16);
+  color: var(--color-text-inverted);
+  font-weight: 700;
+  font-size: 0.95rem;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background var(--transition-hover), border-color var(--transition-hover), box-shadow var(--transition-hover), transform var(--transition-hover);
+}
+
+.site-cart-link:hover,
+.site-cart-link:focus-visible {
+  background: rgba(251, 191, 36, 0.28);
+  border-color: rgba(251, 191, 36, 0.9);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
+  color: var(--color-text-inverted);
+  text-decoration: none;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.site-cart-link:focus-visible {
+  outline: var(--nav-focus-outline);
+  outline-offset: 3px;
+}
+
+.site-cart-link__count {
+  display: inline-grid;
+  place-items: center;
+  min-width: 1.35rem;
+  height: 1.35rem;
+  padding: 0 0.35rem;
+  border-radius: 999px;
+  background: var(--color-accent);
+  color: #111827;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.site-cart-link--desktop {
+  display: none;
+}
+
+.site-cart-link--mobile {
+  display: inline-flex;
+}
+
 /* Skip-link */
 /* Accessible screen reader text + skip link */
 .screen-reader-text {

--- a/wp-content/themes/rytkoset-theme/assets/css/responsive.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/responsive.css
@@ -76,6 +76,12 @@
   }
 }
 
+@media (max-width: 1264px) {
+  .account-nav-wrapper {
+    display: none;
+  }
+}
+
 @media (max-width: 1000px) {
   .site-header {
     padding: 1.25rem 0 1.5rem;
@@ -105,10 +111,20 @@
     gap: 0.6rem;
   }
 
-  .mobile-menu-toggle {
+  .site-header__mobile-actions {
     width: min(100%, 540px);
-    justify-content: center;
     margin: 0 auto;
+    justify-content: center;
+  }
+
+  .mobile-menu-toggle {
+    flex: 1 1 auto;
+    width: auto;
+    justify-content: center;
+  }
+
+  .site-cart-link--mobile {
+    flex: 0 0 auto;
   }
 
   .account-menu__user > a,
@@ -230,14 +246,27 @@
 }
 
 @media (max-width: 480px) {
-  .mobile-menu-toggle {
+  .site-header__mobile-actions {
     width: min(100%, 420px);
+  }
+
+  .site-cart-link {
+    padding-inline: 0.65rem;
   }
 }
 
 @media (min-width: 1265px) {
   .site-nav {
     display: block;
+  }
+
+  .site-cart-link--desktop {
+    display: inline-flex;
+  }
+
+  .site-cart-link--mobile,
+  .site-header__mobile-actions {
+    display: none;
   }
 
   .mobile-menu-toggle {

--- a/wp-content/themes/rytkoset-theme/front-page.php
+++ b/wp-content/themes/rytkoset-theme/front-page.php
@@ -35,14 +35,14 @@
   <!-- KOLME NOSTOA -->
   <section class="section">
     <div class="container grid grid--3">
-      <!-- Valokuvat -->
+      <!-- Albumit -->
       <article class="card">
-        <h3 class="card__title">Valokuvat</h3>
+        <h3 class="card__title">Albumit</h3>
         <p class="card__text">
           Katso kuvagalleriasta tunnelmia sukujuhlista ja tapaamisista eri vuosilta.
         </p>
-        <a href="<?php echo esc_url( home_url('/valokuvat') ); ?>" class="card__link">
-          Siirry valokuviin &rarr;
+        <a href="<?php echo esc_url( home_url('/albumit') ); ?>" class="card__link">
+          Siirry albumeihin &rarr;
         </a>
       </article>
 

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -211,6 +211,60 @@ function rytkoset_theme_setup() {
 }
 add_action( 'after_setup_theme', 'rytkoset_theme_setup' );
 
+if ( ! function_exists( 'rytkoset_theme_get_cart_link_markup' ) ) {
+	/**
+	 * Builds a safe WooCommerce cart link for the site navigation.
+	 *
+	 * @param array $args Markup options.
+	 * @return string
+	 */
+	function rytkoset_theme_get_cart_link_markup( $args = array() ) {
+		if ( ! function_exists( 'wc_get_cart_url' ) ) {
+			return '';
+		}
+
+		$defaults = array(
+			'class' => 'site-cart-link',
+		);
+
+		$args     = wp_parse_args( $args, $defaults );
+		$cart_url = wc_get_cart_url();
+
+		if ( '' === $cart_url ) {
+			return '';
+		}
+
+		$item_count = 0;
+
+		if ( function_exists( 'WC' ) && WC() && WC()->cart ) {
+			$item_count = (int) WC()->cart->get_cart_contents_count();
+		}
+
+		$label      = __( 'Ostoskori', 'rytkoset-theme' );
+		$aria_label = $label;
+
+		if ( $item_count > 0 ) {
+			$aria_label = sprintf(
+				/* translators: %d: Number of products in cart. */
+				_n( 'Ostoskori, %d tuote', 'Ostoskori, %d tuotetta', $item_count, 'rytkoset-theme' ),
+				$item_count
+			);
+		}
+
+		ob_start();
+		?>
+		<a class="<?php echo esc_attr( trim( $args['class'] ) ); ?>" href="<?php echo esc_url( $cart_url ); ?>" aria-label="<?php echo esc_attr( $aria_label ); ?>">
+			<span class="site-cart-link__label"><?php echo esc_html( $label ); ?></span>
+			<?php if ( $item_count > 0 ) : ?>
+				<span class="site-cart-link__count" aria-hidden="true"><?php echo esc_html( (string) $item_count ); ?></span>
+			<?php endif; ?>
+		</a>
+		<?php
+
+		return trim( ob_get_clean() );
+	}
+}
+
 /**
  * Palauttaa logon HTML:n wrapper-luokkineen.
  *

--- a/wp-content/themes/rytkoset-theme/header.php
+++ b/wp-content/themes/rytkoset-theme/header.php
@@ -79,6 +79,16 @@
             </nav>
 
             <?php
+            echo wp_kses_post(
+                rytkoset_theme_get_cart_link_markup(
+                    array(
+                        'class' => 'site-cart-link site-cart-link--desktop',
+                    )
+                )
+            );
+            ?>
+
+            <?php
             $social_links = rytkoset_theme_get_social_links();
 
             if ( ! empty( $social_links ) ) :
@@ -102,18 +112,30 @@
                 </div>
             <?php endif; ?>
 
-            <!-- Mobiilivalikon placeholder -->
-            <button class="mobile-menu-toggle"
-                    type="button"
-                    aria-expanded="false"
-                    aria-controls="mobile-menu"
-                    aria-haspopup="true"
-                    data-submenu-label="<?php esc_attr_e( 'Avaa alavalikko', 'rytkoset-theme' ); ?>">
-                <span class="mobile-menu-toggle__icon" aria-hidden="true"><span></span></span>
-                <span class="mobile-menu-toggle__label">
-                    <?php esc_html_e( 'Valikko', 'rytkoset-theme' ); ?>
-                </span>
-            </button>
+            <div class="site-header__mobile-actions">
+                <!-- Mobiilivalikon placeholder -->
+                <button class="mobile-menu-toggle"
+                        type="button"
+                        aria-expanded="false"
+                        aria-controls="mobile-menu"
+                        aria-haspopup="true"
+                        data-submenu-label="<?php esc_attr_e( 'Avaa alavalikko', 'rytkoset-theme' ); ?>">
+                    <span class="mobile-menu-toggle__icon" aria-hidden="true"><span></span></span>
+                    <span class="mobile-menu-toggle__label">
+                        <?php esc_html_e( 'Valikko', 'rytkoset-theme' ); ?>
+                    </span>
+                </button>
+
+                <?php
+                echo wp_kses_post(
+                    rytkoset_theme_get_cart_link_markup(
+                        array(
+                            'class' => 'site-cart-link site-cart-link--mobile',
+                        )
+                    )
+                );
+                ?>
+            </div>
 
             <div class="account-nav-wrapper">
                 <?php if ( is_user_logged_in() ) : ?>


### PR DESCRIPTION
## Summary
- add a persistent WooCommerce cart shortcut to desktop and mobile header navigation
- keep account actions inside the mobile menu when hamburger navigation is active
- rename the public front-page photo card from Valokuvat to Albumit
- document the target primary menu structure for dev/production admin setup

## Test Plan
- docker compose exec -T wordpress sh -lc "php -l wp-content/themes/rytkoset-theme/functions.php && php -l wp-content/themes/rytkoset-theme/header.php && php -l wp-content/themes/rytkoset-theme/front-page.php"
- git diff --check
- verified local HTTP 200 for /ostoskori/, /albumit/ and /tapahtumat/
- verified front page renders the new Ostoskori link and Albumit wording locally