### PR TITLE
ci: bump actions/checkout to v5 and FTP-Deploy-Action to v4.4.0 (#189)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Deploy via FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USERNAME }}

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync labels from .github/labels.yml
         uses: crazy-max/ghaction-github-labeler@v5

--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## CI: päivitä GitHub Actions Node.js 24:ään (#189)

### Mitä tehtiin

GitHub Actions varoitti kahdesta Node.js 20 -actionista, jotka lakkaavat
toimimasta kun Node 24 tulee pakolliseksi **2.6.2026**:

| Action | Ennen | Nyt |
|---|---|---|
| `actions/checkout` | `@v4` (Node 20) | `@v5` (Node 24) |
| `SamKirkland/FTP-Deploy-Action` | `@v4.3.4` (Node 20) | `@v4.4.0` (Node 24) |

Päivitys tehty kaikkiin kolmeen workflow-tiedostoon:
- `deploy-dev.yml` — molemmat actionit päivitetty
- `labels-sync.yml` — checkout päivitetty
- `php-ci.yml` — checkout päivitetty

`shivammathur/setup-php@v2` ei näkynyt CI-varoituksessa, jätetty ennalleen.
