### PR TITLE
20 kommentointi albumeihin blogiin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ wp-content/ai1wm-backups/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+design_handoff_header_redesign

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,38 @@
+# Kommentointi
+
+Sivustolla käytetään WordPressin omaa kommenttijärjestelmää blogikirjoituksissa ja albumeissa. Ratkaisu on tarkoituksella kevyt: kommentointi ei vielä riipu jäsenyydestä, kirjautumisesta tai erillisistä käyttäjärooleista.
+
+## Käytössä olevat kohteet
+
+- Blogikirjoitukset näyttävät kommentit ja kommenttilomakkeen yksittäisen artikkelin sivulla.
+- Albumit tukevat kommentointia ja näyttävät kommentit albumin yksittäisellä sivulla.
+- Kommentointi voidaan sulkea yksittäiseltä blogikirjoitukselta tai albumilta WordPress-editorin Keskustelu/Discussion-asetuksista.
+
+## Moderointi
+
+Kommentit pidetään aluksi käsin hyväksyttävinä. Tarkista WordPress-adminissa:
+
+1. Avaa `Asetukset > Keskustelu`.
+2. Salli kommentointi uusille julkaistaville artikkeleille.
+3. Vaadi kommentoijalta nimi ja sähköposti.
+4. Älä vaadi kirjautumista kommentointiin.
+5. Ota käyttöön asetus, jossa kommentti täytyy hyväksyä käsin ennen julkaisua.
+
+Kommentit käsitellään adminissa kohdasta `Kommentit`. Ylläpitäjä voi hyväksyä, hylätä, merkitä roskaksi tai siirtää kommentin roskakoriin.
+
+## Roskapostisuoja
+
+Roskapostisuojaksi valitaan Antispam Bee. Se valitaan Akismetin sijaan, koska sukuseuran sivustolla on verkkokauppa- ja jäsenmaksukäyttöä, jolloin Akismetin ilmainen henkilökohtainen käyttö ei ole selkeä valinta. Antispam Bee on ilmainen, ei vaadi API-avainta ja sopii paremmin tämän MVP-vaiheen ylläpidettävään ratkaisuun.
+
+Asenna ja aktivoi Antispam Bee WordPress-adminissa kohdasta `Lisäosat > Lisää uusi`. Pluginia ei lisätä tähän repositorioon.
+
+## Testaus
+
+Perustestissä varmista:
+
+- blogikirjoitus näyttää kommenttilomakkeen
+- albumi näyttää kommenttilomakkeen
+- testikommentti jää moderoitavaksi
+- hyväksytty kommentti näkyy julkisella sivulla
+- suljetun kommentoinnin kohde ei näytä kommenttilomaketta
+- mobiilinäkymä ei riko kommenttilomakkeen tai kommenttilistan asettelua

--- a/wp-content/themes/rytkoset-theme/comments.php
+++ b/wp-content/themes/rytkoset-theme/comments.php
@@ -21,13 +21,13 @@ if ( post_password_required() ) {
 			if ( '1' === $comment_count ) {
 				printf(
 					/* translators: %s: post title */
-					esc_html__( '1 kommentti artikkeliin "%s"', 'rytkoset-theme' ),
+					esc_html__( '1 kommentti aiheeseen "%s"', 'rytkoset-theme' ),
 					'<span>' . get_the_title() . '</span>'
 				);
 			} else {
 				printf(
 					/* translators: 1: number of comments, 2: post title */
-					esc_html( _n( '%1$s kommentti artikkeliin "%2$s"', '%1$s kommenttia artikkeliin "%2$s"', $comment_count, 'rytkoset-theme' ) ),
+					esc_html( _n( '%1$s kommentti aiheeseen "%2$s"', '%1$s kommenttia aiheeseen "%2$s"', $comment_count, 'rytkoset-theme' ) ),
 					number_format_i18n( $comment_count ),
 					'<span>' . get_the_title() . '</span>'
 				);


### PR DESCRIPTION
## Summary

- Finalizes basic WordPress comments support for blog posts and gallery albums
- Updates the shared comments heading so it works for both articles and albums
- Adds short documentation for comment moderation and Antispam Bee setup

## Testing

- Verified blog post comment form renders locally
- Verified gallery album comment form renders locally
- Verified test comments for both post types stay pending moderation
- Verified closed comments hide the comment form
- Verified mobile layout with Playwright snapshot
- Ran PHP syntax check for `comments.php`

## Notes

Antispam Bee is configured as the recommended spam protection plugin. WordPress discussion settings and plugin activation are environment settings, so they must be checked separately in dev/production admin.