### PR TITLE
fix(events): saavutettavuuskorjaukset WCAG 2.1 AA -tasoon (#75)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -272,3 +272,19 @@ Tampereen sukukokoukselle voidaan lisäksi asettaa:
 - Paikka: `Hotelli Rosendahl, Pyynikintie 13, Tampere`
 - Maksullisuus: `Maksullinen`
 - Hintateksti: `49 € / henkilö`
+
+## Saavutettavuus
+
+Tapahtumaosio on testattu WCAG 2.1 AA -vaatimuksia vasten tiketissä #75. Seuraavat asiat on tarkistettu ja korjattu:
+
+- Otsikkohierarkia (h1→h2, ei hyppyjä) ✓
+- Section-alueet aria-labelledby-tunnisteilla ✓
+- Kuvien alt-tekstit ✓
+- Lomakekenttien eksplisiittiset label/for-parit ✓
+- GDPR-checkboxin eksplisiittinen id/for-assosiaatio ja aria-required ✓
+- Checkbox-elementin `:focus-visible`-tyyli ✓
+- Tekstin muted-väri eksplisiittisenä muuttujana (`--color-text-mute`) opacity-hämärryksen sijaan ✓
+- Redirect-URL sisältää fragmenttiankurin (`#element-id`) — selain skrollaa automaattisesti lomakkeelle tai vahvistusosioon ✓
+- `prefers-reduced-motion` -media query koko teemalle ✓
+
+Lomakkeen palvelinpuolen virheviestit ovat yleisiä ilmoituksia lomakkeen yläpuolella (`role="alert"`). HTML5 native validation hoitaa kenttäkohtaiset virheet ennen lähetystä.

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -193,10 +193,9 @@
 
 .event-card__meta {
   margin: 0;
-  color: var(--color-text);
+  color: var(--color-text-mute);
   font-size: 0.9rem;
   font-weight: 700;
-  opacity: 0.72;
 }
 
 .event-card__title {
@@ -265,8 +264,7 @@
 }
 
 .event-details__label {
-  color: var(--color-text);
-  opacity: 0.72;
+  color: var(--color-text-mute);
   font-size: 0.85rem;
   font-weight: 700;
   letter-spacing: 0.03em;
@@ -335,8 +333,7 @@
 }
 
 .event-summary-card__label {
-  color: var(--color-text);
-  opacity: 0.72;
+  color: var(--color-text-mute);
   font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.08em;
@@ -467,7 +464,7 @@
 }
 
 .event-registration__confirmation-row dt {
-  color: var(--color-text-muted);
+  color: var(--color-text-mute);
   font-size: 0.875rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -507,6 +504,11 @@
   width: 1.125rem;
   height: 1.125rem;
   cursor: pointer;
+}
+
+.event-registration__gdpr-label input[type="checkbox"]:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 @media (min-width: 64rem) {

--- a/wp-content/themes/rytkoset-theme/assets/css/responsive.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/responsive.css
@@ -208,3 +208,14 @@
     padding-inline: 0.55rem;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -456,7 +456,17 @@ if ( ! function_exists( 'rytkoset_theme_get_event_registration_redirect_url' ) )
 			$args['registration_error'] = $error;
 		}
 
-		return add_query_arg( $args, $url );
+		$redirect_url = add_query_arg( $args, $url );
+
+		if ( $event_id > 0 ) {
+			if ( 'success' === $status ) {
+				$redirect_url .= '#event-registration-confirmed-' . $event_id;
+			} elseif ( 'error' === $status ) {
+				$redirect_url .= '#event-registration-form-' . $event_id;
+			}
+		}
+
+		return $redirect_url;
 	}
 }
 
@@ -745,8 +755,8 @@ if ( ! function_exists( 'rytkoset_theme_render_free_event_registration_form' ) )
 					<p class="event-registration__gdpr-notice">
 						<?php esc_html_e( 'Ilmoittautumisen yhteydessä kerättyjä henkilötietoja (nimi, sähköpostiosoite, ruokarajoitteet ja lisätiedot) käytetään tapahtuman järjestämistä varten. Tietoja ei luovuteta ulkopuolisille.', 'rytkoset-theme' ); ?>
 					</p>
-					<label class="event-registration__gdpr-label">
-						<input type="checkbox" name="registration_gdpr_consent" value="1" required />
+					<label class="event-registration__gdpr-label" for="<?php echo esc_attr( $form_id . '-gdpr' ); ?>">
+						<input id="<?php echo esc_attr( $form_id . '-gdpr' ); ?>" type="checkbox" name="registration_gdpr_consent" value="1" required aria-required="true" />
 						<?php esc_html_e( 'Hyväksyn henkilötietojeni käsittelyn tapahtumaan ilmoittautumista varten.', 'rytkoset-theme' ); ?>
 						<span aria-hidden="true">*</span>
 					</label>


### PR DESCRIPTION
## Muutokset

- Korjataan CSS-muuttujien kirjoitusvirhe `--color-text-muted` → `--color-text-mute` (jäi tiketistä #32)
- Korvataan `opacity: 0.72` eksplisiittisellä `color: var(--color-text-mute)` kolmessa kohdassa — parempi kontrasti ja ei läpinäkyvyysefektejä lapsielementeille
- Lisätään `:focus-visible`-tyyli GDPR-checkboxille (WCAG 2.4.7)
- GDPR-checkboxille eksplisiittinen `id`/`for` + `aria-required="true"` (WCAG 1.3.1)
- Redirect-URLiin fragmenttiankuri: selain skrollaa automaattisesti lomakkeelle (virhe) tai vahvistusosioon (onnistuminen)
- `@media (prefers-reduced-motion: reduce)` koko teemalle
- Dokumentoidaan saavutettavuustestauksen tulokset `docs/events.md`:hen

## Toimii oikein (ei muutoksia)

Otsikkohierarkia, section-landmark-alueet, kuvien alt-tekstit, time-elementtien datetime-attribuutit, skip-to-content-linkki, lomakekenttien label/for-parit

## Testattu

- PHP-lint puhdas
- Selaimessa: skrollaus lomakkeelle/vahvistusosioon redirect-latauksen jälkeen toimii
- Näppäimistö: checkbox saa näkyvän focus-kehyksen