### PR TITLE
docs: document Mollie MobilePay setup blocker

### DIFF
--- a/docs/woocommerce-mollie-go-live.md
+++ b/docs/woocommerce-mollie-go-live.md
@@ -15,7 +15,7 @@ Tässä vaiheessa ei toteuteta:
 - kirjanpitointegraatioita
 - omia maksulogiikoita virallisen Mollie-lisäosan ohi
 
-`MobilePay` kuuluu erilliseen tikettiin `#156`.
+`MobilePay` kuuluu erilliseen tikettiin `#156` ja on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-mobilepay.md`.
 
 ## Lähtötila
 
@@ -167,3 +167,5 @@ Kun WordPress siirretään osoitteeseen `rytkoset.net`, tee erillinen viimeinen 
   https://docs.mollie.com/docs/woo-set-up-payment-options
 - Mollie go-live checklist  
   https://docs.mollie.com/docs/go-live-checklist
+- Mollie MobilePay
+  https://docs.mollie.com/docs/mobilepay

--- a/docs/woocommerce-mollie-mobilepay.md
+++ b/docs/woocommerce-mollie-mobilepay.md
@@ -1,0 +1,107 @@
+# WooCommerce: Mollie MobilePay -käyttöönotto
+
+Tämä dokumentti kuvaa `#156`-tiketin MobilePay-käyttöönottomallin.
+
+MobilePay otetaan käyttöön vain virallisen `Mollie Payments for WooCommerce` -lisäosan kautta. Oma MobilePay-integraatio, erillinen API-toteutus tai WooPaymentsin käyttöönotto eivät kuulu tähän ratkaisuun.
+
+## Rajaus
+
+Tässä vaiheessa tehdään:
+
+- MobilePayn saatavuuden tarkistus Mollie Dashboardissa
+- MobilePayn aktivointi Molliessa, jos tilin ehdot täyttyvät
+- MobilePayn aktivointi WooCommercen Mollie-asetuksissa, jos gateway on saatavilla
+- pieni dev-live hyväksymistesti, jos maksutapa on aktivoitavissa
+- blocker-dokumentointi, jos MobilePay ei ole vielä käytettävissä
+
+Tässä vaiheessa ei tehdä:
+
+- omaa MobilePay API -integraatiota
+- WooPaymentsin käyttöönottoa
+- MobilePayn kiertototeutusta maksutavan ohi
+- salaisuuksien, API-avainten tai MobilePay Merchant ID:n tallentamista repoon
+
+## Mollien vaatimukset
+
+Mollien dokumentaation mukaan MobilePay on tällä hetkellä beta-maksutapa. Aktivointi voi vaatia yhteydenoton Mollien account manageriin tai supportiin.
+
+MobilePayn käyttöönottoa varten pitää varmistaa vähintään:
+
+- yhdistyksen Mollie-tili on suomalainen tai tanskalainen
+- valuuttana on `EUR` tai `DKK`
+- MobilePay on aktivoitavissa Mollie Dashboardissa
+- yhdistyksellä on tarvittava MobilePay-sopimus, jos Mollie sitä edellyttää
+- MobilePay Merchant ID / MSN voidaan lisätä Mollie Dashboardiin, jos sitä pyydetään
+- WooCommerce käyttää virallista Mollie-lisäosaa tai Mollien Payments API:a
+
+Jos jokin näistä puuttuu, MobilePayta ei oteta käyttöön kiertoteitse. Este kirjataan tämän dokumentin lopussa olevaan testitulostaulukkoon ja tiketti voidaan sulkea dokumentoituna blockerina.
+
+## Aktivointi devissä
+
+Tee nämä vaiheet `dev.rytkoset.net`-ympäristössä:
+
+1. Avaa Mollie Dashboard.
+2. Tarkista, näkyykö `MobilePay` maksutapana.
+3. Jos MobilePay on aktivoitavissa, aktivoi se Mollie Dashboardissa.
+4. Lisää mahdollinen MobilePay Merchant ID / MSN vain Mollie Dashboardiin.
+5. Avaa WordPressissä `WooCommerce -> Settings -> Mollie Settings`.
+6. Tarkista, näkyykö MobilePay omana Mollie-maksutapana.
+7. Ota MobilePay käyttöön.
+8. Rajaa `Sell to specific countries` tarvittaessa Suomeen.
+9. Tallenna asetukset.
+10. Varmista kassalla, että MobilePay näkyy vain silloin, kun se on teknisesti saatavilla.
+
+`Tilisiirto`, korttimaksut ja `Pay by Bank` pidetään käytössä kuten #157-vaiheessa. WooPaymentsin maksutapoja ei oteta käyttöön.
+
+## Hyväksymistestaus
+
+Testaa devissä matala-arvoisella testituotteella:
+
+1. Lisää ostoskoriin `Mollie live testituote` tai muu matala-arvoinen testituote.
+2. Siirry kassalle.
+3. Valitse `MobilePay`, jos se näkyy.
+4. Tee onnistunut pieni live-maksu.
+5. Varmista, että asiakas palaa WooCommercen tilausvahvistukseen.
+6. Varmista WooCommerce-adminissa, että tilauksen maksutapa on MobilePay ja tila päivittyy oikein.
+7. Tee erillinen peruttu tai keskeytetty MobilePay-maksu.
+8. Varmista, ettei peruttu maksu päädy virheellisesti maksetuksi.
+9. Testaa tarvittaessa hyvitys pienelle MobilePay-maksulle, jos Mollie näyttää refundin tuetuksi.
+
+## Capture-huomio
+
+Mollien MobilePay-dokumentaatio huomauttaa, että Norjassa, Tanskassa ja Suomessa maksua ei tule capture-käsitellä ennen kuin tuote tai palvelu on toimitettu asiakkaalle.
+
+Tämä pitää huomioida ennen kuin MobilePay näytetään oikeille asiakkaille esimerkiksi:
+
+- Tampere 2026 -osallistumismaksuissa
+- ennakkotilattavissa fyysisissä tuotteissa
+- muissa tuotteissa, joissa toimitus tai palvelu tapahtuu myöhemmin
+
+Jos MobilePayn käyttö edellyttää manual capture -mallia, se pitää vahvistaa Mollien dokumentaatiosta ja testata erikseen ennen julkaisua. Tätä ei kierretä omalla koodilla tässä tiketissä.
+
+## Testitulosten kirjaus
+
+Täytä tämä taulukko, kun MobilePayn tila on tarkistettu:
+
+| Tarkistus | Tulos | Huomio |
+| --- | --- | --- |
+| MobilePay näkyy Mollie Dashboardissa | Pending |  |
+| MobilePay aktivoitu Molliessa | Pending |  |
+| MobilePay näkyy WooCommerce Mollie -asetuksissa | Pending |  |
+| MobilePay näkyy kassalla | Pending |  |
+| Onnistunut MobilePay-testimaksu | Pending |  |
+| Peruttu MobilePay-testi | Pending |  |
+| Tilauksen status päivittyy oikein | Pending |  |
+| Kortti, Pay by Bank ja Tilisiirto toimivat edelleen | Pending |  |
+| Mahdollinen blocker | Pending |  |
+
+Merkitse `Pending`-arvojen tilalle toteutunut tulos. Jos MobilePay ei ole käytettävissä, kirjaa tarkka este ja seuraava toimenpide, esimerkiksi yhteydenotto Mollie Supportiin tai MobilePay Merchant ID:n hankinta.
+
+## Lähteet
+
+- Mollie MobilePay  
+  https://docs.mollie.com/docs/mobilepay
+- Mollie WooCommerce: Set up your checkout  
+  https://docs.mollie.com/docs/woo-set-up-your-checkout
+- Mollie WooCommerce: Set up payment options  
+  https://docs.mollie.com/docs/woo-set-up-payment-options

--- a/docs/woocommerce-mollie-payments.md
+++ b/docs/woocommerce-mollie-payments.md
@@ -4,6 +4,8 @@ Tämä dokumentti kuvaa #145-tiketin paikallisen Mollie-käyttöönoton ja testi
 
 Varsinainen dev-live käyttöönotto ja oikeiden hyväksymistestien malli on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-go-live.md`.
 
+MobilePayn erillinen käyttöönotto ja mahdolliset Mollie-tilikohtaiset blockerit on dokumentoitu tiedostossa `docs/woocommerce-mollie-mobilepay.md`.
+
 ## Rajaus
 
 Tässä vaiheessa Mollie otetaan käyttöön vain paikallisessa/testimoodin käyttöönotossa.
@@ -16,7 +18,7 @@ Ei tehdä tässä tiketissä:
 - tuotantodomainin Apple Pay -validointia
 - omaa maksupalveluintegraatiota virallisen Mollie-lisäosan ohi
 
-MobilePay käsitellään erillisessä tiketissä #156. Tuotantokäyttöönotto ja oikeat maksut käsitellään erillisessä tiketissä #157.
+MobilePay käsitellään erillisessä tiketissä #156 ja dokumentissa `docs/woocommerce-mollie-mobilepay.md`. Tuotantokäyttöönotto ja oikeat maksut käsitellään erillisessä tiketissä #157.
 
 ## Asennus
 

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -54,6 +54,7 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Tampere 2026 -järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
 - Mollie-maksutapojen paikallinen testikäyttöönotto on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-payments.md`.
 - Mollien dev-live käyttöönotto ja hyväksymistestaus on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-go-live.md`.
+- Mollie MobilePay -käyttöönotto ja mahdolliset tilikohtaiset blockerit on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-mobilepay.md`.
 - Fyysisten tuotteiden perustuki on dokumentoitu erikseen tiedostossa `docs/woocommerce-physical-products.md`.
 - `Rytkösten sukulainen nro 9` -ennakkotilaustuote on dokumentoitu erikseen tiedostossa `docs/woocommerce-rytkosten-sukulainen-product.md`.
 - Kaupan, tapahtumien, albumien ja ostoskorin valikkorakenne on dokumentoitu erikseen tiedostossa `docs/menu-structure.md`.


### PR DESCRIPTION
## Summary

Documents the planned Mollie MobilePay setup for #156 and records the current blocker: Vipps MobilePay registration requires an authorized signatory for the association.

## Changes

- Added MobilePay setup documentation
- Documented that MobilePay must be enabled through the official Mollie WooCommerce plugin
- Added activation and dev-live test checklist
- Documented fallback/blocker handling if MobilePay is not yet available
- Linked the MobilePay documentation from existing WooCommerce/Mollie setup docs

## Testing

- Ran `git diff --check`

## Notes

No code changes were made. MobilePay registration is paused until a person with signing authority for the association can complete the Vipps MobilePay registration.
