### PR TITLE
feat(events): add free event registration form

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -10,10 +10,11 @@ Tapahtumakokonaisuus on tässä vaiheessa kevyt MVP:
 - tapahtuman perustiedot tallennetaan post metaan
 - tapahtuman julkinen sisältö kirjoitetaan WordPress-editorissa
 - ilmaisten tapahtumien ilmoittautumisille on oma ei-julkinen `event_registration`-sisältötyyppi
+- maksuttomien tapahtumien sivulla voidaan näyttää ilmoittautumislomake
 - maksullisen tapahtuman ilmoittautuminen ja maksaminen ohjataan WooCommerce-tuotteelle
 - Tampere 2026 -osallistujien hallinta tehdään WooCommerce-tilausten ja erillisen osallistujalista-adminin kautta
 
-Tapahtuma ei siis vielä ole erillinen täysi ilmoittautumisjärjestelmä. WordPress-tapahtuma kertoo tapahtumasta. Ilmaisten tapahtumien oma ilmoittautumisrakenne on valmiina admin-käyttöä ja myöhempää lomaketallennusta varten, ja WooCommerce hoitaa ostamisen sekä ilmoittautumistiedot silloin, kun tapahtumaan on linkitetty maksutuote.
+Tapahtuma ei siis vielä ole erillinen täysi ilmoittautumisjärjestelmä. WordPress-tapahtuma kertoo tapahtumasta. Ilmaisten tapahtumien oma ilmoittautumisrakenne ja lomakkeen käyttöliittymä ovat valmiina, mutta varsinainen lomakkeen validointi ja tallennus toteutetaan erillisessä vaiheessa. WooCommerce hoitaa ostamisen sekä ilmoittautumistiedot silloin, kun tapahtumaan on linkitetty maksutuote.
 
 ## Tekninen perusrakenne
 
@@ -82,6 +83,7 @@ Yksittäisellä tapahtumasivulla näytetään:
 
 - tapahtuman artikkelikuva ja otsikko
 - editoriin kirjoitettu sisältö
+- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi eikä siihen ole linkitetty maksutuotetta
 - sivupalkin yhteenvetokortti, jos tapahtumalla on perustietoja tai maksutuote
 - jakopainikkeet
 
@@ -138,9 +140,9 @@ Maksulliselle tapahtumalle kannattaa lisäksi täyttää:
 
 ### Yleinen malli
 
-Ilmaisten tapahtumien ilmoittautumiset tallennetaan `event_registration`-sisältötyyppiin. Ylläpitäjä voi luoda ja muokata ilmoittautumisia käsin WordPress-adminissa kohdassa `Tapahtumat > Ilmoittautumiset`.
+Ilmaisten tapahtumien ilmoittautumiset tallennetaan jatkossa `event_registration`-sisältötyyppiin. Ylläpitäjä voi luoda ja muokata ilmoittautumisia käsin WordPress-adminissa kohdassa `Tapahtumat > Ilmoittautumiset`.
 
-Tässä vaiheessa julkista ilmoittautumislomaketta ei vielä ole. Lomake, sen validointi ja varsinainen frontend-tallennus toteutetaan erillisissä tiketeissä #66 ja #67.
+Tässä vaiheessa julkinen ilmoittautumislomake näkyy maksuttomissa tapahtumissa, mutta lomakkeen validointi ja varsinainen frontend-tallennus toteutetaan tiketissä #67.
 
 Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkitetty maksutuote:
 
@@ -197,6 +199,7 @@ Tässä vaiheessa on toteutettu:
 
 - `event`-sisältötyyppi
 - `event_registration`-sisältötyyppi ilmaisten tapahtumien osallistujille
+- maksuttoman tapahtuman julkinen ilmoittautumislomake
 - tapahtuman yksittäinen sivupohja
 - tapahtuma-arkisto, jossa on tulevat, menneet ja päivämäärättömät tapahtumat
 - tapahtumapäivän metakenttä
@@ -214,7 +217,6 @@ Tässä vaiheessa on toteutettu:
 
 Tässä vaiheessa ei toteuteta:
 
-- julkista ilmoittautumislomaketta ilman WooCommercea
 - ilmoittautumislomakkeen validointi- ja tallennuspolkua
 - yleistä osallistujaraporttia kaikille tapahtumille
 - erillistä osallistujien tietokantataulua

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -360,6 +360,71 @@
   width: 100%;
 }
 
+.event-registration {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-medium);
+  background: var(--color-surface-alt);
+  box-shadow: var(--shadow-card);
+}
+
+.event-registration__title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.event-registration__description,
+.event-registration__required-note {
+  margin: 0;
+  color: var(--color-text-mute);
+}
+
+.event-registration__form {
+  display: grid;
+  gap: 1rem;
+}
+
+.event-registration__field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.event-registration__field label {
+  color: var(--color-text);
+  font-weight: 800;
+}
+
+.event-registration__field input,
+.event-registration__field textarea {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 48px;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-s);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+}
+
+.event-registration__field textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.event-registration__field input:focus,
+.event-registration__field textarea:focus {
+  outline: 3px solid rgba(251, 191, 36, 0.35);
+  outline-offset: 2px;
+  border-color: var(--color-accent);
+}
+
+.event-registration__submit {
+  justify-self: start;
+}
+
 @media (min-width: 64rem) {
   .article--event {
     gap: 2.5rem;

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -426,3 +426,110 @@ if ( ! function_exists( 'rytkoset_theme_event_registration_column_content' ) ) {
 	}
 }
 add_action( 'manage_event_registration_posts_custom_column', 'rytkoset_theme_event_registration_column_content', 10, 2 );
+
+if ( ! function_exists( 'rytkoset_theme_event_can_show_free_registration_form' ) ) {
+	/**
+	 * Checks whether an event can show the free registration form.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return bool
+	 */
+	function rytkoset_theme_event_can_show_free_registration_form( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( $event_id <= 0 || 'event' !== get_post_type( $event_id ) ) {
+			return false;
+		}
+
+		if ( ! function_exists( 'rytkoset_theme_get_event_fee_type' ) || 'free' !== rytkoset_theme_get_event_fee_type( $event_id ) ) {
+			return false;
+		}
+
+		if (
+			function_exists( 'rytkoset_theme_get_event_product_meta_key' )
+			&& absint( get_post_meta( $event_id, rytkoset_theme_get_event_product_meta_key(), true ) ) > 0
+		) {
+			return false;
+		}
+
+		if ( function_exists( 'rytkoset_theme_get_event_product_url' ) && '' !== rytkoset_theme_get_event_product_url( $event_id ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) ) {
+	/**
+	 * Renders the free event registration form UI.
+	 *
+	 * The form handler is implemented in a later ticket.
+	 *
+	 * @param int $event_id Event post ID.
+	 */
+	function rytkoset_theme_render_free_event_registration_form( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( ! rytkoset_theme_event_can_show_free_registration_form( $event_id ) ) {
+			return;
+		}
+
+		$form_id        = 'event-registration-form-' . $event_id;
+		$description_id = 'event-registration-description-' . $event_id;
+		?>
+		<section class="event-registration" aria-labelledby="<?php echo esc_attr( $form_id . '-title' ); ?>">
+			<h2 id="<?php echo esc_attr( $form_id . '-title' ); ?>" class="event-registration__title">
+				<?php esc_html_e( 'Ilmoittaudu tapahtumaan', 'rytkoset-theme' ); ?>
+			</h2>
+			<p id="<?php echo esc_attr( $description_id ); ?>" class="event-registration__description">
+				<?php esc_html_e( 'Tällä lomakkeella voit ilmoittautua maksuttomaan tapahtumaan.', 'rytkoset-theme' ); ?>
+			</p>
+
+			<form id="<?php echo esc_attr( $form_id ); ?>" class="event-registration__form" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" aria-describedby="<?php echo esc_attr( $description_id ); ?>">
+				<input type="hidden" name="action" value="rytkoset_submit_event_registration" />
+				<input type="hidden" name="event_id" value="<?php echo esc_attr( (string) $event_id ); ?>" />
+				<?php wp_nonce_field( 'rytkoset_submit_event_registration', 'rytkoset_event_registration_submit_nonce' ); ?>
+
+				<div class="event-registration__field">
+					<label for="<?php echo esc_attr( $form_id . '-name' ); ?>">
+						<?php esc_html_e( 'Osallistujan nimi', 'rytkoset-theme' ); ?>
+						<span aria-hidden="true">*</span>
+					</label>
+					<input id="<?php echo esc_attr( $form_id . '-name' ); ?>" name="registration_name" type="text" autocomplete="name" required />
+				</div>
+
+				<div class="event-registration__field">
+					<label for="<?php echo esc_attr( $form_id . '-email' ); ?>">
+						<?php esc_html_e( 'Sähköposti', 'rytkoset-theme' ); ?>
+						<span aria-hidden="true">*</span>
+					</label>
+					<input id="<?php echo esc_attr( $form_id . '-email' ); ?>" name="registration_email" type="email" autocomplete="email" required />
+				</div>
+
+				<div class="event-registration__field">
+					<label for="<?php echo esc_attr( $form_id . '-diet' ); ?>">
+						<?php esc_html_e( 'Ruokarajoitteet tai allergiat', 'rytkoset-theme' ); ?>
+					</label>
+					<textarea id="<?php echo esc_attr( $form_id . '-diet' ); ?>" name="registration_diet" rows="3"></textarea>
+				</div>
+
+				<div class="event-registration__field">
+					<label for="<?php echo esc_attr( $form_id . '-notes' ); ?>">
+						<?php esc_html_e( 'Lisätieto', 'rytkoset-theme' ); ?>
+					</label>
+					<textarea id="<?php echo esc_attr( $form_id . '-notes' ); ?>" name="registration_notes" rows="4"></textarea>
+				</div>
+
+				<p class="event-registration__required-note">
+					<?php esc_html_e( '* Pakollinen kenttä', 'rytkoset-theme' ); ?>
+				</p>
+
+				<button type="submit" class="btn btn--primary event-registration__submit">
+					<?php esc_html_e( 'Lähetä ilmoittautuminen', 'rytkoset-theme' ); ?>
+				</button>
+			</form>
+		</section>
+		<?php
+	}
+}

--- a/wp-content/themes/rytkoset-theme/single-event.php
+++ b/wp-content/themes/rytkoset-theme/single-event.php
@@ -60,6 +60,12 @@ if ( have_posts() ) :
 							</div>
 
 							<?php
+							if ( function_exists( 'rytkoset_theme_render_free_event_registration_form' ) ) {
+								rytkoset_theme_render_free_event_registration_form( $event_id );
+							}
+							?>
+
+							<?php
 							rytkoset_theme_share_buttons(
 								array(
 									'heading' => __( 'Jaa tapahtuma', 'rytkoset-theme' ),


### PR DESCRIPTION
## Summary

- Lisätty maksuttomille tapahtumille julkinen ilmoittautumislomake tapahtumasivulle.
- Lomake näytetään vain `free`-tapahtumille, joilla ei ole WooCommerce-maksutuotetta.
- Lisätty lomakkeen tekninen kytkentäpinta tulevaa #67-tallennuspolkua varten.
- Päivitetty tapahtumadokumentaatio nykyisestä #66/#67-rajauksesta.

## Changes

- Lisätty helper `rytkoset_theme_event_can_show_free_registration_form()`.
- Lisätty renderöintifunktio `rytkoset_theme_render_free_event_registration_form()`.
- Sijoitettu lomake `single-event.php`:ssä pääsisällön jälkeen ennen jakopainikkeita.
- Lisätty lomakkeen kentät:
  - osallistujan nimi
  - sähköposti
  - ruokarajoitteet tai allergiat
  - lisätieto
  - `action`
  - `event_id`
  - nonce
- Lisätty lomakkeen CSS-tyylit `components.css`:ään.
- Päivitetty `docs/events.md`.

## Out Of Scope

- Ei tallenneta `event_registration`-tietuetta vielä tässä PR:ssä.
- Ei lisätä backend-validointia.
- Ei lisätä onnistuneen lähetyksen kiitosnäkymää.
- Ei lähetetä sähköposteja.
- Ei muuteta WooCommerce-pohjaista maksullisen tapahtuman polkua.

Nämä jatkavat tiketeissä #67 ja #68.

## Verification

- `php -l` OK:
  - `inc/event-registrations.php`
  - `single-event.php`
- `git diff --check` OK.
- Smoke-test:
  - maksuton tapahtuma näyttää lomakkeen
  - maksullinen / maksutuotteeseen linkitetty tapahtuma ei näytä lomaketta
  - lomakkeessa on `action`, `event_id`, nonce ja required-kentät
- Playwright:
  - lomake näkyy sisällön jälkeen ennen jakopainikkeita
  - mobiilileveydellä lomake ei aiheuta vaakasuuntaista overflow’ta

## Notes

- `phpcs` ei ollut käytettävissä kontissa: `exec: "phpcs": executable file not found in $PATH`.
- Lomakkeen POST-action on valmiina muodossa `rytkoset_submit_event_registration`, mutta käsittely toteutetaan #67:ssa.

Closes #66