### PR TITLE
feat(events): lisää GDPR-tietosuojateksti ja hyväksyntächeckbox ilmoittautumislomakkeeseen

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -75,6 +75,7 @@ Ilmoittautumisen tiedot tallennetaan WordPressin post metaan:
 | Ruokarajoitteet ja allergiat | `_rytkoset_registration_diet` | vapaa teksti | Käytännön järjestelyt |
 | Lisätieto | `_rytkoset_registration_notes` | vapaa teksti | Ylläpidon lisätiedot |
 | Tila | `_rytkoset_registration_status` | `pending`, `confirmed`, `cancelled` | Ilmoittautumisen käsittelytila |
+| GDPR-hyväksyntä | `_rytkoset_registration_gdpr_consent` | Unix-aikaleima | Tallennetaan, kun käyttäjä hyväksyy tietosuojakäytännön (#38) |
 
 Ilmoittautumisen otsikko muodostetaan automaattisesti muodossa `Osallistujan nimi - Tapahtuman nimi`, jotta admin-lista pysyy luettavana.
 
@@ -84,7 +85,7 @@ Yksittäisellä tapahtumasivulla näytetään:
 
 - tapahtuman artikkelikuva ja otsikko
 - editoriin kirjoitettu sisältö
-- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi eikä siihen ole linkitetty maksutuotetta
+- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi eikä siihen ole linkitetty maksutuotetta — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38)
 - sivupalkin yhteenvetokortti, jos tapahtumalla on perustietoja tai maksutuote
 - jakopainikkeet
 

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -445,6 +445,37 @@
   justify-self: start;
 }
 
+.event-registration__gdpr {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-s);
+  background: var(--color-surface);
+}
+
+.event-registration__gdpr-notice {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.event-registration__gdpr-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.9375rem;
+  cursor: pointer;
+}
+
+.event-registration__gdpr-label input[type="checkbox"] {
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+  width: 1.125rem;
+  height: 1.125rem;
+  cursor: pointer;
+}
+
 @media (min-width: 64rem) {
   .article--event {
     gap: 2.5rem;

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -15,12 +15,13 @@ if ( ! function_exists( 'rytkoset_theme_get_event_registration_meta_keys' ) ) {
 	 */
 	function rytkoset_theme_get_event_registration_meta_keys() {
 		return array(
-			'event_id' => '_rytkoset_registration_event_id',
-			'name'     => '_rytkoset_registration_name',
-			'email'    => '_rytkoset_registration_email',
-			'diet'     => '_rytkoset_registration_diet',
-			'notes'    => '_rytkoset_registration_notes',
-			'status'   => '_rytkoset_registration_status',
+			'event_id'     => '_rytkoset_registration_event_id',
+			'name'         => '_rytkoset_registration_name',
+			'email'        => '_rytkoset_registration_email',
+			'diet'         => '_rytkoset_registration_diet',
+			'notes'        => '_rytkoset_registration_notes',
+			'status'       => '_rytkoset_registration_status',
+			'gdpr_consent' => '_rytkoset_registration_gdpr_consent',
 		);
 	}
 }
@@ -543,6 +544,12 @@ if ( ! function_exists( 'rytkoset_theme_handle_event_registration_submission' ) 
 			rytkoset_theme_handle_event_registration_error( $event_id, 'invalid_email' );
 		}
 
+		$gdpr_consent = isset( $_POST['registration_gdpr_consent'] ) && '1' === wp_unslash( $_POST['registration_gdpr_consent'] );
+
+		if ( ! $gdpr_consent ) {
+			rytkoset_theme_handle_event_registration_error( $event_id, 'missing_consent' );
+		}
+
 		$meta_keys       = rytkoset_theme_get_event_registration_meta_keys();
 		$registration_id = wp_insert_post(
 			array(
@@ -550,12 +557,13 @@ if ( ! function_exists( 'rytkoset_theme_handle_event_registration_submission' ) 
 				'post_status' => 'publish',
 				'post_title'  => rytkoset_theme_build_event_registration_title( $name, $event_id ),
 				'meta_input'  => array(
-					$meta_keys['event_id'] => $event_id,
-					$meta_keys['name']     => $name,
-					$meta_keys['email']    => $email,
-					$meta_keys['diet']     => $diet,
-					$meta_keys['notes']    => $notes,
-					$meta_keys['status']   => 'pending',
+					$meta_keys['event_id']     => $event_id,
+					$meta_keys['name']         => $name,
+					$meta_keys['email']        => $email,
+					$meta_keys['diet']         => $diet,
+					$meta_keys['notes']        => $notes,
+					$meta_keys['status']       => 'pending',
+					$meta_keys['gdpr_consent'] => time(),
 				),
 			),
 			true
@@ -594,8 +602,9 @@ if ( ! function_exists( 'rytkoset_theme_get_event_registration_feedback' ) ) {
 
 		$error    = isset( $_GET['registration_error'] ) ? sanitize_key( wp_unslash( $_GET['registration_error'] ) ) : '';
 		$messages = array(
-			'missing_name'  => __( 'Tarkista ilmoittautumisen tiedot. Nimi on pakollinen.', 'rytkoset-theme' ),
-			'invalid_email' => __( 'Tarkista ilmoittautumisen tiedot. Sähköpostiosoite ei ole kelvollinen.', 'rytkoset-theme' ),
+			'missing_name'    => __( 'Tarkista ilmoittautumisen tiedot. Nimi on pakollinen.', 'rytkoset-theme' ),
+			'invalid_email'   => __( 'Tarkista ilmoittautumisen tiedot. Sähköpostiosoite ei ole kelvollinen.', 'rytkoset-theme' ),
+			'missing_consent' => __( 'Hyväksy tietosuojakäytäntö ennen lomakkeen lähettämistä.', 'rytkoset-theme' ),
 		);
 
 		return array(
@@ -610,8 +619,6 @@ if ( ! function_exists( 'rytkoset_theme_get_event_registration_feedback' ) ) {
 if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) ) {
 	/**
 	 * Renders the free event registration form UI.
-	 *
-	 * The form handler is implemented in a later ticket.
 	 *
 	 * @param int $event_id Event post ID.
 	 */
@@ -673,6 +680,17 @@ if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) )
 						<?php esc_html_e( 'Lisätieto', 'rytkoset-theme' ); ?>
 					</label>
 					<textarea id="<?php echo esc_attr( $form_id . '-notes' ); ?>" name="registration_notes" rows="4"></textarea>
+				</div>
+
+				<div class="event-registration__gdpr">
+					<p class="event-registration__gdpr-notice">
+						<?php esc_html_e( 'Ilmoittautumisen yhteydessä kerättyjä henkilötietoja (nimi, sähköpostiosoite, ruokarajoitteet ja lisätiedot) käytetään tapahtuman järjestämistä varten. Tietoja ei luovuteta ulkopuolisille.', 'rytkoset-theme' ); ?>
+					</p>
+					<label class="event-registration__gdpr-label">
+						<input type="checkbox" name="registration_gdpr_consent" value="1" required />
+						<?php esc_html_e( 'Hyväksyn henkilötietojeni käsittelyn tapahtumaan ilmoittautumista varten.', 'rytkoset-theme' ); ?>
+						<span aria-hidden="true">*</span>
+					</label>
 				</div>
 
 				<p class="event-registration__required-note">


### PR DESCRIPTION
## Muutokset

- Lisätään ilmoittautumislomakkeeseen tietosuojakappale, joka kertoo mitä tietoja kerätään ja mihin niitä käytetään
- Lisätään pakollinen hyväksyntächeckbox ennen lähetysnappia (`required`)
- Hyväksyntä tallennetaan Unix-aikaleimana meta-kenttään `_rytkoset_registration_gdpr_consent`
- Palvelinpuolen validointi: puuttuva hyväksyntä palauttaa `missing_consent`-virheellä
- Päivitetään `docs/events.md`: uusi meta-kenttä taulukkoon, maininta lomakekuvaukseen

## Ei sisällä

- Linkkiä erilliselle tietosuojasivulle (ei ole vielä olemassa)
- Muutoksia maksullisten tapahtumien WooCommerce-checkoutiin

## Testattu

- Lomake näyttää tietosuojakappale + checkbox
- HTML5 `required` estää lähetyksen ilman hyväksyntää
- Hyväksytyllä lomakkeella ilmoittautuminen tallentuu onnistuneesti
- PHP-lint puhdas
