### PR TITLE
70 9 tapahtuma arkisto tapahtumat

### DIFF
--- a/wp-content/themes/rytkoset-theme/archive-event.php
+++ b/wp-content/themes/rytkoset-theme/archive-event.php
@@ -77,24 +77,35 @@ $has_event_sections = $upcoming_events->have_posts() || $past_events->have_posts
 
 $render_event_list = static function ( WP_Query $event_query ) {
 	?>
-	<div class="article-list">
+	<div class="event-archive-grid">
 		<?php
 		while ( $event_query->have_posts() ) :
 			$event_query->the_post();
 			$event_date_raw     = rytkoset_theme_get_event_date_raw( get_the_ID() );
 			$event_date_display = rytkoset_theme_get_event_date_display( get_the_ID() );
 			$event_location     = rytkoset_theme_get_event_location( get_the_ID() );
-			?>
-			<article <?php post_class( 'article' ); ?>>
-				<?php if ( has_post_thumbnail() ) : ?>
-					<a href="<?php the_permalink(); ?>" aria-label="<?php echo esc_attr( get_the_title() ); ?>">
-						<?php the_post_thumbnail( 'large' ); ?>
-					</a>
-				<?php endif; ?>
+			$event_excerpt      = trim( get_the_excerpt() );
+			$has_product_link   = function_exists( 'rytkoset_theme_get_event_product_url' )
+				&& '' !== rytkoset_theme_get_event_product_url( get_the_ID() );
 
-				<header class="article__header">
+			if ( '' === $event_excerpt ) {
+				$event_excerpt = wp_strip_all_tags( get_the_content() );
+			}
+			?>
+			<article <?php post_class( 'event-card' ); ?>>
+				<a class="event-card__media" href="<?php the_permalink(); ?>" aria-label="<?php echo esc_attr( get_the_title() ); ?>">
+					<?php if ( has_post_thumbnail() ) : ?>
+						<?php the_post_thumbnail( 'large' ); ?>
+					<?php else : ?>
+						<span class="event-card__media-placeholder" aria-hidden="true">
+							<?php esc_html_e( 'Tapahtuma', 'rytkoset-theme' ); ?>
+						</span>
+					<?php endif; ?>
+				</a>
+
+				<div class="event-card__body">
 					<?php if ( '' !== $event_date_display || '' !== $event_location ) : ?>
-						<p class="article__meta">
+						<p class="event-card__meta">
 							<?php if ( '' !== $event_date_display ) : ?>
 								<time datetime="<?php echo esc_attr( $event_date_raw ); ?>"><?php echo esc_html( $event_date_display ); ?></time>
 							<?php endif; ?>
@@ -106,13 +117,22 @@ $render_event_list = static function ( WP_Query $event_query ) {
 							<?php endif; ?>
 						</p>
 					<?php endif; ?>
-					<h3 class="article__title">
+					<h3 class="event-card__title">
 						<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
 					</h3>
-				</header>
 
-				<div class="article__content">
-					<p><?php echo esc_html( wp_trim_words( get_the_excerpt(), 32 ) ); ?></p>
+					<?php if ( '' !== $event_excerpt ) : ?>
+						<p class="event-card__excerpt"><?php echo esc_html( wp_trim_words( $event_excerpt, 32 ) ); ?></p>
+					<?php endif; ?>
+
+					<div class="event-card__actions">
+						<a class="btn btn--light event-card__link" href="<?php the_permalink(); ?>">
+							<?php esc_html_e( 'Katso tapahtuma', 'rytkoset-theme' ); ?>
+						</a>
+						<?php if ( $has_product_link ) : ?>
+							<span class="event-card__badge"><?php esc_html_e( 'Ilmoittautuminen avoinna', 'rytkoset-theme' ); ?></span>
+						<?php endif; ?>
+					</div>
 				</div>
 			</article>
 			<?php
@@ -125,7 +145,7 @@ $render_event_list = static function ( WP_Query $event_query ) {
 ?>
 
 <section class="section">
-	<div class="container section__narrow">
+	<div class="container">
 		<header class="section__header">
 			<h1 class="section__title"><?php post_type_archive_title(); ?></h1>
 			<?php if ( get_the_archive_description() ) : ?>

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -110,6 +110,110 @@
   margin-top: 2.5rem;
 }
 
+.event-archive-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.event-card {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface-alt);
+  box-shadow: var(--shadow-card);
+}
+
+.event-card__media {
+  display: block;
+  aspect-ratio: 16 / 9;
+  min-height: 11rem;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.12), rgba(251, 191, 36, 0.2));
+}
+
+.event-card__media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  object-fit: cover;
+}
+
+.event-card__media-placeholder {
+  display: grid;
+  min-height: 11rem;
+  height: 100%;
+  place-items: center;
+  color: var(--color-primary);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.event-card__body {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1.25rem;
+}
+
+.event-card__meta {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-weight: 700;
+  opacity: 0.72;
+}
+
+.event-card__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+}
+
+.event-card__excerpt {
+  margin: 0;
+}
+
+.event-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.event-card__link {
+  border-color: var(--color-border-neutral);
+}
+
+.event-card__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.4rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: var(--radius-pill);
+  background: rgba(251, 191, 36, 0.22);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  font-weight: 800;
+}
+
+@media (min-width: 64rem) {
+  .event-card {
+    grid-template-columns: minmax(16rem, 0.8fr) minmax(0, 1.2fr);
+  }
+
+  .event-card__media {
+    aspect-ratio: auto;
+  }
+
+  .event-card__media,
+  .event-card__media img,
+  .event-card__media-placeholder {
+    min-height: 100%;
+  }
+}
+
 .event-details {
   display: grid;
   gap: 0.75rem;

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
@@ -201,6 +201,26 @@
   outline-offset: 3px;
 }
 
+.site-cart-link__icon {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 1.25rem;
+  height: 1.25rem;
+  background: url("../icons/ui/cart.svg") center / contain no-repeat;
+}
+
+.site-cart-link__label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .site-cart-link__count {
   display: inline-grid;
   place-items: center;

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/cart.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/cart.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M3 4h2l2.4 11.2a2 2 0 0 0 2 1.6h7.9a2 2 0 0 0 2-1.6L21 8H7" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="10" cy="20" r="1.35" fill="#fff"/>
+  <circle cx="18" cy="20" r="1.35" fill="#fff"/>
+</svg>

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -255,6 +255,7 @@ if ( ! function_exists( 'rytkoset_theme_get_cart_link_markup' ) ) {
 		ob_start();
 		?>
 		<a class="<?php echo esc_attr( trim( $args['class'] ) ); ?>" href="<?php echo esc_url( $cart_url ); ?>" aria-label="<?php echo esc_attr( $aria_label ); ?>">
+			<span class="site-cart-link__icon" aria-hidden="true"></span>
 			<span class="site-cart-link__label"><?php echo esc_html( $label ); ?></span>
 			<?php if ( $item_count > 0 ) : ?>
 				<span class="site-cart-link__count" aria-hidden="true"><?php echo esc_html( (string) $item_count ); ?></span>


### PR DESCRIPTION
## Summary
- Viimeistelee `/tapahtumat/`-arkiston korttimaiseksi tapahtumanäkymäksi.
- Säilyttää tulevat, menneet ja päivämäärättömät tapahtumat erillisinä osioina.
- Näyttää tapahtumakortissa kuvan tai placeholderin, päivämäärän, paikan, otteen ja linkin tapahtumasivulle.
- Näyttää ilmoittautumisbadgen tapahtumille, joilla on linkitetty maksutuote.

## Testing
- `docker compose exec wordpress php -l wp-content/themes/rytkoset-theme/archive-event.php`
- `git diff --check`
- Smoke-testattu Playwrightilla `/tapahtumat/` paikallisesti.
