### PR TITLE
feat(events): lisää ilmoittautumisen vahvistusnäkymä tapahtuman tiedoilla

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -85,7 +85,7 @@ Yksittäisellä tapahtumasivulla näytetään:
 
 - tapahtuman artikkelikuva ja otsikko
 - editoriin kirjoitettu sisältö
-- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi eikä siihen ole linkitetty maksutuotetta — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38)
+- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi eikä siihen ole linkitetty maksutuotetta — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38); onnistumisen jälkeen lomake korvataan vahvistusosiolla, joka näyttää tapahtuman tiedot (#32)
 - sivupalkin yhteenvetokortti, jos tapahtumalla on perustietoja tai maksutuote
 - jakopainikkeet
 

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -445,6 +445,39 @@
   justify-self: start;
 }
 
+.event-registration__confirmation {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.event-registration__confirmation-lead {
+  margin: 0;
+}
+
+.event-registration__confirmation-details {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.event-registration__confirmation-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: 0.25rem 0.75rem;
+}
+
+.event-registration__confirmation-row dt {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.event-registration__confirmation-row dd {
+  margin: 0;
+  font-weight: 600;
+}
+
 .event-registration__gdpr {
   display: grid;
   gap: 0.75rem;

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -616,6 +616,60 @@ if ( ! function_exists( 'rytkoset_theme_get_event_registration_feedback' ) ) {
 	}
 }
 
+if ( ! function_exists( 'rytkoset_theme_render_event_registration_confirmation' ) ) {
+	/**
+	 * Renders the confirmation view shown after a successful registration.
+	 *
+	 * @param int $event_id Event post ID.
+	 */
+	function rytkoset_theme_render_event_registration_confirmation( $event_id ) {
+		$event_id   = absint( $event_id );
+		$section_id = 'event-registration-confirmed-' . $event_id;
+		$title      = get_the_title( $event_id );
+		$date       = function_exists( 'rytkoset_theme_get_event_date_display' ) ? rytkoset_theme_get_event_date_display( $event_id ) : '';
+		$time       = function_exists( 'rytkoset_theme_get_event_time_display' ) ? rytkoset_theme_get_event_time_display( $event_id ) : '';
+		$location   = function_exists( 'rytkoset_theme_get_event_location' ) ? rytkoset_theme_get_event_location( $event_id ) : '';
+		?>
+		<section class="event-registration event-registration--confirmed" aria-labelledby="<?php echo esc_attr( $section_id ); ?>">
+			<h2 id="<?php echo esc_attr( $section_id ); ?>" class="event-registration__title">
+				<?php esc_html_e( 'Ilmoittautuminen vastaanotettu!', 'rytkoset-theme' ); ?>
+			</h2>
+			<div class="event-registration__confirmation">
+				<p class="event-registration__confirmation-lead">
+					<?php esc_html_e( 'Ilmoittautumisesi on vastaanotettu. Otamme tarvittaessa yhteyttä sähköpostitse.', 'rytkoset-theme' ); ?>
+				</p>
+				<dl class="event-registration__confirmation-details">
+					<?php if ( '' !== $title ) : ?>
+						<div class="event-registration__confirmation-row">
+							<dt><?php esc_html_e( 'Tapahtuma', 'rytkoset-theme' ); ?></dt>
+							<dd><?php echo esc_html( $title ); ?></dd>
+						</div>
+					<?php endif; ?>
+					<?php if ( '' !== $date ) : ?>
+						<div class="event-registration__confirmation-row">
+							<dt><?php esc_html_e( 'Päivämäärä', 'rytkoset-theme' ); ?></dt>
+							<dd><?php echo esc_html( $date ); ?></dd>
+						</div>
+					<?php endif; ?>
+					<?php if ( '' !== $time ) : ?>
+						<div class="event-registration__confirmation-row">
+							<dt><?php esc_html_e( 'Kellonaika', 'rytkoset-theme' ); ?></dt>
+							<dd><?php echo esc_html( $time ); ?></dd>
+						</div>
+					<?php endif; ?>
+					<?php if ( '' !== $location ) : ?>
+						<div class="event-registration__confirmation-row">
+							<dt><?php esc_html_e( 'Paikka', 'rytkoset-theme' ); ?></dt>
+							<dd><?php echo esc_html( $location ); ?></dd>
+						</div>
+					<?php endif; ?>
+				</dl>
+			</div>
+		</section>
+		<?php
+	}
+}
+
 if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) ) {
 	/**
 	 * Renders the free event registration form UI.
@@ -632,6 +686,11 @@ if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) )
 		$form_id        = 'event-registration-form-' . $event_id;
 		$description_id = 'event-registration-description-' . $event_id;
 		$feedback       = rytkoset_theme_get_event_registration_feedback();
+
+		if ( ! empty( $feedback ) && 'success' === $feedback['type'] ) {
+			rytkoset_theme_render_event_registration_confirmation( $event_id );
+			return;
+		}
 		?>
 		<section class="event-registration" aria-labelledby="<?php echo esc_attr( $form_id . '-title' ); ?>">
 			<h2 id="<?php echo esc_attr( $form_id . '-title' ); ?>" class="event-registration__title">
@@ -641,8 +700,8 @@ if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) )
 				<?php esc_html_e( 'Tällä lomakkeella voit ilmoittautua maksuttomaan tapahtumaan.', 'rytkoset-theme' ); ?>
 			</p>
 
-			<?php if ( ! empty( $feedback ) ) : ?>
-				<div class="event-registration__notice event-registration__notice--<?php echo esc_attr( $feedback['type'] ); ?>" role="status">
+			<?php if ( ! empty( $feedback ) && 'error' === $feedback['type'] ) : ?>
+				<div class="event-registration__notice event-registration__notice--error" role="alert">
 					<?php echo esc_html( $feedback['message'] ); ?>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
## Muutokset

- Onnistuneen ilmoittautumisen jälkeen lomake piilotetaan ja tilalle renderöidään vahvistusosio
- Vahvistusosio näyttää tapahtuman nimen, päivämäärän, kellonajan ja paikan (vain täytetyt kentät)
- Tekstiä yksinkertaistettiin: ei viitata "vahvistukseen" jota ei automaattisesti lähetetä — status `pending`/`confirmed` on järjestäjän sisäinen hallintatieto
- Error-notice muutettu `role="alert"` (saavutettavuusparannus)
- Lisätään confirmation-osion CSS-tyylit

## Ei sisällä

- Automaattisia sähköposteja statusmuutoksesta — vahvistusviestintä on järjestäjän vastuulla (`Tapahtumat > Viestintä`)

## Testattu

- Onnistunut ilmoittautuminen → vahvistusosio näkyy tapahtuman tiedoilla, lomake piilotettu
- Virheellinen lomake → virheviesti näkyy, lomake säilyy täytettävissä
- PHP-lint puhdas
