### PR TITLE
feat(events): add event registration CPT

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -9,10 +9,11 @@ Tapahtumakokonaisuus on tässä vaiheessa kevyt MVP:
 - tapahtumat ovat WordPressin oma `event`-sisältötyyppi
 - tapahtuman perustiedot tallennetaan post metaan
 - tapahtuman julkinen sisältö kirjoitetaan WordPress-editorissa
+- ilmaisten tapahtumien ilmoittautumisille on oma ei-julkinen `event_registration`-sisältötyyppi
 - maksullisen tapahtuman ilmoittautuminen ja maksaminen ohjataan WooCommerce-tuotteelle
 - Tampere 2026 -osallistujien hallinta tehdään WooCommerce-tilausten ja erillisen osallistujalista-adminin kautta
 
-Tapahtuma ei siis vielä ole erillinen täysi ilmoittautumisjärjestelmä. WordPress-tapahtuma kertoo tapahtumasta, ja WooCommerce hoitaa ostamisen sekä ilmoittautumistiedot silloin, kun tapahtumaan on linkitetty maksutuote.
+Tapahtuma ei siis vielä ole erillinen täysi ilmoittautumisjärjestelmä. WordPress-tapahtuma kertoo tapahtumasta. Ilmaisten tapahtumien oma ilmoittautumisrakenne on valmiina admin-käyttöä ja myöhempää lomaketallennusta varten, ja WooCommerce hoitaa ostamisen sekä ilmoittautumistiedot silloin, kun tapahtumaan on linkitetty maksutuote.
 
 ## Tekninen perusrakenne
 
@@ -33,6 +34,17 @@ Tapahtumat rekisteröidään teemassa tiedostossa `wp-content/themes/rytkoset-th
 
 Tapahtumien yksittäinen näkymä tulee tiedostosta `single-event.php` ja arkisto tiedostosta `archive-event.php`.
 
+### Ilmoittautumisten sisältötyyppi
+
+Ilmaisten tapahtumien ilmoittautumisia varten teemassa on ei-julkinen sisältötyyppi:
+
+- Post type: `event_registration`
+- Admin-nimi: `Ilmoittautumiset`
+- Näkyy WordPress-adminissa `Tapahtumat`-valikon alla
+- Ei julkista arkistoa, yksittäissivua, hakunäkyvyyttä tai REST-näkymää
+
+Yksi `event_registration` vastaa yhtä osallistujaa. Tämä pitää osallistujalistat ja myöhemmän CSV-viennin suoraviivaisina.
+
 ### Metakentät
 
 Tapahtuman lisätiedot tallennetaan WordPressin post metaan:
@@ -48,6 +60,21 @@ Tapahtuman lisätiedot tallennetaan WordPressin post metaan:
 | Maksutuote | `_rytkoset_event_product_id` | WooCommerce-tuotteen ID | Linkki ilmoittautumis-/maksutuotteeseen |
 
 Tallennuksessa tarkistetaan nonce, käyttäjän `edit_post`-oikeus ja kenttäkohtaiset muodot. Tyhjä kenttä poistaa vastaavan metatiedon.
+
+### Ilmoittautumisten metakentät
+
+Ilmoittautumisen tiedot tallennetaan WordPressin post metaan:
+
+| Kenttä ylläpidossa | Meta-avain | Muoto / arvot | Käyttö |
+| --- | --- | --- | --- |
+| Tapahtuma | `_rytkoset_registration_event_id` | `event`-postauksen ID | Viittaus tapahtumaan |
+| Osallistujan nimi | `_rytkoset_registration_name` | vapaa teksti | Osallistujalista ja admin-otsikko |
+| Sähköposti | `_rytkoset_registration_email` | sähköpostiosoite | Yhteydenpito ja myöhempi vahvistus |
+| Ruokarajoitteet ja allergiat | `_rytkoset_registration_diet` | vapaa teksti | Käytännön järjestelyt |
+| Lisätieto | `_rytkoset_registration_notes` | vapaa teksti | Ylläpidon lisätiedot |
+| Tila | `_rytkoset_registration_status` | `pending`, `confirmed`, `cancelled` | Ilmoittautumisen käsittelytila |
+
+Ilmoittautumisen otsikko muodostetaan automaattisesti muodossa `Osallistujan nimi - Tapahtuman nimi`, jotta admin-lista pysyy luettavana.
 
 ### Julkinen näkyminen
 
@@ -111,7 +138,9 @@ Maksulliselle tapahtumalle kannattaa lisäksi täyttää:
 
 ### Yleinen malli
 
-Tällä hetkellä tapahtuman oma `event`-sisältötyyppi ei tallenna ilmoittautumisia itse.
+Ilmaisten tapahtumien ilmoittautumiset tallennetaan `event_registration`-sisältötyyppiin. Ylläpitäjä voi luoda ja muokata ilmoittautumisia käsin WordPress-adminissa kohdassa `Tapahtumat > Ilmoittautumiset`.
+
+Tässä vaiheessa julkista ilmoittautumislomaketta ei vielä ole. Lomake, sen validointi ja varsinainen frontend-tallennus toteutetaan erillisissä tiketeissä #66 ja #67.
 
 Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkitetty maksutuote:
 
@@ -167,6 +196,7 @@ Kun uusi maksullinen tapahtuma otetaan käyttöön:
 Tässä vaiheessa on toteutettu:
 
 - `event`-sisältötyyppi
+- `event_registration`-sisältötyyppi ilmaisten tapahtumien osallistujille
 - tapahtuman yksittäinen sivupohja
 - tapahtuma-arkisto, jossa on tulevat, menneet ja päivämäärättömät tapahtumat
 - tapahtumapäivän metakenttä
@@ -184,7 +214,8 @@ Tässä vaiheessa on toteutettu:
 
 Tässä vaiheessa ei toteuteta:
 
-- tapahtuman omaa ilmoittautumista ilman WooCommercea
+- julkista ilmoittautumislomaketta ilman WooCommercea
+- ilmoittautumislomakkeen validointi- ja tallennuspolkua
 - yleistä osallistujaraporttia kaikille tapahtumille
 - erillistä osallistujien tietokantataulua
 - osallistujien massatoimintoja tapahtumanäkymästä

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -12,6 +12,7 @@ require_once get_template_directory() . '/inc/share.php';
 require_once get_template_directory() . '/inc/gallery-albums.php';
 require_once get_template_directory() . '/inc/media-library.php';
 require_once get_template_directory() . '/inc/events.php';
+require_once get_template_directory() . '/inc/event-registrations.php';
 require_once get_template_directory() . '/inc/digital-magazines.php';
 
 if ( ! function_exists( 'rytkoset_theme_get_attachment_display_caption_text' ) ) {

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -1,0 +1,428 @@
+<?php
+/**
+ * Tapahtumien ilmoittautumiset.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_registration_meta_keys' ) ) {
+	/**
+	 * Returns meta keys used for event registrations.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_registration_meta_keys() {
+		return array(
+			'event_id' => '_rytkoset_registration_event_id',
+			'name'     => '_rytkoset_registration_name',
+			'email'    => '_rytkoset_registration_email',
+			'diet'     => '_rytkoset_registration_diet',
+			'notes'    => '_rytkoset_registration_notes',
+			'status'   => '_rytkoset_registration_status',
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_registration_statuses' ) ) {
+	/**
+	 * Returns supported registration statuses.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_registration_statuses() {
+		return array(
+			'pending'   => __( 'Odottaa vahvistusta', 'rytkoset-theme' ),
+			'confirmed' => __( 'Vahvistettu', 'rytkoset-theme' ),
+			'cancelled' => __( 'Peruttu', 'rytkoset-theme' ),
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_register_event_registration_cpt' ) ) {
+	/**
+	 * Registers the event registration CPT.
+	 */
+	function rytkoset_theme_register_event_registration_cpt() {
+		$labels = array(
+			'name'               => __( 'Ilmoittautumiset', 'rytkoset-theme' ),
+			'singular_name'      => __( 'Ilmoittautuminen', 'rytkoset-theme' ),
+			'menu_name'          => __( 'Ilmoittautumiset', 'rytkoset-theme' ),
+			'name_admin_bar'     => __( 'Ilmoittautuminen', 'rytkoset-theme' ),
+			'add_new'            => __( 'Lisää uusi', 'rytkoset-theme' ),
+			'add_new_item'       => __( 'Lisää uusi ilmoittautuminen', 'rytkoset-theme' ),
+			'new_item'           => __( 'Uusi ilmoittautuminen', 'rytkoset-theme' ),
+			'edit_item'          => __( 'Muokkaa ilmoittautumista', 'rytkoset-theme' ),
+			'view_item'          => __( 'Näytä ilmoittautuminen', 'rytkoset-theme' ),
+			'all_items'          => __( 'Ilmoittautumiset', 'rytkoset-theme' ),
+			'search_items'       => __( 'Etsi ilmoittautumisia', 'rytkoset-theme' ),
+			'not_found'          => __( 'Ilmoittautumisia ei löytynyt.', 'rytkoset-theme' ),
+			'not_found_in_trash' => __( 'Roskakorissa ei ole ilmoittautumisia.', 'rytkoset-theme' ),
+		);
+
+		$args = array(
+			'labels'              => $labels,
+			'public'              => false,
+			'publicly_queryable'  => false,
+			'exclude_from_search' => true,
+			'show_ui'             => true,
+			'show_in_menu'        => 'edit.php?post_type=event',
+			'show_in_admin_bar'   => false,
+			'show_in_nav_menus'   => false,
+			'show_in_rest'        => false,
+			'query_var'           => false,
+			'rewrite'             => false,
+			'has_archive'         => false,
+			'hierarchical'        => false,
+			'menu_icon'           => 'dashicons-id',
+			'supports'            => false,
+			'map_meta_cap'        => true,
+		);
+
+		register_post_type( 'event_registration', $args );
+	}
+}
+add_action( 'init', 'rytkoset_theme_register_event_registration_cpt' );
+
+if ( ! function_exists( 'rytkoset_theme_get_event_registration_meta' ) ) {
+	/**
+	 * Returns a registration meta value.
+	 *
+	 * @param int    $registration_id Registration post ID.
+	 * @param string $key             Meta key alias.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_registration_meta( $registration_id, $key ) {
+		$meta_keys = rytkoset_theme_get_event_registration_meta_keys();
+
+		if ( ! isset( $meta_keys[ $key ] ) ) {
+			return '';
+		}
+
+		$value = get_post_meta( $registration_id, $meta_keys[ $key ], true );
+
+		return is_scalar( $value ) ? (string) $value : '';
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_is_valid_registration_event_id' ) ) {
+	/**
+	 * Checks whether the event ID points to an event post.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return bool
+	 */
+	function rytkoset_theme_is_valid_registration_event_id( $event_id ) {
+		$event_id = absint( $event_id );
+
+		return $event_id > 0 && 'event' === get_post_type( $event_id ) && 'trash' !== get_post_status( $event_id );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_registration_event_options' ) ) {
+	/**
+	 * Returns event options for the registration metabox.
+	 *
+	 * @return WP_Post[]
+	 */
+	function rytkoset_theme_get_event_registration_event_options() {
+		return get_posts(
+			array(
+				'post_type'              => 'event',
+				'post_status'            => array( 'publish', 'future', 'draft', 'pending', 'private' ),
+				'posts_per_page'         => -1,
+				'orderby'                => 'title',
+				'order'                  => 'ASC',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_register_event_registration_metabox' ) ) {
+	/**
+	 * Adds the registration details metabox.
+	 */
+	function rytkoset_theme_register_event_registration_metabox() {
+		add_meta_box(
+			'rytkoset_event_registration_details',
+			__( 'Ilmoittautumisen tiedot', 'rytkoset-theme' ),
+			'rytkoset_theme_render_event_registration_metabox',
+			'event_registration',
+			'normal',
+			'high'
+		);
+	}
+}
+add_action( 'add_meta_boxes_event_registration', 'rytkoset_theme_register_event_registration_metabox' );
+
+if ( ! function_exists( 'rytkoset_theme_render_event_registration_metabox' ) ) {
+	/**
+	 * Renders the registration details metabox.
+	 *
+	 * @param WP_Post $post Registration post object.
+	 */
+	function rytkoset_theme_render_event_registration_metabox( $post ) {
+		$event_id = absint( rytkoset_theme_get_event_registration_meta( $post->ID, 'event_id' ) );
+		$name     = rytkoset_theme_get_event_registration_meta( $post->ID, 'name' );
+		$email    = rytkoset_theme_get_event_registration_meta( $post->ID, 'email' );
+		$diet     = rytkoset_theme_get_event_registration_meta( $post->ID, 'diet' );
+		$notes    = rytkoset_theme_get_event_registration_meta( $post->ID, 'notes' );
+		$status   = rytkoset_theme_get_event_registration_meta( $post->ID, 'status' );
+		$events   = rytkoset_theme_get_event_registration_event_options();
+		$statuses = rytkoset_theme_get_event_registration_statuses();
+
+		if ( ! isset( $statuses[ $status ] ) ) {
+			$status = 'pending';
+		}
+
+		wp_nonce_field( 'rytkoset_save_event_registration', 'rytkoset_event_registration_nonce' );
+		?>
+		<p>
+			<label for="rytkoset_registration_event_id"><strong><?php esc_html_e( 'Tapahtuma', 'rytkoset-theme' ); ?></strong></label>
+		</p>
+		<select id="rytkoset_registration_event_id" name="rytkoset_registration_event_id" class="widefat">
+			<option value=""><?php esc_html_e( 'Valitse tapahtuma', 'rytkoset-theme' ); ?></option>
+			<?php foreach ( $events as $event ) : ?>
+				<option value="<?php echo esc_attr( (string) $event->ID ); ?>" <?php selected( $event_id, $event->ID ); ?>>
+					<?php echo esc_html( get_the_title( $event ) ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+
+		<p>
+			<label for="rytkoset_registration_name"><strong><?php esc_html_e( 'Osallistujan nimi', 'rytkoset-theme' ); ?></strong></label>
+			<input type="text" id="rytkoset_registration_name" name="rytkoset_registration_name" class="widefat" value="<?php echo esc_attr( $name ); ?>" />
+		</p>
+
+		<p>
+			<label for="rytkoset_registration_email"><strong><?php esc_html_e( 'Sähköposti', 'rytkoset-theme' ); ?></strong></label>
+			<input type="email" id="rytkoset_registration_email" name="rytkoset_registration_email" class="widefat" value="<?php echo esc_attr( $email ); ?>" />
+		</p>
+
+		<p>
+			<label for="rytkoset_registration_diet"><strong><?php esc_html_e( 'Ruokarajoitteet ja allergiat', 'rytkoset-theme' ); ?></strong></label>
+			<textarea id="rytkoset_registration_diet" name="rytkoset_registration_diet" class="widefat" rows="3"><?php echo esc_textarea( $diet ); ?></textarea>
+		</p>
+
+		<p>
+			<label for="rytkoset_registration_notes"><strong><?php esc_html_e( 'Lisätieto', 'rytkoset-theme' ); ?></strong></label>
+			<textarea id="rytkoset_registration_notes" name="rytkoset_registration_notes" class="widefat" rows="4"><?php echo esc_textarea( $notes ); ?></textarea>
+		</p>
+
+		<p>
+			<label for="rytkoset_registration_status"><strong><?php esc_html_e( 'Tila', 'rytkoset-theme' ); ?></strong></label>
+		</p>
+		<select id="rytkoset_registration_status" name="rytkoset_registration_status" class="widefat">
+			<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+				<option value="<?php echo esc_attr( $status_key ); ?>" <?php selected( $status, $status_key ); ?>>
+					<?php echo esc_html( $status_label ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_build_event_registration_title' ) ) {
+	/**
+	 * Builds the admin title for an event registration.
+	 *
+	 * @param string $name     Participant name.
+	 * @param int    $event_id Event post ID.
+	 * @return string
+	 */
+	function rytkoset_theme_build_event_registration_title( $name, $event_id ) {
+		$name        = trim( $name );
+		$event_title = rytkoset_theme_is_valid_registration_event_id( $event_id ) ? get_the_title( $event_id ) : '';
+
+		if ( '' === $name ) {
+			$name = __( 'Nimetön osallistuja', 'rytkoset-theme' );
+		}
+
+		if ( '' === $event_title ) {
+			return $name;
+		}
+
+		return sprintf(
+			/* translators: 1: participant name, 2: event title. */
+			__( '%1$s - %2$s', 'rytkoset-theme' ),
+			$name,
+			$event_title
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_save_event_registration' ) ) {
+	/**
+	 * Saves event registration meta.
+	 *
+	 * @param int $post_id Registration post ID.
+	 */
+	function rytkoset_theme_save_event_registration( $post_id ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['rytkoset_event_registration_nonce'] ) ) {
+			return;
+		}
+
+		$nonce = sanitize_text_field( wp_unslash( $_POST['rytkoset_event_registration_nonce'] ) );
+
+		if ( ! wp_verify_nonce( $nonce, 'rytkoset_save_event_registration' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$meta_keys      = rytkoset_theme_get_event_registration_meta_keys();
+		$status_options = rytkoset_theme_get_event_registration_statuses();
+		$event_id       = isset( $_POST['rytkoset_registration_event_id'] ) ? absint( wp_unslash( $_POST['rytkoset_registration_event_id'] ) ) : 0;
+		$name           = isset( $_POST['rytkoset_registration_name'] ) ? sanitize_text_field( wp_unslash( $_POST['rytkoset_registration_name'] ) ) : '';
+		$email          = isset( $_POST['rytkoset_registration_email'] ) ? sanitize_email( wp_unslash( $_POST['rytkoset_registration_email'] ) ) : '';
+		$diet           = isset( $_POST['rytkoset_registration_diet'] ) ? sanitize_textarea_field( wp_unslash( $_POST['rytkoset_registration_diet'] ) ) : '';
+		$notes          = isset( $_POST['rytkoset_registration_notes'] ) ? sanitize_textarea_field( wp_unslash( $_POST['rytkoset_registration_notes'] ) ) : '';
+		$status         = isset( $_POST['rytkoset_registration_status'] ) ? sanitize_key( wp_unslash( $_POST['rytkoset_registration_status'] ) ) : 'pending';
+
+		if ( ! rytkoset_theme_is_valid_registration_event_id( $event_id ) ) {
+			$event_id = 0;
+		}
+
+		if ( '' !== $email && ! is_email( $email ) ) {
+			$email = '';
+		}
+
+		if ( ! isset( $status_options[ $status ] ) ) {
+			$status = 'pending';
+		}
+
+		$values = array(
+			'event_id' => $event_id,
+			'name'     => $name,
+			'email'    => $email,
+			'diet'     => $diet,
+			'notes'    => $notes,
+			'status'   => $status,
+		);
+
+		foreach ( $values as $key => $value ) {
+			if ( '' === $value || 0 === $value ) {
+				delete_post_meta( $post_id, $meta_keys[ $key ] );
+				continue;
+			}
+
+			update_post_meta( $post_id, $meta_keys[ $key ], $value );
+		}
+
+		$title = rytkoset_theme_build_event_registration_title( $name, $event_id );
+
+		if ( get_the_title( $post_id ) !== $title ) {
+			remove_action( 'save_post_event_registration', 'rytkoset_theme_save_event_registration' );
+			wp_update_post(
+				array(
+					'ID'         => $post_id,
+					'post_title' => $title,
+				)
+			);
+			add_action( 'save_post_event_registration', 'rytkoset_theme_save_event_registration' );
+		}
+	}
+}
+add_action( 'save_post_event_registration', 'rytkoset_theme_save_event_registration' );
+
+if ( ! function_exists( 'rytkoset_theme_event_registration_columns' ) ) {
+	/**
+	 * Defines admin columns for event registrations.
+	 *
+	 * @param array $columns Admin columns.
+	 * @return array
+	 */
+	function rytkoset_theme_event_registration_columns( $columns ) {
+		return array(
+			'cb'                           => isset( $columns['cb'] ) ? $columns['cb'] : '<input type="checkbox" />',
+			'rytkoset_registration_name'   => __( 'Osallistuja', 'rytkoset-theme' ),
+			'rytkoset_registration_event'  => __( 'Tapahtuma', 'rytkoset-theme' ),
+			'rytkoset_registration_email'  => __( 'Sähköposti', 'rytkoset-theme' ),
+			'rytkoset_registration_status' => __( 'Tila', 'rytkoset-theme' ),
+			'date'                         => __( 'Päivämäärä', 'rytkoset-theme' ),
+		);
+	}
+}
+add_filter( 'manage_event_registration_posts_columns', 'rytkoset_theme_event_registration_columns' );
+
+if ( ! function_exists( 'rytkoset_theme_event_registration_column_content' ) ) {
+	/**
+	 * Renders admin column content for event registrations.
+	 *
+	 * @param string $column  Column key.
+	 * @param int    $post_id Registration post ID.
+	 */
+	function rytkoset_theme_event_registration_column_content( $column, $post_id ) {
+		$statuses = rytkoset_theme_get_event_registration_statuses();
+
+		if ( 'rytkoset_registration_name' === $column ) {
+			$name = rytkoset_theme_get_event_registration_meta( $post_id, 'name' );
+			$url  = get_edit_post_link( $post_id );
+
+			if ( '' === $name ) {
+				$name = __( 'Nimetön osallistuja', 'rytkoset-theme' );
+			}
+
+			if ( $url ) {
+				echo '<a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $name ) . '</a>';
+				return;
+			}
+
+			echo esc_html( $name );
+			return;
+		}
+
+		if ( 'rytkoset_registration_event' === $column ) {
+			$event_id = absint( rytkoset_theme_get_event_registration_meta( $post_id, 'event_id' ) );
+
+			if ( ! rytkoset_theme_is_valid_registration_event_id( $event_id ) ) {
+				echo '&mdash;';
+				return;
+			}
+
+			$url = get_edit_post_link( $event_id );
+
+			if ( $url ) {
+				echo '<a href="' . esc_url( $url ) . '">' . esc_html( get_the_title( $event_id ) ) . '</a>';
+				return;
+			}
+
+			echo esc_html( get_the_title( $event_id ) );
+			return;
+		}
+
+		if ( 'rytkoset_registration_email' === $column ) {
+			$email = rytkoset_theme_get_event_registration_meta( $post_id, 'email' );
+
+			if ( '' === $email ) {
+				echo '&mdash;';
+				return;
+			}
+
+			echo '<a href="mailto:' . esc_attr( $email ) . '">' . esc_html( $email ) . '</a>';
+			return;
+		}
+
+		if ( 'rytkoset_registration_status' === $column ) {
+			$status = rytkoset_theme_get_event_registration_meta( $post_id, 'status' );
+
+			echo esc_html( isset( $statuses[ $status ] ) ? $statuses[ $status ] : $statuses['pending'] );
+		}
+	}
+}
+add_action( 'manage_event_registration_posts_custom_column', 'rytkoset_theme_event_registration_column_content', 10, 2 );


### PR DESCRIPTION
## Summary

Toteuttaa tapahtumailmoittautumisille oman ei-julkisen WordPress-rakenteen.

- Lisää uuden `event_registration` CPT:n
- Näyttää ilmoittautumiset WordPress-adminissa `Tapahtumat > Ilmoittautumiset`
- Lisää admin-metaboxin osallistujan perustiedoille
- Tallentaa ilmoittautumisen tapahtumaviittauksen, nimen, sähköpostin, ruokarajoitteet, lisätiedon ja tilan post metaan
- Lisää admin-listaan sarakkeet osallistujalle, tapahtumalle, sähköpostille ja tilalle
- Päivittää `docs/events.md`-dokumentaation

## Scope

Tässä PR:ssä ei toteuteta vielä:

- julkista ilmoittautumislomaketta
- frontend-tallennuspolkua
- sähköpostiviestejä
- CSV-vientiä
- Event Organizer -roolia
- WooCommerce-integraatiomuutoksia

## Testing

Testattu paikallisesti:

- `php -l` uudelle `inc/event-registrations.php`-tiedostolle
- `php -l` muutetulle `functions.php`-tiedostolle
- `git diff --check`
- WordPress smoke test Dockerissa:
  - `event_registration` rekisteröityy ei-julkiseksi
  - väliaikainen ilmoittautuminen tallentaa metatiedot oikein
  - virheellinen tapahtumaviittaus hylätään
  - testidata poistetaan lopuksi

`phpcs` ei ollut käytettävissä paikallisessa kontissa.

Closes #52