### PR TITLE
feat: add digital magazine reading view

### DIFF
--- a/docs/digital-magazines.md
+++ b/docs/digital-magazines.md
@@ -1,0 +1,66 @@
+# Digilehdet
+
+Digilehdet ovat WordPressissä HTML-sisältöä. Niitä ei julkaista PDF-tiedostoina, WooCommerce-tuotteina tai ostoon sidottuina sisältöinä tässä MVP-vaiheessa.
+
+## Sisältömalli
+
+Digilehti käyttää yhtä hierarkkista sisältötyyppiä:
+
+- Post type: `digital_magazine`
+- Julkinen arkisto: `/digilehdet/`
+- Lehti: yläkohde, jolla ei ole vanhempaa
+- Juttu: saman sisältötyypin alakohde, jonka vanhemmaksi valitaan lehti
+
+URL-rakenne:
+
+- lehti: `/digilehdet/{lehden-polku}/`
+- juttu: `/digilehdet/{lehden-polku}/{jutun-polku}/`
+
+Sisällysluetteloa ei tallenneta erilliseen kenttään. Lehden sivu muodostaa sisällysluettelon automaattisesti julkaistuista lapsijutuista.
+
+## Lehden luominen
+
+1. Avaa WordPress-adminissa `Digilehdet`.
+2. Valitse `Lisää uusi`.
+3. Kirjoita lehden nimi otsikoksi.
+4. Jätä vanhempi tyhjäksi.
+5. Kirjoita lehden johdanto tai kuvaus editoriin.
+6. Lisää halutessasi ote ja artikkelikuva.
+7. Julkaise lehti.
+
+## Jutun lisääminen lehteen
+
+1. Avaa `Digilehdet > Lisää uusi`.
+2. Kirjoita jutun otsikko.
+3. Valitse sivupalkissa vanhemmaksi oikea lehti.
+4. Kirjoita jutun varsinainen sisältö editoriin.
+5. Aseta `Järjestys` / `Menu order` -kenttään numero, jos haluat määrittää sisällysluettelon järjestyksen.
+6. Julkaise juttu.
+
+Suositeltu järjestysnumerointi on esimerkiksi `10`, `20`, `30`. Silloin väliin voi lisätä myöhemmin uusia juttuja ilman kaikkien numeroiden muuttamista.
+
+## Julkinen näkymä
+
+Lehden sivulla näkyy:
+
+- lehden otsikko
+- lehden kuvaus tai johdanto
+- automaattinen sisällysluettelo
+
+Jutun sivulla näkyy:
+
+- linkki takaisin lehteen
+- jutun otsikko ja sisältö
+- edellinen ja seuraava juttu samassa lehdessä, jos niitä on
+
+Ensimmäisellä jutulla ei näytetä edellinen-linkkiä. Viimeisellä jutulla ei näytetä seuraava-linkkiä.
+
+## Testaus
+
+Perustestissä varmista:
+
+- `/digilehdet/` näyttää vain lehdet, ei yksittäisiä juttuja
+- lehden sivu näyttää jutut sisällysluettelossa oikeassa järjestyksessä
+- jutun sivu näyttää takaisin-linkin lehteen
+- jutun edellinen/seuraava-navigaatio toimii
+- mobiilinäkymässä sisällysluettelo ja lukunäkymä pysyvät luettavina

--- a/wp-content/themes/rytkoset-theme/archive-digital_magazine.php
+++ b/wp-content/themes/rytkoset-theme/archive-digital_magazine.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Digilehtien arkisto.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+?>
+
+<main id="primary" class="site-main">
+	<section class="section">
+		<div class="container section__wide">
+			<header class="section__header">
+				<h1 class="section__title"><?php post_type_archive_title(); ?></h1>
+				<?php if ( get_the_archive_description() ) : ?>
+					<div class="section__description"><?php echo wp_kses_post( wpautop( get_the_archive_description() ) ); ?></div>
+				<?php endif; ?>
+			</header>
+
+			<?php if ( have_posts() ) : ?>
+				<div class="digital-magazine-archive">
+					<?php
+					while ( have_posts() ) :
+						the_post();
+						$excerpt = trim( get_the_excerpt() );
+
+						if ( '' === $excerpt ) {
+							$excerpt = wp_strip_all_tags( get_the_content() );
+						}
+						?>
+						<article <?php post_class( 'digital-magazine-card' ); ?>>
+							<a class="digital-magazine-card__media" href="<?php the_permalink(); ?>" aria-label="<?php echo esc_attr( get_the_title() ); ?>">
+								<?php if ( has_post_thumbnail() ) : ?>
+									<?php the_post_thumbnail( 'large' ); ?>
+								<?php else : ?>
+									<span class="digital-magazine-card__placeholder" aria-hidden="true">
+										<?php esc_html_e( 'Digilehti', 'rytkoset-theme' ); ?>
+									</span>
+								<?php endif; ?>
+							</a>
+
+							<div class="digital-magazine-card__body">
+								<h2 class="digital-magazine-card__title">
+									<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+								</h2>
+
+								<?php if ( '' !== $excerpt ) : ?>
+									<p class="digital-magazine-card__excerpt"><?php echo esc_html( wp_trim_words( $excerpt, 32 ) ); ?></p>
+								<?php endif; ?>
+
+								<a class="btn btn--light digital-magazine-card__link" href="<?php the_permalink(); ?>">
+									<?php esc_html_e( 'Avaa lehti', 'rytkoset-theme' ); ?>
+								</a>
+							</div>
+						</article>
+						<?php
+					endwhile;
+					?>
+				</div>
+
+				<?php
+				the_posts_pagination(
+					array(
+						'prev_text' => __( 'Edelliset', 'rytkoset-theme' ),
+						'next_text' => __( 'Seuraavat', 'rytkoset-theme' ),
+					)
+				);
+				?>
+			<?php else : ?>
+				<p><?php esc_html_e( 'Digilehtiä ei ole vielä julkaistu.', 'rytkoset-theme' ); ?></p>
+			<?php endif; ?>
+		</div>
+	</section>
+</main>
+
+<?php
+get_footer();

--- a/wp-content/themes/rytkoset-theme/assets/css/digital-magazine.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/digital-magazine.css
@@ -1,0 +1,265 @@
+.digital-magazine-archive {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.digital-magazine-card {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface-alt);
+  box-shadow: var(--shadow-card);
+}
+
+.digital-magazine-card__media {
+  display: block;
+  min-height: 12rem;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(15, 76, 129, 0.12), rgba(251, 191, 36, 0.22));
+}
+
+.digital-magazine-card__media img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.digital-magazine-card__placeholder {
+  display: grid;
+  min-height: 12rem;
+  height: 100%;
+  place-items: center;
+  color: var(--color-primary-dark);
+  font-weight: 800;
+}
+
+.digital-magazine-card__body {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.25rem;
+}
+
+.digital-magazine-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.digital-magazine-card__title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.digital-magazine-card__title a:hover,
+.digital-magazine-card__title a:focus-visible {
+  color: var(--color-primary);
+}
+
+.digital-magazine-card__excerpt {
+  margin: 0;
+  color: var(--color-text-mute);
+}
+
+.digital-magazine-card__link {
+  justify-self: start;
+}
+
+.digital-magazine-issue__hero {
+  position: relative;
+  min-height: clamp(360px, 54vh, 620px);
+  display: grid;
+  align-items: end;
+  overflow: hidden;
+  background: var(--color-primary-dark);
+  color: var(--color-text-inverted);
+}
+
+.digital-magazine-issue__hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(8, 37, 74, 0.18), rgba(8, 37, 74, 0.84));
+}
+
+.digital-magazine-issue__hero--no-image {
+  background: linear-gradient(135deg, var(--color-primary-dark), var(--color-primary));
+}
+
+.digital-magazine-issue__media {
+  position: absolute;
+  inset: 0;
+}
+
+.digital-magazine-issue__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.digital-magazine-issue__content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding: 4rem 0 3rem;
+}
+
+.digital-magazine-issue__meta,
+.digital-magazine-reader__meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.digital-magazine-issue__title {
+  margin: 0;
+  max-width: 820px;
+  font-size: clamp(2rem, 6vw, 4.5rem);
+}
+
+.digital-magazine-issue__lead {
+  max-width: 680px;
+  margin-top: 1rem;
+  font-size: 1.05rem;
+}
+
+.digital-magazine-issue__lead p {
+  margin: 0;
+}
+
+.digital-magazine-issue__body {
+  max-width: 760px;
+  margin-bottom: 2.5rem;
+}
+
+.digital-magazine-toc {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.digital-magazine-toc h2 {
+  margin: 0;
+}
+
+.digital-magazine-toc__list {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.digital-magazine-toc__item::marker {
+  font-weight: 800;
+  color: var(--color-primary);
+}
+
+.digital-magazine-toc__link {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.digital-magazine-toc__link:hover,
+.digital-magazine-toc__link:focus-visible {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.digital-magazine-toc__title {
+  font-weight: 800;
+}
+
+.digital-magazine-toc__excerpt {
+  color: var(--color-text-mute);
+}
+
+.digital-magazine-reader__header {
+  padding: 3.5rem 0 2rem;
+  background: var(--color-surface-alt);
+}
+
+.digital-magazine-reader__back {
+  display: inline-flex;
+  margin-bottom: 1.5rem;
+  color: var(--color-primary);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.digital-magazine-reader__back:hover,
+.digital-magazine-reader__back:focus-visible {
+  text-decoration: underline;
+}
+
+.digital-magazine-reader__meta {
+  color: var(--color-text-mute);
+}
+
+.digital-magazine-reader__title {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 3.75rem);
+}
+
+.digital-magazine-reader__section {
+  padding-top: 2.5rem;
+}
+
+.digital-magazine-reader__content {
+  font-size: 1.05rem;
+}
+
+.digital-magazine-reader__nav {
+  display: grid;
+  gap: 1rem;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border-neutral);
+}
+
+.digital-magazine-reader__nav-link {
+  display: grid;
+  gap: 0.3rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.digital-magazine-reader__nav-link:hover,
+.digital-magazine-reader__nav-link:focus-visible {
+  border-color: var(--color-primary);
+  text-decoration: none;
+}
+
+.digital-magazine-reader__nav-link span {
+  color: var(--color-text-mute);
+  font-size: 0.9rem;
+}
+
+@media (min-width: 720px) {
+  .digital-magazine-card {
+    grid-template-columns: minmax(15rem, 0.45fr) 1fr;
+  }
+
+  .digital-magazine-reader__nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .digital-magazine-reader__nav-link--next {
+    text-align: right;
+  }
+
+  .digital-magazine-reader__nav-link--next:only-child {
+    grid-column: 2;
+  }
+}

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -12,6 +12,7 @@ require_once get_template_directory() . '/inc/share.php';
 require_once get_template_directory() . '/inc/gallery-albums.php';
 require_once get_template_directory() . '/inc/media-library.php';
 require_once get_template_directory() . '/inc/events.php';
+require_once get_template_directory() . '/inc/digital-magazines.php';
 
 if ( ! function_exists( 'rytkoset_theme_get_attachment_display_caption_text' ) ) {
 	/**
@@ -414,6 +415,15 @@ function rytkoset_theme_scripts() {
         $theme_version,
         true // footer
     );
+
+	if ( is_post_type_archive( 'digital_magazine' ) || is_singular( 'digital_magazine' ) ) {
+		wp_enqueue_style(
+			'rytkoset-theme-digital-magazine',
+			get_template_directory_uri() . '/assets/css/digital-magazine.css',
+			array( 'rytkoset-theme-style' ),
+			$theme_version
+		);
+	}
 
 	if ( function_exists( 'is_checkout' ) && is_checkout() ) {
 		wp_add_inline_script(

--- a/wp-content/themes/rytkoset-theme/inc/digital-magazines.php
+++ b/wp-content/themes/rytkoset-theme/inc/digital-magazines.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Digilehdet.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'rytkoset_theme_register_digital_magazine_cpt' ) ) {
+	/**
+	 * Rekisteröi digilehtien hierarkkisen sisältötyypin.
+	 */
+	function rytkoset_theme_register_digital_magazine_cpt() {
+		$labels = array(
+			'name'               => __( 'Digilehdet', 'rytkoset-theme' ),
+			'singular_name'      => __( 'Digilehti', 'rytkoset-theme' ),
+			'menu_name'          => __( 'Digilehdet', 'rytkoset-theme' ),
+			'name_admin_bar'     => __( 'Digilehti', 'rytkoset-theme' ),
+			'add_new'            => __( 'Lisää uusi', 'rytkoset-theme' ),
+			'add_new_item'       => __( 'Lisää uusi digilehti tai juttu', 'rytkoset-theme' ),
+			'new_item'           => __( 'Uusi digilehti', 'rytkoset-theme' ),
+			'edit_item'          => __( 'Muokkaa digilehteä', 'rytkoset-theme' ),
+			'view_item'          => __( 'Näytä digilehti', 'rytkoset-theme' ),
+			'all_items'          => __( 'Kaikki digilehdet', 'rytkoset-theme' ),
+			'search_items'       => __( 'Etsi digilehtiä', 'rytkoset-theme' ),
+			'parent_item_colon'  => __( 'Ylälehti:', 'rytkoset-theme' ),
+			'not_found'          => __( 'Digilehtiä ei löytynyt.', 'rytkoset-theme' ),
+			'not_found_in_trash' => __( 'Roskakorissa ei ole digilehtiä.', 'rytkoset-theme' ),
+		);
+
+		$args = array(
+			'labels'       => $labels,
+			'public'       => true,
+			'has_archive'  => true,
+			'hierarchical' => true,
+			'menu_icon'    => 'dashicons-book-alt',
+			'show_in_rest' => true,
+			'supports'     => array( 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes' ),
+			'rewrite'      => array(
+				'slug'         => 'digilehdet',
+				'with_front'   => false,
+				'hierarchical' => true,
+			),
+		);
+
+		register_post_type( 'digital_magazine', $args );
+	}
+}
+add_action( 'init', 'rytkoset_theme_register_digital_magazine_cpt' );
+
+if ( ! function_exists( 'rytkoset_theme_is_digital_magazine_article' ) ) {
+	/**
+	 * Checks whether a digital magazine post is an article.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	function rytkoset_theme_is_digital_magazine_article( $post_id ) {
+		return 0 < (int) wp_get_post_parent_id( $post_id );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_digital_magazine_parent_id' ) ) {
+	/**
+	 * Returns the parent magazine ID for a magazine or article.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int
+	 */
+	function rytkoset_theme_get_digital_magazine_parent_id( $post_id ) {
+		$parent_id = (int) wp_get_post_parent_id( $post_id );
+
+		return 0 < $parent_id ? $parent_id : (int) $post_id;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_digital_magazine_articles' ) ) {
+	/**
+	 * Returns published articles for one digital magazine.
+	 *
+	 * @param int $magazine_id Magazine post ID.
+	 * @return WP_Post[]
+	 */
+	function rytkoset_theme_get_digital_magazine_articles( $magazine_id ) {
+		$magazine_id = absint( $magazine_id );
+
+		if ( 0 === $magazine_id ) {
+			return array();
+		}
+
+		return get_posts(
+			array(
+				'post_type'      => 'digital_magazine',
+				'post_status'    => 'publish',
+				'post_parent'    => $magazine_id,
+				'posts_per_page' => -1,
+				'orderby'        => array(
+					'menu_order' => 'ASC',
+					'title'      => 'ASC',
+				),
+				'no_found_rows'  => true,
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_adjacent_digital_magazine_article' ) ) {
+	/**
+	 * Returns the previous or next article within the same digital magazine.
+	 *
+	 * @param int    $article_id Article post ID.
+	 * @param string $direction  Direction: previous or next.
+	 * @return WP_Post|null
+	 */
+	function rytkoset_theme_get_adjacent_digital_magazine_article( $article_id, $direction ) {
+		$article = get_post( $article_id );
+
+		if ( ! $article instanceof WP_Post || 'digital_magazine' !== $article->post_type || 0 === (int) $article->post_parent ) {
+			return null;
+		}
+
+		$articles = rytkoset_theme_get_digital_magazine_articles( (int) $article->post_parent );
+		$ids      = array_map( 'intval', wp_list_pluck( $articles, 'ID' ) );
+		$index    = array_search( (int) $article_id, $ids, true );
+
+		if ( false === $index ) {
+			return null;
+		}
+
+		$target_index = 'previous' === $direction ? $index - 1 : $index + 1;
+
+		return isset( $articles[ $target_index ] ) ? $articles[ $target_index ] : null;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_limit_digital_magazine_archive_to_top_level' ) ) {
+	/**
+	 * Shows only top-level magazines on the public archive.
+	 *
+	 * @param WP_Query $query Query instance.
+	 */
+	function rytkoset_theme_limit_digital_magazine_archive_to_top_level( $query ) {
+		if ( is_admin() || ! $query->is_main_query() || ! $query->is_post_type_archive( 'digital_magazine' ) ) {
+			return;
+		}
+
+		$query->set( 'post_parent', 0 );
+		$query->set( 'orderby', 'date' );
+		$query->set( 'order', 'DESC' );
+	}
+}
+add_action( 'pre_get_posts', 'rytkoset_theme_limit_digital_magazine_archive_to_top_level' );

--- a/wp-content/themes/rytkoset-theme/single-digital_magazine.php
+++ b/wp-content/themes/rytkoset-theme/single-digital_magazine.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Yksittäinen digilehti tai digilehden juttu.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+?>
+
+<main id="primary" class="site-main">
+<?php
+if ( have_posts() ) :
+	while ( have_posts() ) :
+		the_post();
+
+		$post_id    = get_the_ID();
+		$is_article = rytkoset_theme_is_digital_magazine_article( $post_id );
+
+		if ( $is_article ) :
+			$magazine_id      = rytkoset_theme_get_digital_magazine_parent_id( $post_id );
+			$previous_article = rytkoset_theme_get_adjacent_digital_magazine_article( $post_id, 'previous' );
+			$next_article     = rytkoset_theme_get_adjacent_digital_magazine_article( $post_id, 'next' );
+			?>
+			<article <?php post_class( 'digital-magazine digital-magazine--article' ); ?>>
+				<header class="digital-magazine-reader__header">
+					<div class="container section__narrow">
+						<a class="digital-magazine-reader__back" href="<?php echo esc_url( get_permalink( $magazine_id ) ); ?>">
+							<?php
+							printf(
+								/* translators: %s: magazine title */
+								esc_html__( 'Takaisin lehteen: %s', 'rytkoset-theme' ),
+								esc_html( get_the_title( $magazine_id ) )
+							);
+							?>
+						</a>
+						<p class="digital-magazine-reader__meta"><?php echo esc_html( get_the_title( $magazine_id ) ); ?></p>
+						<h1 class="digital-magazine-reader__title"><?php the_title(); ?></h1>
+					</div>
+				</header>
+
+				<section class="section digital-magazine-reader__section">
+					<div class="container section__narrow">
+						<div class="article__content digital-magazine-reader__content">
+							<?php the_content(); ?>
+						</div>
+
+						<nav class="digital-magazine-reader__nav" aria-label="<?php esc_attr_e( 'Digilehden juttunavigaatio', 'rytkoset-theme' ); ?>">
+							<?php if ( $previous_article instanceof WP_Post ) : ?>
+								<a class="digital-magazine-reader__nav-link digital-magazine-reader__nav-link--previous" href="<?php echo esc_url( get_permalink( $previous_article ) ); ?>">
+									<span><?php esc_html_e( 'Edellinen juttu', 'rytkoset-theme' ); ?></span>
+									<strong><?php echo esc_html( get_the_title( $previous_article ) ); ?></strong>
+								</a>
+							<?php endif; ?>
+
+							<?php if ( $next_article instanceof WP_Post ) : ?>
+								<a class="digital-magazine-reader__nav-link digital-magazine-reader__nav-link--next" href="<?php echo esc_url( get_permalink( $next_article ) ); ?>">
+									<span><?php esc_html_e( 'Seuraava juttu', 'rytkoset-theme' ); ?></span>
+									<strong><?php echo esc_html( get_the_title( $next_article ) ); ?></strong>
+								</a>
+							<?php endif; ?>
+						</nav>
+					</div>
+				</section>
+			</article>
+			<?php
+		else :
+			$articles = rytkoset_theme_get_digital_magazine_articles( $post_id );
+			?>
+			<article <?php post_class( 'digital-magazine digital-magazine--issue' ); ?>>
+				<header class="digital-magazine-issue__hero<?php echo has_post_thumbnail() ? '' : ' digital-magazine-issue__hero--no-image'; ?>">
+					<?php if ( has_post_thumbnail() ) : ?>
+						<div class="digital-magazine-issue__media">
+							<?php
+							the_post_thumbnail(
+								'full',
+								array(
+									'class'         => 'digital-magazine-issue__image',
+									'loading'       => 'eager',
+									'fetchpriority' => 'high',
+									'sizes'         => '100vw',
+								)
+							);
+							?>
+						</div>
+					<?php endif; ?>
+
+					<div class="digital-magazine-issue__content">
+						<div class="container section__wide">
+							<p class="digital-magazine-issue__meta"><?php esc_html_e( 'Digilehti', 'rytkoset-theme' ); ?></p>
+							<h1 class="digital-magazine-issue__title"><?php the_title(); ?></h1>
+							<?php if ( has_excerpt() ) : ?>
+								<div class="digital-magazine-issue__lead"><?php the_excerpt(); ?></div>
+							<?php endif; ?>
+						</div>
+					</div>
+				</header>
+
+				<section class="section">
+					<div class="container section__wide">
+						<?php if ( trim( (string) get_post_field( 'post_content', $post_id ) ) ) : ?>
+							<div class="article__content digital-magazine-issue__body">
+								<?php the_content(); ?>
+							</div>
+						<?php endif; ?>
+
+						<section class="digital-magazine-toc" aria-labelledby="digital-magazine-toc-heading">
+							<h2 id="digital-magazine-toc-heading"><?php esc_html_e( 'Sisällysluettelo', 'rytkoset-theme' ); ?></h2>
+
+							<?php if ( ! empty( $articles ) ) : ?>
+								<ol class="digital-magazine-toc__list">
+									<?php foreach ( $articles as $article ) : ?>
+										<li class="digital-magazine-toc__item">
+											<a class="digital-magazine-toc__link" href="<?php echo esc_url( get_permalink( $article ) ); ?>">
+												<span class="digital-magazine-toc__title"><?php echo esc_html( get_the_title( $article ) ); ?></span>
+												<?php if ( has_excerpt( $article ) ) : ?>
+													<span class="digital-magazine-toc__excerpt"><?php echo esc_html( wp_trim_words( get_the_excerpt( $article ), 24 ) ); ?></span>
+												<?php endif; ?>
+											</a>
+										</li>
+									<?php endforeach; ?>
+								</ol>
+							<?php else : ?>
+								<p><?php esc_html_e( 'Tähän lehteen ei ole vielä julkaistu juttuja.', 'rytkoset-theme' ); ?></p>
+							<?php endif; ?>
+						</section>
+					</div>
+				</section>
+			</article>
+			<?php
+		endif;
+	endwhile;
+endif;
+?>
+</main>
+
+<?php
+get_footer();


### PR DESCRIPTION
## Summary

Toteuttaa HTML-pohjaisen digilehden WordPress-teemaan yhtenä hierarkkisena CPT:nä.

- Lisää uuden `digital_magazine`-sisältötyypin
- Lisää julkiset näkymät polkuihin `/digilehdet/`, `/digilehdet/{lehti}/` ja `/digilehdet/{lehti}/{juttu}/`
- Muodostaa lehden sisällysluettelon automaattisesti julkaistuista lapsijutuista `menu_order`-järjestyksessä
- Lisää jutuille takaisin-linkin lehteen sekä edellinen/seuraava-navigaation
- Rajaa digilehtiarkiston näyttämään vain varsinaiset lehdet, ei lapsijuttuja
- Lisää digilehdille oman kevyen CSS:n, joka latautuu vain digilehtien arkisto- ja single-näkymissä
- Lisää ylläpitodokumentaation `docs/digital-magazines.md`

## Scope

Tässä PR:ssä ei lisätä:

- PDF-jakelua
- WooCommerce-riippuvuutta
- käyttöoikeus- tai jäsenyyslogiikkaa
- custom-tietokantatauluja
- erillistä sisällysluettelokenttää

Sisältömalli on MVP: yksi hierarkkinen CPT, jossa lehti on yläkohde ja jutut ovat sen lapsia.

## Testing

Testattu paikallisesti:

- `/digilehdet/` listaa vain yläkohteet
- lehden single näyttää otsikon, sisällön ja sisällysluettelon
- jutun single näyttää sisällön, takaisin-linkin ja edellinen/seuraava-navigaation
- ensimmäiseltä jutulta puuttuu edellinen-linkki oikein
- viimeiseltä jutulta puuttuu seuraava-linkki oikein
- CSS latautuu digilehtisivuilla, ei tavallisella blogipostauksella
- mobiilinäkymä tarkistettu selaimella
- `php -l` ajettu uusille ja muutetuille PHP-tiedostoille kontissa

`phpcs` ei ollut käytettävissä paikallisessa kontissa.