### PR TITLE
73 12 csv vienti

### DIFF
--- a/.claude/agents/DocsExplorer.md
+++ b/.claude/agents/DocsExplorer.md
@@ -1,0 +1,73 @@
+---
+name: DocsExplorer
+description: Documentation lookup specialist. Use proactively when needing docs for any library, framework, or technology. Fetches docs in parallel for multiple technologies.
+tools: WebFetch, WebSearch, Skill, MCPSearch
+model: sonnet
+---
+
+You are a documentation specialist that fetches up-to-date docs for libraries, frameworks, and technologies. Your goal is to provide accurate, relevant documentation quickly.
+
+## Workflow
+
+When given one or more technologies/libraries to look up:
+
+1. **Execute ALL lookups in parallel** - batch your tool calls for maximum speed
+2. **Use Context7 MCP as primary source** - it has high-quality, LLM-optimized docs
+3. **Fall back to web search** when Context7 lacks coverage
+4. **Prefer machine-readable formats** - llms.txt and .md files over HTML pages
+
+## Lookup Strategy
+
+### Step 1: Context7 MCP (Primary)
+
+For each library, call these in sequence:
+
+1. `mcp_Context7_resolve-library-id` with the library name to get the Context7 ID
+2. `mcp_Context7_query-docs` with the resolved ID and specific query
+
+Run Step 1 for ALL libraries in parallel.
+
+### Step 2: Web Fallback (If Context7 fails or lacks info)
+
+If Context7 doesn't have the library or lacks specific info:
+
+1. **Search for LLM-friendly docs first:**
+   - Search: `{library} llms.txt site:{official-docs-domain}`
+   - Search: `{library} documentation llms.txt`
+
+2. **Try known llms.txt paths:**
+   - Navigate to `{docs-base-url}/llms.txt`
+   - Navigate to `{docs-base-url}/docs/llms.txt`
+   - Navigate to `{docs-base-url}/llms-full.txt`
+
+3. **Try .md documentation paths:**
+   - Search: `{library} {topic} filetype:md site:github.com`
+   - Navigate to `{docs-base-url}/docs/{topic}.md`
+   - Navigate to `{docs-base-url}/{topic}.md`
+
+4. **Final fallback - fetch normal page:**
+   - If no llms.txt or .md found, navigate to the official docs page
+   - Use browser_snapshot to extract content
+
+## Parallel Execution Rules
+
+- When looking up multiple libraries, start ALL Context7 resolve-library-id calls simultaneously
+- After resolving IDs, batch all query-docs calls together
+- For web fallback, batch navigate calls for different libraries
+- Never wait for one library lookup to complete before starting another
+
+## Output Format
+
+For each library/technology, provide:
+
+```
+## {Library Name}
+
+**Source:** {Context7 | URL}
+
+### Key Information
+{Relevant docs content, API references, examples}
+
+### Code Examples
+{Practical code snippets from the docs}
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project context
+
+Rytkösten sukuseura ry:n WordPress-sivusto (rytkoset.net). Katso `AGENTS.md` projektin periaatteista, prioriteeteista ja yhteistyömallista — CLAUDE.md kattaa teknisen ympäristön ja arkkitehtuurin.
+
+## Development environment
+
+```bash
+# Käynnistä paikallinen ympäristö
+docker compose up -d
+# WordPress: http://localhost:8000
+
+# Sammuta
+docker compose down
+```
+
+Kolme konttia: `rytkoset-wp` (WordPress/PHP 8.3), `rytkoset-db` (MariaDB), `rytkoset-joomla-db` (Joomla-migraatio). Vain `wp-content/` on mountattu hostilta — muutos tiedostoon näkyy välittömästi ilman uudelleenkäynnistystä.
+
+## Linting ja CI
+
+Ei erillistä build-vaihetta. PHP-syntaksivalidointi:
+
+```bash
+find wp-content/themes/rytkoset-theme -name "*.php" -print0 | xargs -0 -n1 php -l
+```
+
+GitHub Actions ajaa tämän automaattisesti jokaiselle PR:lle ja `main`-pushille (`.github/workflows/php-ci.yml`).
+
+## Deploy
+
+- `dev`-branchi → automaattinen FTPS-deploy → `dev.rytkoset.net` (kun muutoksia `wp-content/themes/rytkoset-theme/**`)
+- `main`-branchi → ei automaattista deployta
+- Tuotantoon (`rytkoset.net`) deploy on aina manuaalinen
+
+## Commit-viestit
+
+Conventional Commits (katso `CONTRIBUTING.md`):
+
+```
+feat(events): lisää yksittäisen tapahtuman template
+fix(woo): korjaa membership-tilauksen tallennus
+docs: päivitä README staging-ohjeilla
+refactor: pilko functions.php inc/-moduuleihin
+```
+
+Älä luo committia automaattisesti — raportoi toteutus ensin, ehdota commit-viestiä, anna käyttäjän katsoa diff ennen commitia.
+
+## Theme architecture
+
+Teema `wp-content/themes/rytkoset-theme/` on ainoa versioitu koodipohja. WordPress-ydin ja pluginit eivät ole repossa.
+
+### Template-hierarkia
+
+| Tiedosto | Tarkoitus |
+|----------|-----------|
+| `front-page.php` | Etusivu |
+| `page.php` | Staattiset sivut |
+| `single.php` | Blogipostaus |
+| `single-event.php` | Yksittäinen tapahtuma |
+| `single-gallery_album.php` | Yksittäinen albumi |
+| `archive-event.php` | Tapahtumaarkisto (`/tapahtumat`) |
+| `archive-gallery_album.php` | Albumiarkisto (`/albumit`) |
+| `header.php` / `footer.php` | Sivuston ylä- ja alaosa |
+
+### functions.php ja inc/-moduulit
+
+`functions.php` (n. 3 400 riviä) sisältää sekä teeman perusasetukset että WooCommerce/Mollie/Tampere 2026 -logiikan, jota ei ole vielä pilkottu moduuleihin. Moduulit `inc/`-hakemistossa:
+
+| Tiedosto | Sisältö |
+|----------|---------|
+| `inc/events.php` | Event CPT, meta-kenttien rekisteröinti ja getterit |
+| `inc/gallery-albums.php` | Gallery Album CPT ja galleriapinoliikenne |
+| `inc/media-library.php` | Mediakirjaston järjestys albumeittain |
+| `inc/share.php` | Jako-painikkeet (Facebook, X, WhatsApp) |
+| `inc/social-links.php` | Some-linkit headeriin/footeriin |
+
+Kaikki funktiot käyttävät `if ( ! function_exists('rytkoset_theme_...') )` -suojausta ja `rytkoset_theme_` -etuliitettä.
+
+### CSS-rakenne
+
+`style.css` importoi kaikki moduulit; ei build-vaihetta:
+
+```
+assets/css/base.css          # Typografia, värimuuttujat, peruselementit
+assets/css/layout.css        # Containerit, gridit, sectionit
+assets/css/components.css    # Napit, kortit, yleiset komponentit
+assets/css/nav.base.css      # Navigaation yhteiset tyylit
+assets/css/nav.desktop.css   # Desktop-navigaatio
+assets/css/nav.mobile.css    # Mobiilinavigaatio (hamburger)
+assets/css/nav.account.css   # Käyttäjä/tili-valikko
+assets/css/hero.css          # Etusivun hero-osio
+assets/css/gallery.css       # Galleria ja albumit
+assets/css/footer.css        # Footer
+assets/css/login.css         # WP-kirjautumissivun brändäys
+assets/css/responsive.css    # Media queryt
+```
+
+Käytä CSS-muuttujia väreille ja spacingille. Ei Bootstrap-riippuvuutta.
+
+### JavaScript
+
+`assets/js/main.js` — mobiilivalikon toggle ja muut yleiset interaktiot.  
+`assets/js/photoswipe-init.js` — PhotoSwipe 5 -lightboxin alustus albumisivuille.  
+`assets/vendor/photoswipe/` — PhotoSwipe 5 vendoroituna (ei npm/bundler).
+
+## Custom Post Types
+
+### Event (`event`)
+
+- Slug: `/tapahtumat/`
+- Rekisteröity: `inc/events.php`
+- Meta-avaimet (via `rytkoset_theme_get_event_details_meta_keys()`):
+  - `_rytkoset_event_date` — päivämäärä `YYYY-MM-DD`
+  - `_rytkoset_event_start_time` — aloitusaika `HH:MM`
+  - `_rytkoset_event_end_time` — lopetusaika `HH:MM`
+  - `_rytkoset_event_location` — paikka
+  - `_rytkoset_event_fee_type` — `free` | `paid`
+  - `_rytkoset_event_price_text` — hintateksti näytettäväksi
+
+### Gallery Album (`gallery_album`)
+
+- Slug: `/albumit/`
+- Rekisteröity: `inc/gallery-albums.php`
+- Kuvat ovat WordPress media attachmentteja, joissa `post_parent = album_post_id`
+- Järjestys: tiedostonimen mukaan (lajiteltu `inc/media-library.php`:ssä)
+
+## WooCommerce-integraatio
+
+WooCommerce-koodi elää tällä hetkellä `functions.php`:ssä (ei vielä `inc/`-moduuleissa). Tärkeimmät kokonaisuudet:
+
+- **Jäsenmaksutuotteet** — vuosi- ja ainaisjäsenmaksu; kassa-huomio kun tuote korissa
+- **Tampere 2026 -tapahtumamaksu** — custom checkout-kentät, osallistujalista adminissa, CSV-vienti, sähköposti-ilmoitukset järjestäjille
+- **Mollie-maksut** — suomenkieliset tekstit, output-bufferointi `thankyou`-sivulla pankkisiirron ohjeille
+- **PhotoSwipe-konflikti** — WooCommerce rekisteröi PhotoSwipe 4 -skriptit; teema dequeue niitä aktiivisesti konfliktien välttämiseksi
+
+## Navigaatiomenut
+
+WordPress-administa hallittavat menut: `primary` (päävalikko), `footer`, `account` (käyttäjä/tili).
+
+## Dokumentaatio
+
+`docs/`-hakemistossa on käyttöönotto- ja ylläpito-ohjeet WooCommercen eri ominaisuuksille. Lue relevantti doc ennen WooCommerce-muutoksia.

--- a/README.md
+++ b/README.md
@@ -144,25 +144,27 @@ Ydinsisältö:
 ## Roadmap & projektinhallinta
 
 - GitHub Projects (roadmap + tehtävätaulu): https://github.com/Alpine78/rytkoset-wp/projects
-- Epicit ja alitehtävät on jaettu taululle; hallitus voi seurata etenemistä tilojen (Todo -> In progress -> Done) ja milestonejen kautta.
+- Epicit ja alitehtävät on jaettu taululle; hallitus voi seurata etenemistä tilojen (Backlog → Next → In Progress → Done) kautta.
 
-### MVP
-- Teeman peruslayout (header/footer, navigaatio), etusivu ja keskeiset sisältösivut julkaistavassa kunnossa.
-- Blogi ja uutisvirta sekä perus media-albumit (Photoswipe) katsottavissa myös mobiilissa.
-- Dev/staging (Docker + CI/CD + FTPS) toimii ja hallitus pääsee katselmoimaan dev.rytkoset.netissä.
-- Saavutettavuuden peruslinjaukset valmiit (kontrastit, fokus, näppäimistö).
+### Nykytila — toukokuu 2026
 
-### Phase 2
-- WooCommerce-jäsenmaksut ja digitaaliset tuotteet, maksutavat ja sähköpostit.
-- Tapahtumien luonti + ilmoittautuminen ilmaisille tapahtumille (lomake + osallistujanäkymä).
-- Sisällönhallinnan ohjeistus (menu, blogi, galleriat) dokumentoituna ja testattuna.
-- Saavutettavuuden tarkennukset lomakkeisiin ja modaalikomponentteihin.
+**Valmiit:**
+- Teeman peruslayout, header/footer, navigaatio, responsiivisuus ✅
+- Media-albumit (PhotoSwipe-galleria), YouTube-videoiden upotus ✅
+- WooCommerce: jäsenmaksutuotteet, digitaaliset tuotteet, Tampere 2026 -tapahtumamaksu ✅
+- Dev/staging (Docker + CI/CD + FTPS) toimii ✅
 
-### Long-term
-- Maksullisten tapahtumien maksupolku (liput, maksutavat) ja organizer-työkalut.
-- Jäsenyyden jatkot: uusinnat, sähköpostimuistutukset ja raportointi.
-- Lisäintegraatiot (uutiskirje, analytiikka) ja laajennetut hakutoiminnot sivustolla.
-- Jatkuva optimointi: suorituskyky, kuvien optimointi, varmuuskopioinnin automatisointi.
+**Käynnissä:**
+- Header/footer-uudistus ja valikon refaktorointi
+- EPIC 5 (Tapahtumat): CSV-vienti ja pienet viimeistelytehtävät
+- Mollie MobilePay -käyttöönotto ja Mollie tuotantoon
+
+**Seuraavaksi:**
+- Sukuseuran esittelysivut (historia, hallitus, yhteystiedot)
+- Blogin arkistonäkymä ja postaussivupohja
+- Saavutettavuustestaus (WCAG 2.1 AA)
+- Uutiskirjeet (AcyMailing)
+- Tietosuojaseloste ja julkaisuvalmius
 
 ---
 
@@ -186,30 +188,21 @@ Ydinsisältö:
 
 ---
 
-## 🧱 Suunnittelun pääepicit
+## 🧱 Pääepicit
 
-Projektia seurataan GitHub-issuilla ja epiceillä. Pääepicit:
+Projektia seurataan GitHub-issuilla ja epiceillä.
 
-1. **EPIC 1 — Perusrakenne & navigaatio (UI/UX / Theme Core)**
-   - Teeman peruslayout, header/footer, navigaatio, responsiivisuus
-
-2. **EPIC 2 — Media (Kuvat, albumit, video)**
-   - Galleria-albumit, Photoswipe, videoiden upotus
-
-3. **EPIC 3 — WooCommerce (jäsenmaksut, tuotteet, maksut)**
-   - Jäsenmaksutuotteet, digitaaliset tuotteet, maksutavat, jäsenyydet
-
-4. **EPIC 4 — Blogi & sisältösivut**
-   - Sukuseuran sivusisällöt, blogi, tapahtumasivut
-
-5. **EPIC 5 — Tapahtumat & ilmoittautumiset (ilmaiset + maksulliset)**
-   - Event-CPT, ilmoittautumislomakkeet, osallistujalistat, organizer-työkalut
-
-6. **EPIC 6 — Saavutettavuus (WCAG 2.1 AA)**
-   - Kontrastit, näppäimistökäyttö, ARIA, lomakkeet, dev-testaus
-   - 
-7. **EPIC 7 — Uutiskirjeet & AcyMailing**
-   - AcyMailing-uutiskirjeiden hallinta, lähettäminen ja ylläpito
+| Epic | Tila | Kuvaus |
+|------|------|--------|
+| EPIC 1 | ✅ Valmis | Perusrakenne & navigaatio — teema, header/footer, navigaatio |
+| EPIC 2 | ✅ Valmis | Media — albumit, PhotoSwipe-galleria, YouTube-videot |
+| EPIC 3 | 🔄 Pääosin valmis | WooCommerce — jäsenmaksut, tuotteet, Mollie-maksut |
+| EPIC 4 | 🔄 Käynnissä | Blogi & sisältösivut — esittelysivut, hallitus, blogi |
+| EPIC 5 | 🔄 Käynnissä | Tapahtumat & ilmoittautumiset — CPT, lomakkeet, organizer-työkalut |
+| EPIC 6 | 📋 Backlog | Saavutettavuus — WCAG 2.1 AA, kontrastit, ARIA, lomakkeet |
+| EPIC 7 | 📋 Backlog | Uutiskirjeet & AcyMailing — pohjat, mailing-listat, lähetykset |
+| EPIC 8 | 📋 Backlog | Julkaisuvalmius — tietosuoja, turvallisuus, suorituskyky |
+| Digilehti | 📋 Backlog | Digilehtien käyttöoikeudet ja hinnoittelu |
 
 ### Rajaukset
 - Sivusto on yksikielinen (suomi). Monikielisyys ja kieliversioita hyödyntävät lisäosat (esim. Polylang, MultilingualPress) eivät ole osa projektin laajuutta eikä niitä ole tarkoitus asentaa.

--- a/docs/event-participants-admin.md
+++ b/docs/event-participants-admin.md
@@ -1,6 +1,6 @@
 # Tapahtumakohtainen osallistujalista adminissa
 
-Tämä dokumentti kuvaa tiketin `#72` toteutuksen.
+Tämä dokumentti kuvaa tikettien `#72` (näkymä) ja `#73` (CSV-vienti) toteutukset.
 
 ## Tavoite
 
@@ -50,6 +50,28 @@ Jokaiselta osallistujalta näkyy:
 
 Jos tapahtumalla ei ole yhtään osallistujaa valituilla suodattimilla, taulukko näyttää "Ei osallistujia tällä suodatuksella".
 
+### CSV-vienti
+
+Suodattimien vieressä on **Vie CSV** -painike, joka lataa osallistujat CSV-tiedostona. Vienti kunnioittaa nykyisiä suodattimia: jos tapahtuma- tai statussuodatin on käytössä, vientiin tulee vain niitä vastaavat rivit. Tiedoston nimi sisältää tapahtuman slugin (tai `kaikki-tapahtumat`) ja mahdollisen statussuodatimen.
+
+Tiedosto on UTF-8-koodattu BOM-merkillä, joten Excel ja LibreOffice tunnistavat ääkköset suoraan. Erottimena on puolipiste (`;`), joka soveltuu suomalaiseen Excel-asetukseen.
+
+Sarakkeet:
+
+| Sarake | Sisältö |
+| --- | --- |
+| Tapahtuma | Tapahtuman otsikko |
+| Nimi | Osallistujan nimi |
+| Sähköposti | Osallistujan sähköposti |
+| Puhelin | Puhelinnumero |
+| Ruokavalio / huomiot | Ruokarajoitteet ja lisätiedot yhdistettynä |
+| Lähde | `Maksuton` tai `Maksullinen` |
+| Status | Luettava tilaselite |
+| Ilmoittautunut | Ilmoittautumispäivä |
+| Yhteyshenkilö | Tilaajan nimi (maksullisissa) |
+| Yhteyshenkilön sähköposti | Tilaajan sähköposti (maksullisissa) |
+| Tilausnumero | WooCommerce-tilausnumero (maksullisissa) |
+
 ## Lähteet ja normalisointi
 
 Näkymä yhdistää kaksi eri lähdettä yhtenäiseen rivi­rakenteeseen:
@@ -86,11 +108,11 @@ event_id      – tapahtuman post ID
 event_title   – tapahtuman otsikko
 ```
 
-Tämä rakenne on suunniteltu CSV-vientiä (`#12`) varten.
+Tämä rakenne on käytössä myös CSV-viennissä.
 
 ## Oikeudet
 
-Sivu on näkyvissä käyttäjillä, joilla on `edit_others_event_registrations`-oikeus. Tämä kuuluu sekä `administrator`- että `event_organizer`-roolille.
+Sivu ja CSV-vienti ovat näkyvissä käyttäjillä, joilla on `edit_others_event_registrations`-oikeus. Tämä kuuluu sekä `administrator`- että `event_organizer`-roolille. Vienti tarkistaa oikeuden uudelleen `admin_post`-käsittelijässä ja vahvistaa nonce-merkin ennen tiedoston luontia.
 
 ## Tekninen toteutus
 
@@ -104,9 +126,10 @@ Pääfunktiot:
 - `rytkoset_theme_get_all_events_participants($status_filter)` — kerää osallistujat kaikista tapahtumista
 - `rytkoset_theme_register_event_participants_admin_page()` — rekisteröi adminisivun
 - `rytkoset_theme_render_event_participants_admin_page()` — renderöi sivun
+- `rytkoset_theme_render_event_participants_export_form()` — renderöi CSV-vientipainikkeen
+- `rytkoset_theme_export_event_participants_csv()` — `admin_post`-handleri, joka tuottaa CSV-tiedoston
 
 ## Rajaus tässä vaiheessa
 
-- Ei CSV-vientiä (tulossa tiketissä `#12`)
 - Ei massatoimintoja osallistujille
 - Ei ilmoittautumisten tilamuutosta suoraan listanäkymästä (tehdään `event_registration`-postilomakkeella)

--- a/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
@@ -365,6 +365,160 @@ if ( ! function_exists( 'rytkoset_theme_get_event_participants_admin_status_opti
 	}
 }
 
+if ( ! function_exists( 'rytkoset_theme_render_event_participants_export_form' ) ) {
+	/**
+	 * Renders the CSV export form for the unified event participants admin page.
+	 *
+	 * @param int    $selected_event  Selected event ID (0 for all events).
+	 * @param string $selected_status Selected status filter.
+	 * @return void
+	 */
+	function rytkoset_theme_render_event_participants_export_form( $selected_event, $selected_status ) {
+		?>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="alignleft actions">
+			<input type="hidden" name="action" value="rytkoset_export_event_participants_csv" />
+			<input type="hidden" name="event_id" value="<?php echo esc_attr( (string) absint( $selected_event ) ); ?>" />
+			<input type="hidden" name="status" value="<?php echo esc_attr( $selected_status ); ?>" />
+			<?php wp_nonce_field( 'rytkoset_export_event_participants_csv', 'rytkoset_event_participants_csv_nonce' ); ?>
+			<?php submit_button( __( 'Vie CSV', 'rytkoset-theme' ), 'secondary', '', false ); ?>
+		</form>
+		<?php
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_event_participants_csv_filename' ) ) {
+	/**
+	 * Builds a filename for the participants CSV export.
+	 *
+	 * @param int    $event_id        Event ID or 0 for all events.
+	 * @param string $selected_status Status filter value.
+	 * @return string
+	 */
+	function rytkoset_theme_get_event_participants_csv_filename( $event_id, $selected_status ) {
+		$event_id = absint( $event_id );
+		$slug     = 'kaikki-tapahtumat';
+
+		if ( $event_id > 0 ) {
+			$post = get_post( $event_id );
+
+			if ( $post instanceof WP_Post && '' !== $post->post_name ) {
+				$slug = $post->post_name;
+			} elseif ( $post instanceof WP_Post ) {
+				$slug = sanitize_title( $post->post_title );
+			}
+		}
+
+		$parts = array( 'osallistujat', $slug );
+
+		if ( '' !== $selected_status ) {
+			$parts[] = $selected_status;
+		}
+
+		return sanitize_file_name( implode( '-', $parts ) . '.csv' );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_export_event_participants_csv' ) ) {
+	/**
+	 * Sends the unified event participant list as a CSV download.
+	 *
+	 * @return void
+	 */
+	function rytkoset_theme_export_event_participants_csv() {
+		if ( ! current_user_can( 'edit_others_event_registrations' ) ) {
+			wp_die( esc_html__( 'Sinulla ei ole oikeutta viedä osallistujalistaa.', 'rytkoset-theme' ) );
+		}
+
+		check_admin_referer( 'rytkoset_export_event_participants_csv', 'rytkoset_event_participants_csv_nonce' );
+
+		$event_id        = isset( $_POST['event_id'] ) ? absint( wp_unslash( $_POST['event_id'] ) ) : 0;
+		$selected_status = isset( $_POST['status'] ) ? sanitize_key( wp_unslash( $_POST['status'] ) ) : '';
+
+		$status_options = rytkoset_theme_get_event_participants_admin_status_options();
+
+		if ( ! isset( $status_options[ $selected_status ] ) ) {
+			$selected_status = '';
+		}
+
+		if ( $event_id > 0 && 'event' !== get_post_type( $event_id ) ) {
+			$event_id = 0;
+		}
+
+		$rows = $event_id > 0
+			? rytkoset_theme_get_event_participants( $event_id, $selected_status )
+			: rytkoset_theme_get_all_events_participants( $selected_status );
+
+		$filename = rytkoset_theme_get_event_participants_csv_filename( $event_id, $selected_status );
+
+		nocache_headers();
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename="' . $filename . '"' );
+		header( 'X-Content-Type-Options: nosniff' );
+
+		$output = fopen( 'php://output', 'w' );
+
+		if ( false === $output ) {
+			wp_die( esc_html__( 'CSV-viennin alustaminen epäonnistui.', 'rytkoset-theme' ) );
+		}
+
+		// UTF-8 BOM jotta Excel tunnistaa koodauksen oikein.
+		echo "\xEF\xBB\xBF";
+
+		fputcsv(
+			$output,
+			array(
+				__( 'Tapahtuma', 'rytkoset-theme' ),
+				__( 'Nimi', 'rytkoset-theme' ),
+				__( 'Sähköposti', 'rytkoset-theme' ),
+				__( 'Puhelin', 'rytkoset-theme' ),
+				__( 'Ruokavalio / huomiot', 'rytkoset-theme' ),
+				__( 'Lähde', 'rytkoset-theme' ),
+				__( 'Status', 'rytkoset-theme' ),
+				__( 'Ilmoittautunut', 'rytkoset-theme' ),
+				__( 'Yhteyshenkilö', 'rytkoset-theme' ),
+				__( 'Yhteyshenkilön sähköposti', 'rytkoset-theme' ),
+				__( 'Tilausnumero', 'rytkoset-theme' ),
+			),
+			';'
+		);
+
+		foreach ( $rows as $row ) {
+			$details = trim( (string) ( $row['diet'] ?? '' ) );
+			$notes   = trim( (string) ( $row['notes'] ?? '' ) );
+
+			if ( '' !== $notes ) {
+				$details = '' !== $details ? $details . "\n" . $notes : $notes;
+			}
+
+			$source_label = isset( $row['source'] ) && 'paid' === $row['source']
+				? __( 'Maksullinen', 'rytkoset-theme' )
+				: __( 'Maksuton', 'rytkoset-theme' );
+
+			fputcsv(
+				$output,
+				array(
+					(string) ( $row['event_title'] ?? '' ),
+					(string) ( $row['name'] ?? '' ),
+					(string) ( $row['email'] ?? '' ),
+					(string) ( $row['phone'] ?? '' ),
+					$details,
+					$source_label,
+					(string) ( $row['status_label'] ?? '' ),
+					(string) ( $row['created'] ?? '' ),
+					(string) ( $row['contact_name'] ?? '' ),
+					(string) ( $row['contact_email'] ?? '' ),
+					isset( $row['order_number'] ) && null !== $row['order_number'] ? (string) $row['order_number'] : '',
+				),
+				';'
+			);
+		}
+
+		fclose( $output );
+		exit;
+	}
+}
+add_action( 'admin_post_rytkoset_export_event_participants_csv', 'rytkoset_theme_export_event_participants_csv' );
+
 if ( ! function_exists( 'rytkoset_theme_render_event_participants_admin_page' ) ) {
 	/**
 	 * Renders the unified event participants admin page.
@@ -410,12 +564,12 @@ if ( ! function_exists( 'rytkoset_theme_render_event_participants_admin_page' ) 
 			<h1><?php esc_html_e( 'Tapahtumien osallistujat', 'rytkoset-theme' ); ?></h1>
 			<p><?php esc_html_e( 'Valitse tapahtuma nähdäksesi sekä maksuttomat että maksulliset ilmoittautumiset yhtenäisenä listana.', 'rytkoset-theme' ); ?></p>
 
-			<form method="get">
-				<input type="hidden" name="post_type" value="event" />
-				<input type="hidden" name="page" value="rytkoset-event-participants" />
+			<div class="tablenav top">
+				<div class="alignleft actions" style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+					<form method="get" style="display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin:0;">
+						<input type="hidden" name="post_type" value="event" />
+						<input type="hidden" name="page" value="rytkoset-event-participants" />
 
-				<div class="tablenav top">
-					<div class="alignleft actions" style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
 						<label for="rytkoset-event-participants-event">
 							<?php esc_html_e( 'Tapahtuma:', 'rytkoset-theme' ); ?>
 						</label>
@@ -450,24 +604,26 @@ if ( ! function_exists( 'rytkoset_theme_render_event_participants_admin_page' ) 
 						</select>
 
 						<?php submit_button( __( 'Suodata', 'rytkoset-theme' ), 'secondary', '', false ); ?>
+					</form>
 
-						<p class="description">
-							<?php
-							echo esc_html(
-								sprintf(
-									/* translators: 1: total, 2: free count, 3: paid count */
-									__( 'Yhteensä %1$d osallistujaa (maksuttomat %2$d, maksulliset %3$d).', 'rytkoset-theme' ),
-									$total_count,
-									$free_count,
-									$paid_count
-								)
-							);
-							?>
-						</p>
-					</div>
-					<br class="clear" />
+					<?php rytkoset_theme_render_event_participants_export_form( $selected_event, $selected_status ); ?>
+
+					<p class="description">
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: 1: total, 2: free count, 3: paid count */
+								__( 'Yhteensä %1$d osallistujaa (maksuttomat %2$d, maksulliset %3$d).', 'rytkoset-theme' ),
+								$total_count,
+								$free_count,
+								$paid_count
+							)
+						);
+						?>
+					</p>
 				</div>
-			</form>
+				<br class="clear" />
+			</div>
 
 			<?php $show_event_column = 0 === $selected_event; ?>
 			<table class="widefat striped">


### PR DESCRIPTION
feat(events): lisää CSV-vienti tapahtumakohtaiseen osallistujalistaan (#73)

Closes #73
## Summary

Lisätty Vie CSV -painike Tapahtumat > Osallistujat -sivulle; painike kunnioittaa aktiivisia suodattimia (tapahtuma + status)
Uusi admin_post-käsittelijä (rytkoset_export_event_participants_csv) tuottaa UTF-8 BOM + puolipisteen erottimena — toimii suoraan suomalaisessa Excelissä
CSV-tiedosto sisältää 11 saraketta: Tapahtuma, Nimi, Sähköposti, Puhelin, Ruokavalio/huomiot, Lähde, Status, Ilmoittautunut, Yhteyshenkilö, Yhteyshenkilön sähköposti, Tilausnumero
Lataus on suojattu wp_nonce + edit_others_event_registrations -oikeustarkistuksella
Tiedostonimi sisältää tapahtuman slugin tai kaikki-tapahtumat sekä mahdollisen statussuodattimen (esim. osallistujat-tampere-2026-confirmed.csv)
## Test plan

 Avaa Tapahtumat > Osallistujat — "Vie CSV" -painike näkyy suodatinrivillä
 Klikkaa ilman suodattimia → CSV latautuu nimellä osallistujat-kaikki-tapahtumat.csv, sisältää kaikki osallistujat
 Valitse yksittäinen tapahtuma → tiedostonimessä tapahtuman slug, vain ko. tapahtuman rivit
 Valitse statussuodatin (esim. Vahvistettu) → vain confirmed-rivit, nimi osallistujat-{slug}-confirmed.csv
 Avaa CSV Excelissä (suomalainen) — ääkköset näkyvät oikein, sarakkeet pilkkoutuvat puolipisteellä
 Kirjaudu ulos tai käytä tilin, jolla ei ole edit_others_event_registrations → vienti palauttaa 403
 Muokkaa nonce-arvo URL:issa/POST-datassa → WordPress hylkää pyynnön