### PR TITLE
fix: sort media library attachments by filename

### DIFF
--- a/docs/media-library-ordering.md
+++ b/docs/media-library-ordering.md
@@ -1,0 +1,31 @@
+# Mediakirjaston kuvien järjestys
+
+Albumien ylläpidossa käytetään WordPressin omaa mediakirjastoa ja ACF:n galleriakenttää. Maksullista FileBird Pro -järjestelyä ei käytetä.
+
+## Oletusjärjestys
+
+Teema asettaa adminin mediakirjaston oletusjärjestykseksi tiedostonimestä syntyvän liitteen otsikon nousevassa järjestyksessä.
+
+Käytännössä tämä toimii oikein, kun kuvat on nimetty nollatäytetyillä juoksevilla nimillä, esimerkiksi:
+
+- `IMG_0001`
+- `IMG_0002`
+- `IMG_0003`
+
+Sama oletusjärjestys asetetaan myös median valintamodaaliin, jota käytetään albumin kuvien valinnassa.
+
+## Mitä tämä ei muuta
+
+- Julkisen albumin kuvajärjestystä ei muuteta automaattisesti.
+- ACF:n galleriakenttään jo tallennettu kuvajärjestys säilyy ennallaan.
+- Mediakirjaston haku, päivämääräsuodatus ja tiedostotyyppisuodatus säilyvät käytössä.
+- Jos ylläpitäjä valitsee mediakirjastossa erikseen jonkin muun sarakejärjestyksen, WordPressin oma valinta ohittaa teeman oletuksen.
+
+## Ylläpitomalli
+
+1. Nimeä albumikuvat ennen latausta nollatäytettyyn järjestykseen.
+2. Lataa kuvat oikeaan FileBird-kansioon.
+3. Lisää kuvat albumin ACF-galleriakenttään mediakirjastosta.
+4. Tarkista albumin kuvajärjestys ennen julkaisua.
+
+Jos kuvia pitää järjestää käsin julkisessa albumissa, tee järjestely albumin omassa galleriakentässä. Mediakirjaston oletusjärjestys auttaa valintaa, mutta ei korvaa albumikohtaista tarkistusta.

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once get_template_directory() . '/inc/social-links.php';
 require_once get_template_directory() . '/inc/share.php';
 require_once get_template_directory() . '/inc/gallery-albums.php';
+require_once get_template_directory() . '/inc/media-library.php';
 require_once get_template_directory() . '/inc/events.php';
 
 if ( ! function_exists( 'rytkoset_theme_get_attachment_display_caption_text' ) ) {

--- a/wp-content/themes/rytkoset-theme/inc/media-library.php
+++ b/wp-content/themes/rytkoset-theme/inc/media-library.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Admin media library adjustments.
+ *
+ * @package RytkosetTheme
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sorts the Media Library admin screen by attachment title by default.
+ *
+ * WordPress creates attachment titles from the uploaded filename by default.
+ * For zero-padded album filenames this gives the intended chronological order
+ * without requiring a paid media library ordering plugin.
+ *
+ * @param WP_Query $query Current admin query.
+ */
+function rytkoset_theme_sort_media_library_by_filename( $query ) {
+	global $pagenow;
+
+	if ( ! is_admin() || 'upload.php' !== $pagenow || ! $query instanceof WP_Query || ! $query->is_main_query() ) {
+		return;
+	}
+
+	if ( 'attachment' !== $query->get( 'post_type' ) ) {
+		return;
+	}
+
+	// Respect explicit admin sorting from column headers or query parameters.
+	if ( isset( $_GET['orderby'] ) || isset( $_GET['order'] ) ) {
+		return;
+	}
+
+	$query->set( 'orderby', 'title' );
+	$query->set( 'order', 'ASC' );
+}
+add_action( 'pre_get_posts', 'rytkoset_theme_sort_media_library_by_filename' );
+
+/**
+ * Sorts the media selection modal by attachment title when no custom order is requested.
+ *
+ * This affects the WordPress media modal used by ACF gallery fields while keeping
+ * search, MIME type filters and date filters intact.
+ *
+ * @param array $query_args Attachment query arguments.
+ * @return array
+ */
+function rytkoset_theme_sort_media_modal_by_filename( $query_args ) {
+	$action = isset( $_REQUEST['action'] ) ? sanitize_key( wp_unslash( $_REQUEST['action'] ) ) : '';
+
+	if ( 'query-attachments' !== $action ) {
+		return $query_args;
+	}
+
+	$request_query = array();
+
+	if ( isset( $_REQUEST['query'] ) && is_array( $_REQUEST['query'] ) ) {
+		$request_query = wp_unslash( $_REQUEST['query'] );
+	}
+
+	$requested_orderby = isset( $request_query['orderby'] ) ? sanitize_key( $request_query['orderby'] ) : '';
+	$requested_order   = isset( $request_query['order'] ) ? strtoupper( sanitize_key( $request_query['order'] ) ) : '';
+
+	// Do not override plugin- or user-provided custom ordering.
+	if ( $requested_orderby && ! in_array( $requested_orderby, array( 'date', 'title' ), true ) ) {
+		return $query_args;
+	}
+
+	if ( $requested_order && ! in_array( $requested_order, array( 'ASC', 'DESC' ), true ) ) {
+		return $query_args;
+	}
+
+	$query_args['orderby'] = 'title';
+	$query_args['order']   = 'ASC';
+
+	return $query_args;
+}
+add_filter( 'ajax_query_attachments_args', 'rytkoset_theme_sort_media_modal_by_filename' );


### PR DESCRIPTION
## Summary

- Add free MVP ordering for the WordPress Media Library by attachment title ascending.
- Apply the same default ordering to the media selection modal used by album maintenance.
- Keep public album image order unchanged.
- Document the media library ordering model and filename requirements.

## Testing

- PHP syntax check passed for `functions.php`.
- PHP syntax check passed for `inc/media-library.php`.
- `git diff --check` passed.
- Browser admin verification was not completed because the local session was not logged in.
