### PR TITLE
feat: redesign event details as summary card

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -11,6 +11,31 @@ Tapahtuman muokkausnäkymässä on kenttä `Tapahtumapäivä`.
 - Kenttä kannattaa täyttää sekä tuleville että menneille tapahtumille.
 - Jos päivämäärä puuttuu, tapahtuma jää näkyviin, mutta se näytetään arkiston päivämäärättömien tapahtumien osiossa.
 
+## Tapahtuman tiedot
+
+Tapahtuman muokkausnäkymän oikeassa sivupalkissa on lisäksi metabox `Tapahtuman tiedot`.
+
+Kentät ovat:
+
+- `Alkamisaika`: tallennetaan post metaan `_rytkoset_event_start_time`, kiinteässä 24 tunnin muodossa `HH:MM`.
+- `Päättymisaika`: tallennetaan post metaan `_rytkoset_event_end_time`, kiinteässä 24 tunnin muodossa `HH:MM`. Kenttä on valinnainen.
+- `Paikka`: tallennetaan post metaan `_rytkoset_event_location`, esimerkiksi `Hotelli Rosendahl, Pyynikintie 13, Tampere`.
+- `Maksullisuus`: tallennetaan post metaan `_rytkoset_event_fee_type`. Arvot ovat `free`, `paid` tai tyhjä.
+- `Hintateksti`: tallennetaan post metaan `_rytkoset_event_price_text`, esimerkiksi `49 € / henkilö`.
+
+Kellonajat syötetään tekstikenttiin kiinteässä 24 tunnin muodossa, esimerkiksi `11:30` ja `18:00`. Virheellistä aikaa ei tallenneta. Tyhjä kenttä poistaa vastaavan metatiedon.
+
+## Näkyminen sivustolla
+
+Yksittäisellä tapahtumasivulla näytetään täytetyt perustiedot tapahtuman otsikon jälkeen:
+
+- päivämäärä
+- kellonaika tai aikaväli
+- paikka
+- maksullisuus ja hintateksti
+
+Tapahtuma-arkistossa `/tapahtumat/` näytetään vähintään päivämäärä, jos se on asetettu. Jos tapahtumalle on asetettu paikka, se näytetään arkistolistauksessa päivämäärän rinnalla.
+
 ## Tapahtuma-arkiston järjestys
 
 Tapahtuma-arkisto `/tapahtumat/` jakaa tapahtumat kolmeen osioon:
@@ -21,13 +46,39 @@ Tapahtuma-arkisto `/tapahtumat/` jakaa tapahtumat kolmeen osioon:
 
 Tulevat tapahtumat näytetään lähimmästä tulevasta tapahtumasta alkaen. Menneet tapahtumat näytetään uusimmasta vanhimpaan.
 
+## Maksulliset tapahtumat
+
+Tapahtuman maksullisuus ja hintateksti ovat informatiivisia kenttiä. Varsinainen maksaminen hoidetaan edelleen WooCommerce-tuotteella, joka voidaan linkittää tapahtumaan erillisellä `Maksutuote`-kentällä.
+
+Tämä tarkoittaa:
+
+- tapahtuman hintateksti ei muuta WooCommerce-tuotteen hintaa
+- maksullisuus ei luo tuotetta automaattisesti
+- ilmoittautuminen ja maksaminen kulkevat WooCommerce-tuotesivun ja kassan kautta
+
 ## Ensimmäiset tapahtumat
 
-Aseta nykyisille tapahtumille nämä päivämäärät:
+Aseta nykyisille tapahtumille vähintään nämä päivämäärät:
 
 - Rytkösten sukuseuran Etelä-Suomen tapaaminen: `2025-10-07`
 - Rytkösten sukukokous Tampereella: `2026-08-29`
 
+Tampereen sukukokoukselle voidaan lisäksi asettaa:
+
+- Alkamisaika: `11:30`
+- Päättymisaika: `18:00`
+- Paikka: `Hotelli Rosendahl, Pyynikintie 13, Tampere`
+- Maksullisuus: `Maksullinen`
+- Hintateksti: `49 € / henkilö`
+
 ## Rajaukset
 
-Tässä vaiheessa tapahtumalla on vain yksi päivämäärä. Kellonaika, paikka, ilmoittautumisen määräpäivä ja muut tapahtumakohtaiset lisäkentät voidaan lisätä myöhemmin erillisissä tiketeissä.
+Tässä vaiheessa tapahtumalla on yksi päivämäärä, yksi aikaväli, yksi vapaa paikkateksti ja informatiivinen maksullisuustieto.
+
+Toteutus ei sisällä:
+
+- erillistä päättymispäivää
+- karttalinkkiä tai karttaupotusta
+- toistuvia tapahtumia
+- numeerista hintamallia
+- automaattista WooCommerce-tuotteen luontia tai muuttamista

--- a/wp-content/themes/rytkoset-theme/archive-event.php
+++ b/wp-content/themes/rytkoset-theme/archive-event.php
@@ -83,6 +83,7 @@ $render_event_list = static function ( WP_Query $event_query ) {
 			$event_query->the_post();
 			$event_date_raw     = rytkoset_theme_get_event_date_raw( get_the_ID() );
 			$event_date_display = rytkoset_theme_get_event_date_display( get_the_ID() );
+			$event_location     = rytkoset_theme_get_event_location( get_the_ID() );
 			?>
 			<article <?php post_class( 'article' ); ?>>
 				<?php if ( has_post_thumbnail() ) : ?>
@@ -92,9 +93,17 @@ $render_event_list = static function ( WP_Query $event_query ) {
 				<?php endif; ?>
 
 				<header class="article__header">
-					<?php if ( '' !== $event_date_display ) : ?>
+					<?php if ( '' !== $event_date_display || '' !== $event_location ) : ?>
 						<p class="article__meta">
-							<time datetime="<?php echo esc_attr( $event_date_raw ); ?>"><?php echo esc_html( $event_date_display ); ?></time>
+							<?php if ( '' !== $event_date_display ) : ?>
+								<time datetime="<?php echo esc_attr( $event_date_raw ); ?>"><?php echo esc_html( $event_date_display ); ?></time>
+							<?php endif; ?>
+							<?php if ( '' !== $event_date_display && '' !== $event_location ) : ?>
+								<span aria-hidden="true"> &middot; </span>
+							<?php endif; ?>
+							<?php if ( '' !== $event_location ) : ?>
+								<span class="article__meta-location"><?php echo esc_html( $event_location ); ?></span>
+							<?php endif; ?>
 						</p>
 					<?php endif; ?>
 					<h3 class="article__title">

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -88,6 +88,14 @@
   gap: 1rem;
 }
 
+.article--event {
+  gap: 2rem;
+}
+
+.event-article__header {
+  max-width: 760px;
+}
+
 .article-list {
   display: grid;
   gap: 2rem;
@@ -100,6 +108,145 @@
 
 .event-archive-section + .event-archive-section {
   margin-top: 2.5rem;
+}
+
+.event-details {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface-alt);
+  text-align: left;
+}
+
+.event-details__item {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.event-details__label {
+  color: var(--color-text);
+  opacity: 0.72;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.event-details__value {
+  margin: 0;
+}
+
+@media (min-width: 48rem) {
+  .event-details__item {
+    grid-template-columns: 9rem 1fr;
+    gap: 1rem;
+  }
+}
+
+.event-layout {
+  display: grid;
+  gap: 2rem;
+}
+
+.event-layout__main {
+  display: grid;
+  gap: 1.5rem;
+  min-width: 0;
+}
+
+.event-layout__sidebar {
+  min-width: 0;
+}
+
+.event-summary-card {
+  margin: 0;
+  padding: 1.25rem;
+  border: 1px solid var(--color-border-neutral);
+  border-top: 0.35rem solid var(--color-accent);
+  border-radius: var(--radius-medium);
+  background:
+    linear-gradient(180deg, rgba(251, 191, 36, 0.08), transparent 6rem),
+    var(--color-surface-alt);
+  box-shadow: var(--shadow-card);
+}
+
+.event-summary-card__title {
+  margin: 0 0 1rem;
+  font-size: 1.2rem;
+}
+
+.event-summary-card__details {
+  display: grid;
+  gap: 0;
+  margin: 0;
+}
+
+.event-summary-card__item {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--color-border-neutral);
+}
+
+.event-summary-card__item:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.event-summary-card__label {
+  color: var(--color-text);
+  opacity: 0.72;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.event-summary-card__value {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.event-summary-card__cta {
+  margin-top: 1.1rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--color-border-neutral);
+}
+
+.event-summary-card__button {
+  box-sizing: border-box;
+  width: 100%;
+}
+
+@media (min-width: 64rem) {
+  .article--event {
+    gap: 2.5rem;
+  }
+
+  .event-layout--has-sidebar {
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+    align-items: start;
+    gap: 3rem;
+  }
+
+  .event-layout--has-sidebar .event-layout__main {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .event-layout--has-sidebar .event-layout__sidebar {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .event-summary-card {
+    position: sticky;
+    top: 2rem;
+  }
 }
 
 .rytkoset-checkout-note {

--- a/wp-content/themes/rytkoset-theme/inc/events.php
+++ b/wp-content/themes/rytkoset-theme/inc/events.php
@@ -121,6 +121,259 @@ if ( ! function_exists( 'rytkoset_theme_get_event_date_display' ) ) {
 	}
 }
 
+if ( ! function_exists( 'rytkoset_theme_get_event_details_meta_keys' ) ) {
+	/**
+	 * Returns meta keys used for event details.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_details_meta_keys() {
+		return array(
+			'start_time' => '_rytkoset_event_start_time',
+			'end_time'   => '_rytkoset_event_end_time',
+			'location'   => '_rytkoset_event_location',
+			'fee_type'   => '_rytkoset_event_fee_type',
+			'price_text' => '_rytkoset_event_price_text',
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_is_valid_event_time' ) ) {
+	/**
+	 * Checks whether an event time uses the expected HH:MM format.
+	 *
+	 * @param string $time Event time.
+	 * @return bool
+	 */
+	function rytkoset_theme_is_valid_event_time( $time ) {
+		return is_string( $time ) && 1 === preg_match( '/^(?:[01]\d|2[0-3]):[0-5]\d$/', $time );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_time_raw' ) ) {
+	/**
+	 * Returns a validated event time.
+	 *
+	 * @param int    $event_id Event post ID.
+	 * @param string $key      Event detail key.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_time_raw( $event_id, $key ) {
+		$meta_keys = rytkoset_theme_get_event_details_meta_keys();
+
+		if ( ! isset( $meta_keys[ $key ] ) ) {
+			return '';
+		}
+
+		$time = get_post_meta( $event_id, $meta_keys[ $key ], true );
+
+		if ( ! is_string( $time ) || ! rytkoset_theme_is_valid_event_time( $time ) ) {
+			return '';
+		}
+
+		return $time;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_time_display' ) ) {
+	/**
+	 * Returns the event time range for display.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_time_display( $event_id ) {
+		$start_time = rytkoset_theme_get_event_time_raw( $event_id, 'start_time' );
+		$end_time   = rytkoset_theme_get_event_time_raw( $event_id, 'end_time' );
+
+		if ( '' !== $start_time && '' !== $end_time ) {
+			return $start_time . '–' . $end_time;
+		}
+
+		if ( '' !== $start_time ) {
+			return $start_time;
+		}
+
+		return $end_time;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_location' ) ) {
+	/**
+	 * Returns the event location.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_location( $event_id ) {
+		$meta_keys = rytkoset_theme_get_event_details_meta_keys();
+		$location  = get_post_meta( $event_id, $meta_keys['location'], true );
+
+		return is_string( $location ) ? trim( $location ) : '';
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_fee_type' ) ) {
+	/**
+	 * Returns the event fee type.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_fee_type( $event_id ) {
+		$meta_keys = rytkoset_theme_get_event_details_meta_keys();
+		$fee_type  = get_post_meta( $event_id, $meta_keys['fee_type'], true );
+
+		if ( ! is_string( $fee_type ) || ! in_array( $fee_type, array( 'free', 'paid' ), true ) ) {
+			return '';
+		}
+
+		return $fee_type;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_price_text' ) ) {
+	/**
+	 * Returns the event price text.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_price_text( $event_id ) {
+		$meta_keys  = rytkoset_theme_get_event_details_meta_keys();
+		$price_text = get_post_meta( $event_id, $meta_keys['price_text'], true );
+
+		return is_string( $price_text ) ? trim( $price_text ) : '';
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_format_event_price_text' ) ) {
+	/**
+	 * Formats event price text for display.
+	 *
+	 * @param string $price_text Event price text.
+	 * @return string
+	 */
+	function rytkoset_theme_format_event_price_text( $price_text ) {
+		$price_text = trim( $price_text );
+
+		if ( '' === $price_text ) {
+			return '';
+		}
+
+		if ( preg_match( '/^\d+(?:[,.]\d{1,2})?$/', $price_text ) ) {
+			return $price_text . ' €';
+		}
+
+		return $price_text;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_fee_display' ) ) {
+	/**
+	 * Returns the event fee information for display.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_fee_display( $event_id ) {
+		$fee_type   = rytkoset_theme_get_event_fee_type( $event_id );
+		$price_text = rytkoset_theme_get_event_price_text( $event_id );
+
+		if ( 'free' === $fee_type ) {
+			return __( 'Maksuton', 'rytkoset-theme' );
+		}
+
+		if ( 'paid' === $fee_type && '' !== $price_text ) {
+			return rytkoset_theme_format_event_price_text( $price_text );
+		}
+
+		if ( 'paid' === $fee_type ) {
+			return __( 'Maksullinen', 'rytkoset-theme' );
+		}
+
+		return $price_text;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_detail_items' ) ) {
+	/**
+	 * Returns visible event detail items.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_detail_items( $event_id ) {
+		$items        = array();
+		$date_display = rytkoset_theme_get_event_date_display( $event_id );
+		$time_display = rytkoset_theme_get_event_time_display( $event_id );
+		$location     = rytkoset_theme_get_event_location( $event_id );
+		$fee_display  = rytkoset_theme_get_event_fee_display( $event_id );
+
+		if ( '' !== $date_display ) {
+			$items[] = array(
+				'label'    => __( 'Päivämäärä', 'rytkoset-theme' ),
+				'value'    => $date_display,
+				'datetime' => rytkoset_theme_get_event_date_raw( $event_id ),
+			);
+		}
+
+		if ( '' !== $time_display ) {
+			$items[] = array(
+				'label' => __( 'Kellonaika', 'rytkoset-theme' ),
+				'value' => $time_display,
+			);
+		}
+
+		if ( '' !== $location ) {
+			$items[] = array(
+				'label' => __( 'Paikka', 'rytkoset-theme' ),
+				'value' => $location,
+			);
+		}
+
+		if ( '' !== $fee_display ) {
+			$items[] = array(
+				'label' => __( 'Hinta', 'rytkoset-theme' ),
+				'value' => $fee_display,
+			);
+		}
+
+		return $items;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_render_event_details' ) ) {
+	/**
+	 * Renders event details on the single event page.
+	 *
+	 * @param int $event_id Event post ID.
+	 */
+	function rytkoset_theme_render_event_details( $event_id ) {
+		$items = rytkoset_theme_get_event_detail_items( $event_id );
+
+		if ( empty( $items ) ) {
+			return;
+		}
+		?>
+		<dl class="event-details">
+			<?php foreach ( $items as $item ) : ?>
+				<div class="event-details__item">
+					<dt class="event-details__label"><?php echo esc_html( $item['label'] ); ?></dt>
+					<dd class="event-details__value">
+						<?php if ( ! empty( $item['datetime'] ) ) : ?>
+							<time datetime="<?php echo esc_attr( $item['datetime'] ); ?>"><?php echo esc_html( $item['value'] ); ?></time>
+						<?php else : ?>
+							<?php echo esc_html( $item['value'] ); ?>
+						<?php endif; ?>
+					</dd>
+				</div>
+			<?php endforeach; ?>
+		</dl>
+		<?php
+	}
+}
+
 if ( ! function_exists( 'rytkoset_theme_register_event_date_metabox' ) ) {
 	/**
 	 * Adds the event date metabox.
@@ -215,6 +468,193 @@ if ( ! function_exists( 'rytkoset_theme_save_event_date' ) ) {
 }
 add_action( 'save_post_event', 'rytkoset_theme_save_event_date' );
 
+if ( ! function_exists( 'rytkoset_theme_register_event_details_metabox' ) ) {
+	/**
+	 * Adds the event details metabox.
+	 */
+	function rytkoset_theme_register_event_details_metabox() {
+		add_meta_box(
+			'rytkoset_event_details',
+			__( 'Tapahtuman tiedot', 'rytkoset-theme' ),
+			'rytkoset_theme_render_event_details_metabox',
+			'event',
+			'side',
+			'default'
+		);
+	}
+}
+add_action( 'add_meta_boxes_event', 'rytkoset_theme_register_event_details_metabox' );
+
+if ( ! function_exists( 'rytkoset_theme_render_event_details_metabox' ) ) {
+	/**
+	 * Renders the event details metabox.
+	 *
+	 * @param WP_Post $post Event post object.
+	 */
+	function rytkoset_theme_render_event_details_metabox( $post ) {
+		$start_time = rytkoset_theme_get_event_time_raw( $post->ID, 'start_time' );
+		$end_time   = rytkoset_theme_get_event_time_raw( $post->ID, 'end_time' );
+		$location   = rytkoset_theme_get_event_location( $post->ID );
+		$fee_type   = rytkoset_theme_get_event_fee_type( $post->ID );
+		$price_text = rytkoset_theme_get_event_price_text( $post->ID );
+
+		wp_nonce_field( 'rytkoset_save_event_details', 'rytkoset_event_details_nonce' );
+		?>
+		<p>
+			<label for="rytkoset_event_start_time">
+				<?php esc_html_e( 'Alkamisaika', 'rytkoset-theme' ); ?>
+			</label>
+			<input
+				type="text"
+				id="rytkoset_event_start_time"
+				name="rytkoset_event_start_time"
+				value="<?php echo esc_attr( $start_time ); ?>"
+				class="widefat"
+				inputmode="numeric"
+				maxlength="5"
+				pattern="(?:[01][0-9]|2[0-3]):[0-5][0-9]"
+				placeholder="<?php esc_attr_e( 'Esim. 11:30', 'rytkoset-theme' ); ?>"
+			/>
+			<span class="description"><?php esc_html_e( 'Muoto HH:MM.', 'rytkoset-theme' ); ?></span>
+		</p>
+		<p>
+			<label for="rytkoset_event_end_time">
+				<?php esc_html_e( 'Päättymisaika', 'rytkoset-theme' ); ?>
+			</label>
+			<input
+				type="text"
+				id="rytkoset_event_end_time"
+				name="rytkoset_event_end_time"
+				value="<?php echo esc_attr( $end_time ); ?>"
+				class="widefat"
+				inputmode="numeric"
+				maxlength="5"
+				pattern="(?:[01][0-9]|2[0-3]):[0-5][0-9]"
+				placeholder="<?php esc_attr_e( 'Esim. 18:00', 'rytkoset-theme' ); ?>"
+			/>
+			<span class="description"><?php esc_html_e( 'Valinnainen. Muoto HH:MM.', 'rytkoset-theme' ); ?></span>
+		</p>
+		<p>
+			<label for="rytkoset_event_location">
+				<?php esc_html_e( 'Paikka', 'rytkoset-theme' ); ?>
+			</label>
+			<textarea
+				id="rytkoset_event_location"
+				name="rytkoset_event_location"
+				class="widefat"
+				rows="3"
+			><?php echo esc_textarea( $location ); ?></textarea>
+		</p>
+		<p>
+			<label for="rytkoset_event_fee_type">
+				<?php esc_html_e( 'Maksullisuus', 'rytkoset-theme' ); ?>
+			</label>
+			<select id="rytkoset_event_fee_type" name="rytkoset_event_fee_type">
+				<option value=""><?php esc_html_e( 'Ei määritelty', 'rytkoset-theme' ); ?></option>
+				<option value="free" <?php selected( $fee_type, 'free' ); ?>><?php esc_html_e( 'Maksuton', 'rytkoset-theme' ); ?></option>
+				<option value="paid" <?php selected( $fee_type, 'paid' ); ?>><?php esc_html_e( 'Maksullinen', 'rytkoset-theme' ); ?></option>
+			</select>
+		</p>
+		<p>
+			<label for="rytkoset_event_price_text">
+				<?php esc_html_e( 'Hintateksti', 'rytkoset-theme' ); ?>
+			</label>
+			<input
+				type="text"
+				id="rytkoset_event_price_text"
+				name="rytkoset_event_price_text"
+				value="<?php echo esc_attr( $price_text ); ?>"
+				class="widefat"
+				placeholder="<?php esc_attr_e( 'Esim. 49 € / henkilö', 'rytkoset-theme' ); ?>"
+			/>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'Hintateksti on informatiivinen. Varsinainen maksaminen hoidetaan erillisellä WooCommerce-tuotteella, jos tapahtumaan on linkitetty maksutuote.', 'rytkoset-theme' ); ?>
+		</p>
+		<?php
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_save_event_details' ) ) {
+	/**
+	 * Saves the event details.
+	 *
+	 * @param int $post_id Event post ID.
+	 */
+	function rytkoset_theme_save_event_details( $post_id ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['rytkoset_event_details_nonce'] ) ) {
+			return;
+		}
+
+		$nonce = sanitize_text_field( wp_unslash( $_POST['rytkoset_event_details_nonce'] ) );
+
+		if ( ! wp_verify_nonce( $nonce, 'rytkoset_save_event_details' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$meta_keys = rytkoset_theme_get_event_details_meta_keys();
+
+		foreach ( array( 'start_time', 'end_time' ) as $time_key ) {
+			$field_name = 'rytkoset_event_' . $time_key;
+			$time       = isset( $_POST[ $field_name ] )
+				? sanitize_text_field( wp_unslash( $_POST[ $field_name ] ) )
+				: '';
+
+			if ( '' === $time ) {
+				delete_post_meta( $post_id, $meta_keys[ $time_key ] );
+				continue;
+			}
+
+			if ( rytkoset_theme_is_valid_event_time( $time ) ) {
+				update_post_meta( $post_id, $meta_keys[ $time_key ], $time );
+			}
+		}
+
+		$location = isset( $_POST['rytkoset_event_location'] )
+			? sanitize_textarea_field( wp_unslash( $_POST['rytkoset_event_location'] ) )
+			: '';
+
+		if ( '' === $location ) {
+			delete_post_meta( $post_id, $meta_keys['location'] );
+		} else {
+			update_post_meta( $post_id, $meta_keys['location'], $location );
+		}
+
+		$fee_type = isset( $_POST['rytkoset_event_fee_type'] )
+			? sanitize_key( wp_unslash( $_POST['rytkoset_event_fee_type'] ) )
+			: '';
+
+		if ( in_array( $fee_type, array( 'free', 'paid' ), true ) ) {
+			update_post_meta( $post_id, $meta_keys['fee_type'], $fee_type );
+		} else {
+			delete_post_meta( $post_id, $meta_keys['fee_type'] );
+		}
+
+		$price_text = isset( $_POST['rytkoset_event_price_text'] )
+			? sanitize_text_field( wp_unslash( $_POST['rytkoset_event_price_text'] ) )
+			: '';
+
+		if ( '' === $price_text ) {
+			delete_post_meta( $post_id, $meta_keys['price_text'] );
+		} else {
+			update_post_meta( $post_id, $meta_keys['price_text'], $price_text );
+		}
+	}
+}
+add_action( 'save_post_event', 'rytkoset_theme_save_event_details' );
+
 if ( ! function_exists( 'rytkoset_theme_get_event_product_meta_key' ) ) {
 	/**
 	 * Returns the meta key used to link an event to a WooCommerce product.
@@ -306,7 +746,10 @@ if ( ! function_exists( 'rytkoset_theme_print_event_admin_styles' ) ) {
 		?>
 		<style>
 			#rytkoset_event_date_field,
-			#rytkoset_event_product_id {
+			#rytkoset_event_product_id,
+			#rytkoset_event_start_time,
+			#rytkoset_event_end_time,
+			#rytkoset_event_fee_type {
 				box-sizing: border-box;
 				max-width: calc(100% - 12px);
 				width: calc(100% - 12px);
@@ -545,6 +988,26 @@ if ( ! function_exists( 'rytkoset_theme_save_event_product_link' ) ) {
 }
 add_action( 'save_post_event', 'rytkoset_theme_save_event_product_link' );
 
+if ( ! function_exists( 'rytkoset_theme_get_event_product_url' ) ) {
+	/**
+	 * Returns the linked product URL for an event.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_product_url( $event_id ) {
+		$product = rytkoset_theme_get_event_linked_product( $event_id );
+
+		if ( ! class_exists( 'WC_Product' ) || ! $product instanceof WC_Product ) {
+			return '';
+		}
+
+		$product_url = get_permalink( $product->get_id() );
+
+		return is_string( $product_url ) ? $product_url : '';
+	}
+}
+
 if ( ! function_exists( 'rytkoset_theme_render_event_product_cta' ) ) {
 	/**
 	 * Renders the linked product CTA for an event.
@@ -552,13 +1015,7 @@ if ( ! function_exists( 'rytkoset_theme_render_event_product_cta' ) ) {
 	 * @param int $event_id Event post ID.
 	 */
 	function rytkoset_theme_render_event_product_cta( $event_id ) {
-		$product = rytkoset_theme_get_event_linked_product( $event_id );
-
-		if ( ! class_exists( 'WC_Product' ) || ! $product instanceof WC_Product ) {
-			return;
-		}
-
-		$product_url = get_permalink( $product->get_id() );
+		$product_url = rytkoset_theme_get_event_product_url( $event_id );
 
 		if ( ! $product_url ) {
 			return;
@@ -569,6 +1026,69 @@ if ( ! function_exists( 'rytkoset_theme_render_event_product_cta' ) ) {
 				<?php esc_html_e( 'Ilmoittaudu ja maksa', 'rytkoset-theme' ); ?>
 			</a>
 		</div>
+		<?php
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_event_has_summary_card' ) ) {
+	/**
+	 * Checks whether an event has visible summary card content.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return bool
+	 */
+	function rytkoset_theme_event_has_summary_card( $event_id ) {
+		return ! empty( rytkoset_theme_get_event_detail_items( $event_id ) )
+			|| '' !== rytkoset_theme_get_event_product_url( $event_id );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_render_event_summary_card' ) ) {
+	/**
+	 * Renders the public event summary card.
+	 *
+	 * @param int $event_id Event post ID.
+	 */
+	function rytkoset_theme_render_event_summary_card( $event_id ) {
+		$items       = rytkoset_theme_get_event_detail_items( $event_id );
+		$product_url = rytkoset_theme_get_event_product_url( $event_id );
+
+		if ( empty( $items ) && '' === $product_url ) {
+			return;
+		}
+
+		$title_id = 'event-summary-card-title-' . absint( $event_id );
+		?>
+		<aside class="event-summary-card" aria-labelledby="<?php echo esc_attr( $title_id ); ?>">
+			<h2 id="<?php echo esc_attr( $title_id ); ?>" class="event-summary-card__title">
+				<?php esc_html_e( 'Tapahtuman tiedot', 'rytkoset-theme' ); ?>
+			</h2>
+
+			<?php if ( ! empty( $items ) ) : ?>
+				<dl class="event-summary-card__details">
+					<?php foreach ( $items as $item ) : ?>
+						<div class="event-summary-card__item">
+							<dt class="event-summary-card__label"><?php echo esc_html( $item['label'] ); ?></dt>
+							<dd class="event-summary-card__value">
+								<?php if ( ! empty( $item['datetime'] ) ) : ?>
+									<time datetime="<?php echo esc_attr( $item['datetime'] ); ?>"><?php echo esc_html( $item['value'] ); ?></time>
+								<?php else : ?>
+									<?php echo esc_html( $item['value'] ); ?>
+								<?php endif; ?>
+							</dd>
+						</div>
+					<?php endforeach; ?>
+				</dl>
+			<?php endif; ?>
+
+			<?php if ( '' !== $product_url ) : ?>
+				<div class="event-summary-card__cta">
+					<a class="btn btn--primary event-summary-card__button" href="<?php echo esc_url( $product_url ); ?>">
+						<?php esc_html_e( 'Ilmoittaudu ja maksa', 'rytkoset-theme' ); ?>
+					</a>
+				</div>
+			<?php endif; ?>
+		</aside>
 		<?php
 	}
 }

--- a/wp-content/themes/rytkoset-theme/single-event.php
+++ b/wp-content/themes/rytkoset-theme/single-event.php
@@ -13,46 +13,47 @@ get_header();
 ?>
 
 <section class="section">
-	<div class="container section__narrow">
+	<div class="container">
 		<?php
 		if ( have_posts() ) :
 			while ( have_posts() ) :
 				the_post();
+				$event_id         = get_the_ID();
+				$has_summary_card = function_exists( 'rytkoset_theme_event_has_summary_card' ) && rytkoset_theme_event_has_summary_card( $event_id );
 				?>
-				<article <?php post_class( 'article' ); ?>>
-					<header class="article__header">
+				<article <?php post_class( 'article article--event' ); ?>>
+					<header class="article__header event-article__header">
 						<h1 class="article__title"><?php the_title(); ?></h1>
-						<?php
-						$event_date_raw     = rytkoset_theme_get_event_date_raw( get_the_ID() );
-						$event_date_display = rytkoset_theme_get_event_date_display( get_the_ID() );
-						?>
-						<?php if ( '' !== $event_date_display ) : ?>
-							<p class="article__meta">
-								<time datetime="<?php echo esc_attr( $event_date_raw ); ?>"><?php echo esc_html( $event_date_display ); ?></time>
-							</p>
-						<?php endif; ?>
 					</header>
 
-					<?php if ( has_post_thumbnail() ) : ?>
-						<div class="article__image">
-							<?php the_post_thumbnail( 'large' ); ?>
+					<div class="<?php echo esc_attr( $has_summary_card ? 'event-layout event-layout--has-sidebar' : 'event-layout' ); ?>">
+						<?php if ( $has_summary_card ) : ?>
+							<div class="event-layout__sidebar">
+								<?php rytkoset_theme_render_event_summary_card( $event_id ); ?>
+							</div>
+						<?php endif; ?>
+
+						<div class="event-layout__main">
+							<?php if ( has_post_thumbnail() ) : ?>
+								<div class="article__image">
+									<?php the_post_thumbnail( 'large' ); ?>
+								</div>
+							<?php endif; ?>
+
+							<div class="article__content">
+								<?php the_content(); ?>
+							</div>
+
+							<?php
+							rytkoset_theme_share_buttons(
+								array(
+									'heading' => __( 'Jaa tapahtuma', 'rytkoset-theme' ),
+									'post_id' => $post->ID,
+								)
+							);
+							?>
 						</div>
-					<?php endif; ?>
-
-					<div class="article__content">
-						<?php the_content(); ?>
 					</div>
-
-					<?php rytkoset_theme_render_event_product_cta( get_the_ID() ); ?>
-
-					<?php
-					rytkoset_theme_share_buttons(
-						array(
-							'heading' => __( 'Jaa tapahtuma', 'rytkoset-theme' ),
-							'post_id' => $post->ID,
-						)
-					);
-					?>
 				</article>
 				<?php
 			endwhile;


### PR DESCRIPTION
## Summary
- Adds event metadata fields for time, location, fee type and price text.
- Shows event details on the public event page in a dedicated summary card.
- Moves the WooCommerce registration CTA into the same event summary card.
- Keeps the layout responsive: card before content on mobile, side card on desktop.
- Updates event documentation for the new fields and display model.

## Testing
- docker compose exec wordpress php -l wp-content/themes/rytkoset-theme/inc/events.php
- docker compose exec wordpress php -l wp-content/themes/rytkoset-theme/single-event.php
- git diff --check
