### PR TITLE
feat(events): add unified event participants admin page (#72)

### DIFF
--- a/docs/event-participants-admin.md
+++ b/docs/event-participants-admin.md
@@ -1,0 +1,112 @@
+# Tapahtumakohtainen osallistujalista adminissa
+
+Tämä dokumentti kuvaa tiketin `#72` toteutuksen.
+
+## Tavoite
+
+Ylläpitäjä ja tapahtumajärjestäjä näkevät kaikki tapahtuman osallistujat yhdestä admin-näkymästä riippumatta siitä, onko kyseessä ilmainen tapahtuma (lomakepohjainen ilmoittautuminen) vai maksullinen tapahtuma (WooCommerce-tilaus).
+
+## Sijainti
+
+`Tapahtumat > Osallistujat`
+
+## Mitä näkymä näyttää
+
+### Tapahtumavalitsin
+
+Sivun yläosassa on dropdown-valitsin, josta voi valita yksittäisen tapahtuman tai nähdä kaikkien tapahtumien osallistujat kerralla. Tapahtumat on järjestetty tapahtumapäivän mukaan lähimmästä tulevasta vanhimpaan menneeseen, ja päivämäärättömät tapahtumat ovat listan lopussa.
+
+Oletuksena valittu: `Kaikki tapahtumat`.
+
+### Statussuodatin
+
+Näkymässä voi suodattaa osallistujia statuksen perusteella:
+
+- Kaikki tilat
+- Odottaa vahvistusta (`pending`)
+- Vahvistettu (`confirmed`)
+- Peruutettu (`cancelled`)
+- Maksettu (WooCommerce-tilaus)
+
+### Yhteenveto
+
+Suodattimien yläpuolella näkyy osallistujamäärä eriteltynä lähteen mukaan: kuinka moni on ilmoittautunut lomakkeella ja kuinka moni WooCommercen kautta.
+
+### Taulukko
+
+Jokaiselta osallistujalta näkyy:
+
+| Sarake | Selite |
+| --- | --- |
+| Nimi | Osallistujan nimi |
+| Sähköposti | Osallistujan sähköposti (ilmaisessa) tai yhteyshenkilön sähköposti (maksullisessa) |
+| Puhelin | Puhelinnumero |
+| Ruokavalio | Ruokarajoitteet tai allergiat |
+| Status | Osallistumisen tila |
+| Lähde | `Maksuton` tai `Maksullinen` |
+| Tapahtuma | Tapahtuman nimi linkkinä (vain "Kaikki tapahtumat" -näkymässä) |
+| Pvm | Ilmoittautumisen tai tilauksen luontipäivä |
+| Muokkaa | Linkki osallistumisen muokkaamiseen (`event_registration`-postille tai WooCommerce-tilaukselle) |
+
+Jos tapahtumalla ei ole yhtään osallistujaa valituilla suodattimilla, taulukko näyttää "Ei osallistujia tällä suodatuksella".
+
+## Lähteet ja normalisointi
+
+Näkymä yhdistää kaksi eri lähdettä yhtenäiseen rivi­rakenteeseen:
+
+### Maksuttomat ilmoittautumiset
+
+Lähde: `event_registration` -sisältötyyppi. Meta-avain `_rytkoset_registration_event_id` kytkee ilmoittautumisen tapahtumaan. Status tulee meta-avaimesta `_rytkoset_registration_status`.
+
+### Maksulliset ilmoittautumiset
+
+Lähde: WooCommerce-tilaukset, joissa on tapahtuman meta-avaimeen `_rytkoset_event_product_id` tallennettu tuote. Status seuraa tilauksen WooCommerce-statusta.
+
+- **Tampere 2026**: käytetään olemassa olevaa moniosallistujarakennetta — tilauksen checkout-kentistä puretaan jokainen osallistuja erikseen omaksi riviksi.
+- **Muut maksulliset tapahtumat**: yksi rivi per tilaus, tiedot tilauksen laskutustiedoista.
+
+### Yhtenäinen rivirakenne
+
+```
+name          – osallistujan nimi
+email         – sähköposti
+phone         – puhelinnumero
+diet          – ruokarajoitteet
+notes         – lisätiedot
+status        – pending / confirmed / cancelled / processing / completed / ...
+status_label  – luettava tilaselite
+source        – "free" tai "paid"
+created       – Unix-aikaleima
+contact_name  – tilaajan nimi (maksullisessa)
+contact_email – tilaajan sähköposti (maksullisessa)
+edit_url      – suoralinkki adminiin
+order_id      – WooCommerce-tilauksen ID (maksullisessa)
+order_number  – WooCommerce-tilausnumero (maksullisessa)
+event_id      – tapahtuman post ID
+event_title   – tapahtuman otsikko
+```
+
+Tämä rakenne on suunniteltu CSV-vientiä (`#12`) varten.
+
+## Oikeudet
+
+Sivu on näkyvissä käyttäjillä, joilla on `edit_others_event_registrations`-oikeus. Tämä kuuluu sekä `administrator`- että `event_organizer`-roolille.
+
+## Tekninen toteutus
+
+Toteutus on tiedostossa `wp-content/themes/rytkoset-theme/inc/event-participants-admin.php`.
+
+Pääfunktiot:
+
+- `rytkoset_theme_get_event_free_participants($event_id, $status_filter)` — hakee ilmaiset osallistujat ja normalisoi rivit
+- `rytkoset_theme_get_event_paid_participants($event_id)` — hakee maksulliset osallistujat WooCommercesta
+- `rytkoset_theme_get_event_participants($event_id, $status_filter)` — yhdistää molemmat lähteet
+- `rytkoset_theme_get_all_events_participants($status_filter)` — kerää osallistujat kaikista tapahtumista
+- `rytkoset_theme_register_event_participants_admin_page()` — rekisteröi adminisivun
+- `rytkoset_theme_render_event_participants_admin_page()` — renderöi sivun
+
+## Rajaus tässä vaiheessa
+
+- Ei CSV-vientiä (tulossa tiketissä `#12`)
+- Ei massatoimintoja osallistujille
+- Ei ilmoittautumisten tilamuutosta suoraan listanäkymästä (tehdään `event_registration`-postilomakkeella)

--- a/docs/events.md
+++ b/docs/events.md
@@ -12,7 +12,8 @@ Tapahtumakokonaisuus on tässä vaiheessa kevyt MVP:
 - ilmaisten tapahtumien ilmoittautumisille on oma ei-julkinen `event_registration`-sisältötyyppi
 - maksuttomien tapahtumien sivulla voidaan näyttää ilmoittautumislomake, jonka tiedot tallentuvat ilmoittautumisiksi
 - maksullisen tapahtuman ilmoittautuminen ja maksaminen ohjataan WooCommerce-tuotteelle
-- Tampere 2026 -osallistujien hallinta tehdään WooCommerce-tilausten ja erillisen osallistujalista-adminin kautta
+- osallistujat näkee tapahtumakohtaisesti `Tapahtumat > Osallistujat` -näkymästä, joka yhdistää ilmaiset ja maksulliset ilmoittautumiset
+- Tampere 2026 -osallistujien hallintaan on lisäksi oma WooCommerce-pikalinkkinäkymä
 
 Tapahtuma ei siis vielä ole erillinen täysi ilmoittautumisjärjestelmä. WordPress-tapahtuma kertoo tapahtumasta. Ilmaisten tapahtumien oma ilmoittautumisrakenne, lomakkeen käyttöliittymä sekä perustason validointi ja tallennus ovat valmiina. WooCommerce hoitaa ostamisen sekä ilmoittautumistiedot silloin, kun tapahtumaan on linkitetty maksutuote.
 
@@ -191,13 +192,30 @@ Ylläpidon kannalta tärkein näkymä on:
 
 Siellä osallistujat näkyvät riveinä. Näkymä käyttää WooCommerce-tilauksille tallennettuja osallistujatietoja eikä luo erillistä tapahtumarekisteritaulua.
 
+### Yleinen osallistujanäkymä
+
+Kaikkien tapahtumien osallistujat näkee yhdistettynä näkymässä:
+
+- `Tapahtumat > Osallistujat`
+
+Näkymässä voi valita yksittäisen tapahtuman tai katsella kaikkien tapahtumien osallistujia kerralla. Näkymä yhdistää ilmaisten tapahtumien lomakeilmoittautumiset ja maksullisten tapahtumien WooCommerce-tilaukset. Suodatus tilauksen statuksen mukaan on tuettu.
+
+Tarkempi kuvaus on tiedostossa `docs/event-participants-admin.md`.
+
+### Tampere 2026 -osallistujanäkymä
+
+Tampere 2026 -tapahtumalle on lisäksi erillinen pikalinkkisivu:
+
+- `WooCommerce > Tampere 2026 osallistujat`
+
+Tämä sivu näyttää vain Tampere 2026 -tilausten osallistujat ja toimii edelleen sellaisenaan. Uusi yleinen näkymä palvelee tulevia tapahtumia.
+
 ### Mitä ylläpitäjä tekee ilmoittautumisille
 
-1. Avaa `WooCommerce > Tampere 2026 osallistujat`.
-2. Tarkista osallistujat, yhteyshenkilöt ja tilauksen tila.
-3. Avaa tarvittaessa tilaus linkistä, jos maksun tai asiakkaan tietoja pitää tarkistaa.
-4. Suodata osallistujia tilauksen statuksen mukaan, jos haluat erottaa aktiiviset ja perutut ilmoittautumiset.
-5. Vie osallistujat CSV-tiedostoon, jos osallistujalista tarvitaan taulukkolaskentaan.
+1. Avaa `Tapahtumat > Osallistujat`.
+2. Valitse tapahtuma dropdownista tai katso kaikki tapahtumat kerralla.
+3. Suodata tarvittaessa statuksen mukaan.
+4. Avaa osallistuja muokkauslinkistä, jos tietoja pitää tarkistaa tai statusta pitää muuttaa.
 
 Jos tilaus perutaan tai hyvitetään, tarkista WooCommerce-tuotteen varastosaldo. Kapasiteetti perustuu WooCommercen varastoon, ei tapahtuman omaan laskuriin.
 
@@ -234,12 +252,12 @@ Tässä vaiheessa on toteutettu:
 - Tampere 2026 -osallistujien CSV-vienti
 - Tampere 2026 -järjestäjäilmoitukset
 - rajattu `Event Organizer` -rooli tapahtumien ja ilmoittautumisten hallintaan
+- yhdistetty `Tapahtumat > Osallistujat` -näkymä ilmaisten ja maksullisten tapahtumien osallistujille
 
 ## Jätetään myöhempään vaiheeseen
 
 Tässä vaiheessa ei toteuteta:
 
-- yleistä osallistujaraporttia kaikille tapahtumille
 - erillistä osallistujien tietokantataulua
 - osallistujien massatoimintoja tapahtumanäkymästä
 - usean maksutuotteen linkitystä samaan tapahtumaan

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -14,6 +14,7 @@ require_once get_template_directory() . '/inc/media-library.php';
 require_once get_template_directory() . '/inc/event-roles.php';
 require_once get_template_directory() . '/inc/events.php';
 require_once get_template_directory() . '/inc/event-registrations.php';
+require_once get_template_directory() . '/inc/event-participants-admin.php';
 require_once get_template_directory() . '/inc/digital-magazines.php';
 
 if ( ! function_exists( 'rytkoset_theme_get_attachment_display_caption_text' ) ) {

--- a/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
@@ -1,0 +1,576 @@
+<?php
+/**
+ * Yhdistetty osallistujalistan hallinta adminille.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_free_participants' ) ) {
+	/**
+	 * Returns normalized rows for free event registrations.
+	 *
+	 * @param int    $event_id      Event post ID.
+	 * @param string $status_filter Optional registration status filter.
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_free_participants( $event_id, $status_filter = '' ) {
+		$event_id = absint( $event_id );
+
+		if ( $event_id <= 0 ) {
+			return array();
+		}
+
+		$meta_keys = rytkoset_theme_get_event_registration_meta_keys();
+		$statuses  = rytkoset_theme_get_event_registration_statuses();
+
+		$query_args = array(
+			'post_type'      => 'event_registration',
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'     => array(
+				array(
+					'key'   => $meta_keys['event_id'],
+					'value' => $event_id,
+				),
+			),
+		);
+
+		$registrations = get_posts( $query_args );
+		$rows          = array();
+
+		foreach ( $registrations as $registration ) {
+			$status = rytkoset_theme_get_event_registration_meta( $registration->ID, 'status' );
+
+			if ( '' === $status ) {
+				$status = 'pending';
+			}
+
+			if ( '' !== $status_filter && $status_filter !== $status ) {
+				continue;
+			}
+
+			$name = rytkoset_theme_get_event_registration_meta( $registration->ID, 'name' );
+
+			$rows[] = array(
+				'name'          => '' !== $name ? $name : __( 'Nimetön osallistuja', 'rytkoset-theme' ),
+				'email'         => rytkoset_theme_get_event_registration_meta( $registration->ID, 'email' ),
+				'phone'         => '',
+				'diet'          => rytkoset_theme_get_event_registration_meta( $registration->ID, 'diet' ),
+				'notes'         => rytkoset_theme_get_event_registration_meta( $registration->ID, 'notes' ),
+				'status'        => $status,
+				'status_label'  => isset( $statuses[ $status ] ) ? $statuses[ $status ] : $statuses['pending'],
+				'source'        => 'free',
+				'created'       => get_the_date( '', $registration ),
+				'contact_name'  => '' !== $name ? $name : '',
+				'contact_email' => rytkoset_theme_get_event_registration_meta( $registration->ID, 'email' ),
+				'edit_url'      => (string) get_edit_post_link( $registration->ID, '' ),
+				'order_id'      => null,
+				'order_number'  => null,
+				'event_id'      => $event_id,
+				'event_title'   => get_the_title( $event_id ),
+			);
+		}
+
+		return $rows;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_paid_participants' ) ) {
+	/**
+	 * Returns normalized rows for paid event participants.
+	 *
+	 * Looks up orders that contain the WooCommerce product linked to the event.
+	 * For Tampere 2026 events the per-order multi-participant schema is honored;
+	 * for other paid events the order's billing contact is used as a single
+	 * participant per ordered quantity.
+	 *
+	 * @param int $event_id Event post ID.
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_paid_participants( $event_id ) {
+		$event_id = absint( $event_id );
+
+		if ( $event_id <= 0 || ! function_exists( 'wc_get_orders' ) ) {
+			return array();
+		}
+
+		$product_id = (int) get_post_meta( $event_id, '_rytkoset_event_product_id', true );
+
+		if ( $product_id <= 0 ) {
+			return array();
+		}
+
+		$is_tampere_2026 = function_exists( 'rytkoset_theme_is_tampere_2026_registration_product' )
+			&& rytkoset_theme_is_tampere_2026_registration_product( wc_get_product( $product_id ) );
+
+		$statuses = function_exists( 'rytkoset_theme_get_supported_order_statuses' )
+			? rytkoset_theme_get_supported_order_statuses()
+			: array_keys( wc_get_order_statuses() );
+
+		$orders = wc_get_orders(
+			array(
+				'limit'   => -1,
+				'orderby' => 'date',
+				'order'   => 'DESC',
+				'return'  => 'objects',
+				'status'  => $statuses,
+			)
+		);
+
+		$rows = array();
+
+		foreach ( $orders as $order ) {
+			if ( ! $order instanceof WC_Order ) {
+				continue;
+			}
+
+			$order_has_product = false;
+			$quantity          = 0;
+
+			foreach ( $order->get_items() as $item ) {
+				$item_product = $item->get_product();
+
+				if ( ! $item_product instanceof WC_Product ) {
+					continue;
+				}
+
+				if ( (int) $item_product->get_id() === $product_id ) {
+					$order_has_product = true;
+					$quantity         += (int) $item->get_quantity();
+				}
+			}
+
+			if ( ! $order_has_product ) {
+				continue;
+			}
+
+			$contact_name = trim( $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() );
+
+			if ( '' === $contact_name ) {
+				$contact_name = __( 'Nimi puuttuu', 'rytkoset-theme' );
+			}
+
+			$contact_email = (string) $order->get_billing_email();
+			$contact_phone = (string) $order->get_billing_phone();
+			$order_status  = $order->get_status();
+			$status_label  = wc_get_order_status_name( $order_status );
+			$created       = wp_date( get_option( 'date_format' ), $order->get_date_created() ? $order->get_date_created()->getTimestamp() : null );
+			$edit_url      = (string) admin_url( 'admin.php?page=wc-orders&action=edit&id=' . $order->get_id() );
+
+			if ( $is_tampere_2026 ) {
+				$participants = rytkoset_theme_get_tampere_2026_order_participants( $order );
+
+				if ( empty( $participants ) ) {
+					continue;
+				}
+
+				foreach ( $participants as $participant ) {
+					$participant_name = isset( $participant['name'] ) && '' !== $participant['name']
+						? $participant['name']
+						: __( 'Nimi puuttuu', 'rytkoset-theme' );
+
+					$rows[] = array(
+						'name'          => $participant_name,
+						'email'         => '',
+						'phone'         => '',
+						'diet'          => isset( $participant['diet'] ) ? (string) $participant['diet'] : '',
+						'notes'         => '',
+						'status'        => 'paid',
+						'status_label'  => $status_label,
+						'source'        => 'paid',
+						'created'       => $created,
+						'contact_name'  => $contact_name,
+						'contact_email' => $contact_email,
+						'edit_url'      => $edit_url,
+						'order_id'      => $order->get_id(),
+						'order_number'  => $order->get_order_number(),
+						'event_id'      => $event_id,
+						'event_title'   => get_the_title( $event_id ),
+					);
+				}
+
+				continue;
+			}
+
+			$units = max( 1, $quantity );
+
+			for ( $i = 0; $i < $units; $i++ ) {
+				$rows[] = array(
+					'name'          => $contact_name,
+					'email'         => $contact_email,
+					'phone'         => $contact_phone,
+					'diet'          => '',
+					'notes'         => (string) $order->get_customer_note(),
+					'status'        => 'paid',
+					'status_label'  => $status_label,
+					'source'        => 'paid',
+					'created'       => $created,
+					'contact_name'  => $contact_name,
+					'contact_email' => $contact_email,
+					'edit_url'      => $edit_url,
+					'order_id'      => $order->get_id(),
+					'order_number'  => $order->get_order_number(),
+					'event_id'      => $event_id,
+					'event_title'   => get_the_title( $event_id ),
+				);
+			}
+		}
+
+		return $rows;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_participants' ) ) {
+	/**
+	 * Returns unified participant rows for an event.
+	 *
+	 * @param int    $event_id      Event post ID.
+	 * @param string $status_filter Optional status filter.
+	 *                              Accepts a free registration status, 'paid' or '' for all.
+	 * @return array
+	 */
+	function rytkoset_theme_get_event_participants( $event_id, $status_filter = '' ) {
+		$event_id = absint( $event_id );
+
+		if ( $event_id <= 0 ) {
+			return array();
+		}
+
+		$rows = array();
+
+		if ( 'paid' !== $status_filter ) {
+			$free_filter = '' === $status_filter ? '' : $status_filter;
+			$rows        = array_merge( $rows, rytkoset_theme_get_event_free_participants( $event_id, $free_filter ) );
+		}
+
+		$statuses = rytkoset_theme_get_event_registration_statuses();
+
+		if ( '' === $status_filter || 'paid' === $status_filter ) {
+			$rows = array_merge( $rows, rytkoset_theme_get_event_paid_participants( $event_id ) );
+		}
+
+		if ( '' !== $status_filter && isset( $statuses[ $status_filter ] ) ) {
+			$rows = array_values(
+				array_filter(
+					$rows,
+					static function ( $row ) use ( $status_filter ) {
+						return isset( $row['status'] ) && $status_filter === $row['status'];
+					}
+				)
+			);
+		}
+
+		return $rows;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_all_events_participants' ) ) {
+	/**
+	 * Returns aggregated participant rows across all events.
+	 *
+	 * @param string $status_filter Optional status filter.
+	 * @return array
+	 */
+	function rytkoset_theme_get_all_events_participants( $status_filter = '' ) {
+		$events = get_posts(
+			array(
+				'post_type'      => 'event',
+				'post_status'    => array( 'publish', 'future', 'draft', 'private' ),
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+
+		$rows = array();
+
+		if ( ! is_array( $events ) ) {
+			return $rows;
+		}
+
+		foreach ( $events as $event_id ) {
+			$rows = array_merge( $rows, rytkoset_theme_get_event_participants( (int) $event_id, $status_filter ) );
+		}
+
+		return $rows;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_register_event_participants_admin_page' ) ) {
+	/**
+	 * Registers the unified event participants submenu under the Events CPT.
+	 */
+	function rytkoset_theme_register_event_participants_admin_page() {
+		add_submenu_page(
+			'edit.php?post_type=event',
+			__( 'Osallistujat', 'rytkoset-theme' ),
+			__( 'Osallistujat', 'rytkoset-theme' ),
+			'edit_others_event_registrations',
+			'rytkoset-event-participants',
+			'rytkoset_theme_render_event_participants_admin_page'
+		);
+	}
+}
+add_action( 'admin_menu', 'rytkoset_theme_register_event_participants_admin_page' );
+
+if ( ! function_exists( 'rytkoset_theme_get_event_participants_admin_events' ) ) {
+	/**
+	 * Returns published events for the admin event picker, sorted by event date DESC.
+	 *
+	 * @return WP_Post[]
+	 */
+	function rytkoset_theme_get_event_participants_admin_events() {
+		$events = get_posts(
+			array(
+				'post_type'      => 'event',
+				'post_status'    => array( 'publish', 'future', 'draft', 'private' ),
+				'posts_per_page' => -1,
+				'orderby'        => 'meta_value',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'       => '_rytkoset_event_date',
+				'order'          => 'DESC',
+			)
+		);
+
+		return is_array( $events ) ? $events : array();
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_participants_admin_status_options' ) ) {
+	/**
+	 * Returns status filter options for the participants admin page.
+	 *
+	 * @return array<string,string>
+	 */
+	function rytkoset_theme_get_event_participants_admin_status_options() {
+		$options = array(
+			'' => __( 'Kaikki', 'rytkoset-theme' ),
+		);
+
+		foreach ( rytkoset_theme_get_event_registration_statuses() as $key => $label ) {
+			$options[ $key ] = sprintf(
+				/* translators: %s: free registration status label */
+				__( 'Maksuton: %s', 'rytkoset-theme' ),
+				$label
+			);
+		}
+
+		$options['paid'] = __( 'Maksulliset', 'rytkoset-theme' );
+
+		return $options;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_render_event_participants_admin_page' ) ) {
+	/**
+	 * Renders the unified event participants admin page.
+	 */
+	function rytkoset_theme_render_event_participants_admin_page() {
+		if ( ! current_user_can( 'edit_others_event_registrations' ) ) {
+			wp_die( esc_html__( 'Sinulla ei ole oikeutta tarkastella tätä sivua.', 'rytkoset-theme' ) );
+		}
+
+		$selected_event  = isset( $_GET['event_id'] ) ? absint( wp_unslash( $_GET['event_id'] ) ) : 0;
+		$selected_status = isset( $_GET['status'] ) ? sanitize_key( wp_unslash( $_GET['status'] ) ) : '';
+
+		$status_options = rytkoset_theme_get_event_participants_admin_status_options();
+
+		if ( ! isset( $status_options[ $selected_status ] ) ) {
+			$selected_status = '';
+		}
+
+		$events = rytkoset_theme_get_event_participants_admin_events();
+
+		if ( $selected_event > 0 && 'event' !== get_post_type( $selected_event ) ) {
+			$selected_event = 0;
+		}
+
+		$rows = $selected_event > 0
+			? rytkoset_theme_get_event_participants( $selected_event, $selected_status )
+			: rytkoset_theme_get_all_events_participants( $selected_status );
+
+		$total_count = count( $rows );
+		$free_count  = 0;
+		$paid_count  = 0;
+
+		foreach ( $rows as $row ) {
+			if ( isset( $row['source'] ) && 'paid' === $row['source'] ) {
+				$paid_count++;
+			} else {
+				$free_count++;
+			}
+		}
+
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Tapahtumien osallistujat', 'rytkoset-theme' ); ?></h1>
+			<p><?php esc_html_e( 'Valitse tapahtuma nähdäksesi sekä maksuttomat että maksulliset ilmoittautumiset yhtenäisenä listana.', 'rytkoset-theme' ); ?></p>
+
+			<form method="get">
+				<input type="hidden" name="post_type" value="event" />
+				<input type="hidden" name="page" value="rytkoset-event-participants" />
+
+				<div class="tablenav top">
+					<div class="alignleft actions" style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+						<label for="rytkoset-event-participants-event">
+							<?php esc_html_e( 'Tapahtuma:', 'rytkoset-theme' ); ?>
+						</label>
+						<select name="event_id" id="rytkoset-event-participants-event">
+							<option value="0"><?php esc_html_e( 'Kaikki tapahtumat', 'rytkoset-theme' ); ?></option>
+							<?php foreach ( $events as $event ) : ?>
+								<?php
+								$event_date    = function_exists( 'rytkoset_theme_get_event_date_display' )
+									? rytkoset_theme_get_event_date_display( $event->ID )
+									: '';
+								$option_label  = $event->post_title;
+
+								if ( '' !== $event_date ) {
+									$option_label .= ' (' . $event_date . ')';
+								}
+								?>
+								<option value="<?php echo esc_attr( $event->ID ); ?>" <?php selected( $selected_event, $event->ID ); ?>>
+									<?php echo esc_html( $option_label ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+
+						<label for="rytkoset-event-participants-status">
+							<?php esc_html_e( 'Status:', 'rytkoset-theme' ); ?>
+						</label>
+						<select name="status" id="rytkoset-event-participants-status">
+							<?php foreach ( $status_options as $value => $label ) : ?>
+								<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $selected_status, $value ); ?>>
+									<?php echo esc_html( $label ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+
+						<?php submit_button( __( 'Suodata', 'rytkoset-theme' ), 'secondary', '', false ); ?>
+
+						<p class="description">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: 1: total, 2: free count, 3: paid count */
+									__( 'Yhteensä %1$d osallistujaa (maksuttomat %2$d, maksulliset %3$d).', 'rytkoset-theme' ),
+									$total_count,
+									$free_count,
+									$paid_count
+								)
+							);
+							?>
+						</p>
+					</div>
+					<br class="clear" />
+				</div>
+			</form>
+
+			<?php $show_event_column = 0 === $selected_event; ?>
+			<table class="widefat striped">
+				<thead>
+					<tr>
+						<th scope="col"><?php esc_html_e( 'Nimi', 'rytkoset-theme' ); ?></th>
+						<?php if ( $show_event_column ) : ?>
+							<th scope="col"><?php esc_html_e( 'Tapahtuma', 'rytkoset-theme' ); ?></th>
+						<?php endif; ?>
+						<th scope="col"><?php esc_html_e( 'Sähköposti', 'rytkoset-theme' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Puhelin', 'rytkoset-theme' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Ruokavalio / huomiot', 'rytkoset-theme' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Lähde', 'rytkoset-theme' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Status', 'rytkoset-theme' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Ilmoittautunut', 'rytkoset-theme' ); ?></th>
+						<th scope="col"><?php esc_html_e( 'Toiminnot', 'rytkoset-theme' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php if ( empty( $rows ) ) : ?>
+						<tr>
+							<td colspan="<?php echo $show_event_column ? 9 : 8; ?>"><?php esc_html_e( 'Ei osallistujia valitulla suodatuksella.', 'rytkoset-theme' ); ?></td>
+						</tr>
+					<?php else : ?>
+						<?php foreach ( $rows as $row ) : ?>
+							<tr>
+								<td><?php echo esc_html( (string) $row['name'] ); ?></td>
+								<?php if ( $show_event_column ) : ?>
+									<td>
+										<?php
+										$event_id_for_row = isset( $row['event_id'] ) ? (int) $row['event_id'] : 0;
+
+										if ( $event_id_for_row > 0 ) {
+											$event_link = add_query_arg(
+												array(
+													'post_type' => 'event',
+													'page'      => 'rytkoset-event-participants',
+													'event_id'  => $event_id_for_row,
+													'status'    => $selected_status,
+												),
+												admin_url( 'edit.php' )
+											);
+											echo '<a href="' . esc_url( $event_link ) . '">' . esc_html( (string) $row['event_title'] ) . '</a>';
+										} else {
+											echo '&mdash;';
+										}
+										?>
+									</td>
+								<?php endif; ?>
+									<td>
+										<?php if ( '' !== (string) $row['email'] ) : ?>
+											<a href="mailto:<?php echo esc_attr( (string) $row['email'] ); ?>"><?php echo esc_html( (string) $row['email'] ); ?></a>
+										<?php elseif ( '' !== (string) $row['contact_email'] ) : ?>
+											<a href="mailto:<?php echo esc_attr( (string) $row['contact_email'] ); ?>"><?php echo esc_html( (string) $row['contact_email'] ); ?></a>
+											<span class="description">(<?php esc_html_e( 'tilaaja', 'rytkoset-theme' ); ?>)</span>
+										<?php else : ?>
+											&mdash;
+										<?php endif; ?>
+									</td>
+									<td>
+										<?php if ( '' !== (string) $row['phone'] ) : ?>
+											<a href="tel:<?php echo esc_attr( preg_replace( '/\s+/', '', (string) $row['phone'] ) ); ?>"><?php echo esc_html( (string) $row['phone'] ); ?></a>
+										<?php else : ?>
+											&mdash;
+										<?php endif; ?>
+									</td>
+									<td>
+										<?php
+										$details = trim( (string) $row['diet'] );
+										if ( '' !== (string) $row['notes'] ) {
+											$details = trim( $details . "\n" . (string) $row['notes'] );
+										}
+										echo '' !== $details ? esc_html( $details ) : '&mdash;';
+										?>
+									</td>
+									<td>
+										<?php
+										echo 'paid' === $row['source']
+											? esc_html__( 'Maksullinen', 'rytkoset-theme' )
+											: esc_html__( 'Maksuton', 'rytkoset-theme' );
+										?>
+									</td>
+									<td><?php echo esc_html( (string) $row['status_label'] ); ?></td>
+									<td><?php echo esc_html( (string) $row['created'] ); ?></td>
+									<td>
+										<?php if ( '' !== (string) $row['edit_url'] ) : ?>
+											<a href="<?php echo esc_url( (string) $row['edit_url'] ); ?>">
+												<?php
+												echo 'paid' === $row['source']
+													? esc_html( '#' . (string) $row['order_number'] )
+													: esc_html__( 'Muokkaa', 'rytkoset-theme' );
+												?>
+											</a>
+										<?php else : ?>
+											&mdash;
+										<?php endif; ?>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						<?php endif; ?>
+					</tbody>
+				</table>
+		</div>
+		<?php
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Tapahtumat > Osallistujat` admin page showing all event participants in a unified view
- Merges free registrations (`event_registration` CPT) and paid registrations (WooCommerce orders) with a normalized row structure
- Default view shows all events; dropdown lets you filter to a single event
- Status filter: all / pending / confirmed / cancelled / paid
- Tampere 2026 multi-participant schema reused for paid rows; generic billing fields used for other paid events
- Accessible to `administrator` and `event_organizer` roles (`edit_others_event_registrations`)
- Adds `docs/event-participants-admin.md` documenting the new page and row structure
- Updates `docs/events.md` to reflect the new admin entry point

## Test plan

- [ ] Create a free event, register 2–3 times from the front end → participants appear in `Tapahtumat > Osallistujat` with correct statuses
- [ ] Select Tampere 2026 event → same participants visible as in `WooCommerce > Tampere 2026 osallistujat`
- [ ] Status filter works (pending / confirmed / cancelled / paid)
- [ ] "Kaikki tapahtumat" shows participants from multiple events with the event column and clickable filter links
- [ ] Empty filter result shows "Ei osallistujia tällä suodatuksella"
- [ ] Event Organizer role can access the page; non-privileged user cannot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
