### PR TITLE
Add event organizer role

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -154,6 +154,26 @@ Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkit
 
 Tapahtuman ja WooCommerce-tuotteen välinen linkitys on dokumentoitu tarkemmin tiedostossa `docs/woocommerce-event-product-link.md`.
 
+### Event Organizer -rooli
+
+Tapahtumien käytännön hallintaa varten sivustolla on rajattu `Event Organizer` -rooli.
+
+Rooli saa:
+
+- luoda, muokata, julkaista ja poistaa tapahtumia
+- hallita kaikkia ilmaisten tapahtumien ilmoittautumisia kohdassa `Tapahtumat > Ilmoittautumiset`
+- muuttaa ilmoittautumisen tilaa, esimerkiksi `pending`, `confirmed` tai `cancelled`
+- lisätä tapahtuman artikkelikuvan mediakirjastosta
+- linkittää tapahtumaan olemassa olevan WooCommerce-maksutuotteen
+
+Rooli ei saa:
+
+- hallita WooCommerce-tuotteita, tilauksia, maksutapoja tai asetuksia
+- avata WooCommerce-hallintanäkymiä
+- muuttaa sivuston yleisiä asetuksia, teeman asetuksia tai käyttäjärooleja
+
+Tämä rooli on tarkoitettu tapahtumien järjestäjille, joille ei haluta antaa täysiä ylläpitäjän oikeuksia. Maksutuotteet luo ja ylläpitää edelleen varsinainen ylläpitäjä.
+
 ### Tampere 2026
 
 Tampere 2026 -tapahtuman ilmoittautuminen on toteutettu WooCommercen päälle erillisinä MVP-osina:
@@ -213,6 +233,7 @@ Tässä vaiheessa on toteutettu:
 - Tampere 2026 -osallistujalista adminissa
 - Tampere 2026 -osallistujien CSV-vienti
 - Tampere 2026 -järjestäjäilmoitukset
+- rajattu `Event Organizer` -rooli tapahtumien ja ilmoittautumisten hallintaan
 
 ## Jätetään myöhempään vaiheeseen
 

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -11,6 +11,7 @@ require_once get_template_directory() . '/inc/social-links.php';
 require_once get_template_directory() . '/inc/share.php';
 require_once get_template_directory() . '/inc/gallery-albums.php';
 require_once get_template_directory() . '/inc/media-library.php';
+require_once get_template_directory() . '/inc/event-roles.php';
 require_once get_template_directory() . '/inc/events.php';
 require_once get_template_directory() . '/inc/event-registrations.php';
 require_once get_template_directory() . '/inc/digital-magazines.php';

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -77,6 +77,9 @@ if ( ! function_exists( 'rytkoset_theme_register_event_registration_cpt' ) ) {
 			'hierarchical'        => false,
 			'menu_icon'           => 'dashicons-id',
 			'supports'            => false,
+			'capability_type'     => function_exists( 'rytkoset_theme_get_event_registration_capability_type' )
+				? rytkoset_theme_get_event_registration_capability_type()
+				: array( 'event_registration', 'event_registrations' ),
 			'map_meta_cap'        => true,
 		);
 

--- a/wp-content/themes/rytkoset-theme/inc/event-roles.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-roles.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Tapahtumien roolit ja oikeudet.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_roles_version' ) ) {
+	/**
+	 * Returns the event role capability schema version.
+	 *
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_roles_version() {
+		return '1';
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_capability_type' ) ) {
+	/**
+	 * Returns the event CPT capability type.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_capability_type() {
+		return array( 'event', 'events' );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_registration_capability_type' ) ) {
+	/**
+	 * Returns the event registration CPT capability type.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_registration_capability_type() {
+		return array( 'event_registration', 'event_registrations' );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_post_type_capabilities' ) ) {
+	/**
+	 * Returns primitive capabilities for an event-related CPT.
+	 *
+	 * @param string $plural Plural capability base.
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_post_type_capabilities( $plural ) {
+		return array(
+			'edit_' . $plural,
+			'edit_others_' . $plural,
+			'publish_' . $plural,
+			'read_private_' . $plural,
+			'delete_' . $plural,
+			'delete_private_' . $plural,
+			'delete_published_' . $plural,
+			'delete_others_' . $plural,
+			'edit_private_' . $plural,
+			'edit_published_' . $plural,
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_organizer_capabilities' ) ) {
+	/**
+	 * Returns capabilities granted to Event Organizers.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_organizer_capabilities() {
+		return array_unique(
+			array_merge(
+				array(
+					'read',
+					'upload_files',
+				),
+				rytkoset_theme_get_event_post_type_capabilities( 'events' ),
+				rytkoset_theme_get_event_post_type_capabilities( 'event_registrations' )
+			)
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_organizer_forbidden_capabilities' ) ) {
+	/**
+	 * Returns capabilities that Event Organizers must not receive.
+	 *
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_organizer_forbidden_capabilities() {
+		return array(
+			'manage_options',
+			'manage_woocommerce',
+			'edit_products',
+			'publish_products',
+			'delete_products',
+			'edit_shop_orders',
+			'edit_others_shop_orders',
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_role_has_capabilities' ) ) {
+	/**
+	 * Checks whether a role has every expected capability.
+	 *
+	 * @param WP_Role|null $role         Role object.
+	 * @param array        $capabilities Capability names.
+	 * @return bool
+	 */
+	function rytkoset_theme_role_has_capabilities( $role, $capabilities ) {
+		if ( ! $role instanceof WP_Role ) {
+			return false;
+		}
+
+		foreach ( $capabilities as $capability ) {
+			if ( ! $role->has_cap( $capability ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_role_lacks_capabilities' ) ) {
+	/**
+	 * Checks whether a role lacks every listed capability.
+	 *
+	 * @param WP_Role|null $role         Role object.
+	 * @param array        $capabilities Capability names.
+	 * @return bool
+	 */
+	function rytkoset_theme_role_lacks_capabilities( $role, $capabilities ) {
+		if ( ! $role instanceof WP_Role ) {
+			return false;
+		}
+
+		foreach ( $capabilities as $capability ) {
+			if ( $role->has_cap( $capability ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_sync_event_roles' ) ) {
+	/**
+	 * Creates and updates event-specific roles and capabilities.
+	 */
+	function rytkoset_theme_sync_event_roles() {
+		$version                = rytkoset_theme_get_event_roles_version();
+		$organizer_capabilities = rytkoset_theme_get_event_organizer_capabilities();
+		$forbidden_capabilities = rytkoset_theme_get_event_organizer_forbidden_capabilities();
+		$event_organizer        = get_role( 'event_organizer' );
+		$administrator          = get_role( 'administrator' );
+
+		if (
+			get_option( 'rytkoset_event_roles_version' ) === $version
+			&& rytkoset_theme_role_has_capabilities( $event_organizer, $organizer_capabilities )
+			&& rytkoset_theme_role_lacks_capabilities( $event_organizer, $forbidden_capabilities )
+			&& rytkoset_theme_role_has_capabilities( $administrator, $organizer_capabilities )
+		) {
+			return;
+		}
+
+		if ( ! $event_organizer ) {
+			add_role(
+				'event_organizer',
+				__( 'Event Organizer', 'rytkoset-theme' ),
+				array()
+			);
+
+			$event_organizer = get_role( 'event_organizer' );
+		}
+
+		if ( $event_organizer ) {
+			foreach ( $organizer_capabilities as $capability ) {
+				$event_organizer->add_cap( $capability );
+			}
+
+			foreach ( $forbidden_capabilities as $capability ) {
+				$event_organizer->remove_cap( $capability );
+			}
+		}
+
+		if ( $administrator ) {
+			foreach ( $organizer_capabilities as $capability ) {
+				$administrator->add_cap( $capability );
+			}
+		}
+
+		update_option( 'rytkoset_event_roles_version', $version );
+	}
+}
+add_action( 'init', 'rytkoset_theme_sync_event_roles', 20 );
+
+if ( ! function_exists( 'rytkoset_theme_allow_event_organizer_admin_access' ) ) {
+	/**
+	 * Allows Event Organizers into wp-admin without granting generic post or WooCommerce caps.
+	 *
+	 * WooCommerce redirects users without edit_posts, manage_woocommerce, or
+	 * view_admin_dashboard away from wp-admin. Event Organizers intentionally use
+	 * custom CPT capabilities instead of edit_posts.
+	 *
+	 * @param bool $prevent_access Whether WooCommerce should block admin access.
+	 * @return bool
+	 */
+	function rytkoset_theme_allow_event_organizer_admin_access( $prevent_access ) {
+		if (
+			current_user_can( 'edit_events' )
+			|| current_user_can( 'edit_event_registrations' )
+		) {
+			return false;
+		}
+
+		return $prevent_access;
+	}
+}
+add_filter( 'woocommerce_prevent_admin_access', 'rytkoset_theme_allow_event_organizer_admin_access' );

--- a/wp-content/themes/rytkoset-theme/inc/events.php
+++ b/wp-content/themes/rytkoset-theme/inc/events.php
@@ -29,13 +29,17 @@ if ( ! function_exists( 'rytkoset_theme_register_event_cpt' ) ) {
 		);
 
 		$args = array(
-			'labels'        => $labels,
-			'public'        => true,
-			'has_archive'   => true,
-			'menu_icon'     => 'dashicons-calendar-alt',
-			'show_in_rest'  => true,
-			'supports'      => array( 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ),
-			'rewrite'       => array(
+			'labels'          => $labels,
+			'public'          => true,
+			'has_archive'     => true,
+			'menu_icon'       => 'dashicons-calendar-alt',
+			'show_in_rest'    => true,
+			'supports'        => array( 'title', 'editor', 'excerpt', 'thumbnail', 'custom-fields' ),
+			'capability_type' => function_exists( 'rytkoset_theme_get_event_capability_type' )
+				? rytkoset_theme_get_event_capability_type()
+				: array( 'event', 'events' ),
+			'map_meta_cap'    => true,
+			'rewrite'         => array(
 				'slug'       => 'tapahtumat',
 				'with_front' => false,
 			),


### PR DESCRIPTION
## Summary
- Lisätään rajattu Event Organizer -rooli tapahtumien ja ilmaisten tapahtumien ilmoittautumisten hallintaan.
- Vaihdetaan event- ja event_registration-CPT:t käyttämään omia custom capabilityjä.
- Synkataan uudet capabilityt myös administrator-roolille deployn jälkeen versionoidulla role syncillä.
- Sallitaan Event Organizerin WP-admin-pääsy ilman yleisiä blogi- tai WooCommerce-hallintaoikeuksia.
- Päivitetään tapahtumadokumentaatio roolin oikeuksista ja rajauksista.

## Testing
- `php -l wp-content/themes/rytkoset-theme/inc/event-roles.php`
- `php -l wp-content/themes/rytkoset-theme/inc/events.php`
- `php -l wp-content/themes/rytkoset-theme/inc/event-registrations.php`
- `php -l wp-content/themes/rytkoset-theme/functions.php`
- `git diff --check`
- PHP smoke test kontissa: role sync, required caps, forbidden caps, administrator caps, CPT capability mapping
- Browser smoke test: Event Organizer näkee Tapahtumat ja Ilmoittautumiset, ei WooCommerce-valikkoa, WooCommerce-asetussivu estetään

## Notes
- `phpcs` ei ole kontissa asennettuna, joten sitä ei voitu ajaa.
- `git diff --check` antoi vain olemassa olevaan line ending -asetukseen liittyviä CRLF-varoituksia.

Closes #71