### PR TITLE
210 sukuseuran esittelysivut historia hallitus ja yhteystiedot

### DIFF
--- a/docs/event-participants-admin.md
+++ b/docs/event-participants-admin.md
@@ -39,6 +39,8 @@ Jokaiselta osallistujalta näkyy:
 | Sarake | Selite |
 | --- | --- |
 | Nimi | Osallistujan nimi |
+| Osallistujatyyppi | Tampere 2026 -variaatiosta tuleva osallistujatyyppi, esimerkiksi `Aikuinen` tai `Lapsi 3-12 vuotta` |
+| Perjantain buffet | Osallistuuko henkilö perjantain buffet-illalliselle |
 | Sähköposti | Osallistujan sähköposti (ilmaisessa) tai yhteyshenkilön sähköposti (maksullisessa) |
 | Puhelin | Puhelinnumero |
 | Ruokavalio | Ruokarajoitteet tai allergiat |
@@ -62,6 +64,8 @@ Sarakkeet:
 | --- | --- |
 | Tapahtuma | Tapahtuman otsikko |
 | Nimi | Osallistujan nimi |
+| Osallistujatyyppi | Tampere 2026 -osallistujilla tuotteen variaatio |
+| Perjantain buffet | `Kyllä` tai `Ei` |
 | Sähköposti | Osallistujan sähköposti |
 | Puhelin | Puhelinnumero |
 | Ruokavalio / huomiot | Ruokarajoitteet ja lisätiedot yhdistettynä |
@@ -84,13 +88,15 @@ Lähde: `event_registration` -sisältötyyppi. Meta-avain `_rytkoset_registratio
 
 Lähde: WooCommerce-tilaukset, joissa on tapahtuman meta-avaimeen `_rytkoset_event_product_id` tallennettu tuote. Status seuraa tilauksen WooCommerce-statusta.
 
-- **Tampere 2026**: käytetään olemassa olevaa moniosallistujarakennetta — tilauksen checkout-kentistä puretaan jokainen osallistuja erikseen omaksi riviksi.
+- **Tampere 2026**: käytetään olemassa olevaa moniosallistujarakennetta — tilauksen checkout-kentistä puretaan jokainen osallistuja erikseen omaksi riviksi. Osallistujatyyppi tulee tilauksen variaatiosta ja perjantain buffet-valinta checkout-kentästä.
 - **Muut maksulliset tapahtumat**: yksi rivi per tilaus, tiedot tilauksen laskutustiedoista.
 
 ### Yhtenäinen rivirakenne
 
 ```
 name          – osallistujan nimi
+participant_type – Tampere 2026 -osallistujatyyppi
+friday_buffet – true/false perjantain buffet-illalliselle
 email         – sähköposti
 phone         – puhelinnumero
 diet          – ruokarajoitteet

--- a/docs/woocommerce-tampere-2026-checkout-fields.md
+++ b/docs/woocommerce-tampere-2026-checkout-fields.md
@@ -9,8 +9,8 @@ Yksi maksaja voi ilmoittaa samalla tilauksella useamman osallistujan Tampereen s
 Mallissa:
 
 - yhteyshenkilön tiedot tulevat WooCommercen normaalista checkoutista
-- yksi kappale `Tampere 2026 osallistumismaksu` -tuotetta vastaa yhtä osallistujaa
-- osallistujakohtaiset kentät generoidaan tuotteen kappalemäärän mukaan
+- yksi kappale `Tampere 2026 osallistumismaksu` -tuotteen variaatiota vastaa yhtä osallistujaa
+- osallistujakohtaiset kentät generoidaan Tampere 2026 -variaatioiden yhteenlasketun kappalemäärän mukaan
 
 ## Kerättävät tiedot
 
@@ -29,30 +29,36 @@ Jokaiselle osallistujalle kerätään:
 
 - nimi
 - ruokarajoitteet / allergiat
+- perjantain `28.8.2026` buffet-illalliselle osallistuminen (`kyllä` / `ei`)
+
+Osallistujatyyppi (`Aikuinen` tai `Lapsi 3-12 vuotta`) tulee tuotteen variaatiosta, eikä sitä kysytä uudelleen checkoutissa.
 
 ## Tekninen toteutus
 
 - Checkout-kentät rekisteröidään WooCommerce Blocks -kassan lisäkenttärajapinnalla.
-- Kentät aktivoituvat vain, jos ostoskorissa on Tampere 2026 -tuote.
-- Kenttien määrä perustuu Tampere 2026 -tuotteen kappalemäärään.
-- Tunnistus tehdään ensisijaisesti tuotteen SKU:lla `tampere-2026-osallistumismaksu`.
+- Kentät aktivoituvat vain, jos ostoskorissa on Tampere 2026 -tuote tai jokin sen variaatioista.
+- Kenttien määrä perustuu Tampere 2026 -variaatioiden yhteenlaskettuun kappalemäärään.
+- Tunnistus tehdään ensisijaisesti parent-tuotteen SKU:lla `tampere-2026-osallistumismaksu`.
 - Kentät tallentuvat tilauksen lisäkentiksiin order-metana.
 - Osallistujatiedot näytetään myös WooCommerce-adminissa tilauksen yhteydessä.
+- Osallistujatyyppi puretaan tilauksen rivien variaatioista samassa järjestyksessä kuin osallistujakohtaiset checkout-kentät.
 - Kenttien autocomplete on tarkoituksella rajattu pois, jotta selaimen autofill ei kirjoita nimiä ruokarajoitekenttiin.
 
 ## Rajaus tässä vaiheessa
 
 - ei osallistujakohtaista jäsenmaksun tilaa
 - ei avec-kenttää erillisenä käsitteenä
-- ei illallisen tai majoituksen lisävalintoja
+- ei perjantain buffet-illallisen verkkomaksua
+- ei majoituksen lisävalintoja
 - ei erillistä osallistujaraporttia
 - ei erillistä tapahtumarekisteriä
 
 ## Testaus
 
-- Lisää Tampere 2026 -tuotetta ostoskoriin 2 kappaletta
+- Lisää Tampere 2026 -tuotetta ostoskoriin yksi aikuinen ja yksi lapsi
 - Varmista, että kassalla näkyy 2 osallistujan kentät
 - Täytä molempien osallistujien nimet
 - Lisää toiselle ruokarajoite
+- Merkitse toiselle perjantain buffet-illallinen
 - Tee testitilaus loppuun
-- Varmista administa, että molemmat osallistujat näkyvät tilauksella luettavasti
+- Varmista administa, että molemmat osallistujat näkyvät tilauksella luettavasti osallistujatyypin, ruokarajoitteen ja buffet-valinnan kanssa

--- a/docs/woocommerce-tampere-2026-product.md
+++ b/docs/woocommerce-tampere-2026-product.md
@@ -5,27 +5,32 @@ Tämä dokumentti kuvaa tiketin `#139` tavoitetilan ja toteutusmallin paikallise
 ## Rajaus tässä vaiheessa
 
 - Tuote koskee vain sukukokouksen varsinaista juhlapäivää `29.8.2026`
-- Perjantain `28.8.2026` iltaohjelmaa ei huomioida tässä vaiheessa
 - Tuote kattaa vain osallistumisen lauantain ohjelmaan
-- Illallinen, majoitus, verkkomaksuintegraatio ja osallistujakohtaiset checkout-kentät jäävät myöhempiin tiketteihin
+- Perjantain `28.8.2026` buffet-illalliselle ilmoittaudutaan samalla kassapolulla osallistujakohtaisella valinnalla
+- Perjantain buffet-illallinen maksetaan paikan päällä, joten siitä ei tehdä omaa maksullista tuotetta
+- Majoitus ja varsinainen verkkomaksuintegraatio jäävät myöhempiin tiketteihin
 
 ## Tuotemalli
 
 - Tuotteen nimi: `Tampere 2026 osallistumismaksu`
 - Suositeltu SKU: `tampere-2026-osallistumismaksu`
-- Tuotetyyppi: `Simple product`
+- Tuotetyyppi: `Variable product`
 - Virtuaalituote: `Kyllä`
 - Ladattava tuote: `Ei`
-- Hinta: `49 € / henkilö`
+- Variaatiot:
+  - `Aikuinen`: `49 €`
+  - `Lapsi 3-12 vuotta`: `24,50 €`
 - `Sold individually`: `Ei`
 
 ## Myyntilogiikka
 
-- Yksi kappale tuotetta vastaa yhtä osallistujaa
+- Yksi variaation kappale vastaa yhtä osallistujaa
 - Samalla tilauksella voidaan ostaa useampi kappale
-- Tuotteen kappalemäärä kertoo osallistujien lukumäärän
+- Tuotteelle valitaan osallistujatyyppi samalla tavalla kuin vaatteelle valittaisiin koko
+- Variaatioiden kappalemäärät kertovat osallistujien lukumäärän
 - Maksutapana riittää tässä vaiheessa nykyinen `Tilisiirto`
-- Checkoutin osallistujakentät ja ilmoituslogiikka tunnistavat tuotteen ensisijaisesti SKU:lla `tampere-2026-osallistumismaksu`
+- Checkoutin osallistujakentät ja ilmoituslogiikka tunnistavat tuotteen parent-tuotteen SKU:lla `tampere-2026-osallistumismaksu` sekä sen variaatioilla
+- Perjantain buffet-illallinen kerätään checkoutissa osallistujakohtaisena kyllä/ei-valintana
 
 ## Tuotekuvauksen minimitiedot
 
@@ -34,31 +39,34 @@ Tuotekuvauksessa pitää kertoa vähintään:
 - tapahtuma: `Rytkösten sukukokous 29.8.2026`
 - että osallistumismaksu koskee lauantain ohjelmaa
 - että hinta sisältää buffetlounaan ja iltapäiväkahvin
+- että aikuisen hinta on `49 €` ja lapsen `24,50 €`
 - että ilmoittautumisen määräpäivä on `30.7.2026`
-- että ostoskoriin lisätään yhtä monta kappaletta kuin osallistujia
+- että ostoskoriin lisätään oikea määrä aikuisia ja lapsia
+- että perjantain buffet-illallinen valitaan kassalla ja maksetaan paikan päällä
 
 ## Esimerkkikuvaus
 
 `Tampere 2026 osallistumismaksu` on Rytkösten sukukokouksen osallistumismaksu lauantaille `29.8.2026`.
 
-Hinta on `49 € / henkilö` ja sisältää buffetlounaan sekä iltapäiväkahvin.
+Hinta on `49 € / aikuinen` ja `24,50 € / lapsi 3-12 vuotta`. Osallistumismaksu sisältää buffetlounaan sekä iltapäiväkahvin.
 
-Lisää ostoskoriin yhtä monta kappaletta kuin osallistujia. Ilmoittautumisen määräpäivä on `30.7.2026`.
+Valitse osallistujatyyppi ja lisää ostoskoriin oikea määrä aikuisia ja lapsia. Perjantain buffet-illallinen valitaan kassalla osallistujakohtaisesti ja maksetaan paikan päällä. Ilmoittautumisen määräpäivä on `30.7.2026`.
 
 ## Testaus
 
 - Tuote näkyy WooCommerce-adminissa oikealla nimellä
-- Tuotteen hinta on `49 €`
-- Tuote on `Simple product`
+- Tuote on `Variable product`
+- Tuotteella on variaatiot `Aikuinen` ja `Lapsi 3-12 vuotta`
+- Aikuisen hinta on `49 €`
+- Lapsen hinta on `24,50 €`
 - Tuote on `Virtual`
-- Tuotetta voi lisätä ostoskoriin useamman kappaleen
-- Ostoskorin summa muuttuu oikein kappalemäärän mukaan
+- Tuotetta voi lisätä ostoskoriin useamman kappaleen eri variaatioilla
+- Ostoskorin summa muuttuu oikein variaatioiden ja kappalemäärien mukaan
 - `Kassa` toimii tuotteen kanssa nykyisellä maksupolulla
 
 ## Jätetään seuraaviin tiketteihin
 
-- osallistujakohtaiset tiedot kassalla (`#140`)
 - tapahtuman linkitys maksutuotteeseen (`#138`)
 - määräpäivän ja kapasiteetin hallinta (`#141`)
 - varsinainen verkkomaksuintegraatio (`#145`)
-- perjantain `28.8.2026` iltaohjelman mahdollinen myyntipolku
+- perjantain `28.8.2026` buffet-illallisen maksaminen verkossa

--- a/wp-content/themes/rytkoset-theme/assets/js/main.js
+++ b/wp-content/themes/rytkoset-theme/assets/js/main.js
@@ -624,28 +624,33 @@ document.addEventListener('DOMContentLoaded', () => {
 
 (function () {
   const config = window.rytkosetCheckoutConfig;
+  const checkoutNotes = Array.isArray(config?.checkoutNotes)
+    ? config.checkoutNotes
+    : config?.showMembershipNote && config.membershipNoteHtml
+      ? [config.membershipNoteHtml]
+      : [];
 
-  if (!config || !config.showMembershipNote || !config.membershipNoteHtml) {
+  if (!checkoutNotes.length) {
     return;
   }
 
-  const insertMembershipNote = () => {
+  const insertCheckoutNotes = () => {
     const checkoutRoot = document.querySelector('.wp-block-woocommerce-checkout, .wc-block-checkout');
 
     if (!checkoutRoot || document.querySelector('.rytkoset-checkout-note')) {
       return false;
     }
 
-    checkoutRoot.insertAdjacentHTML('beforebegin', config.membershipNoteHtml);
+    checkoutRoot.insertAdjacentHTML('beforebegin', checkoutNotes.join(''));
     return true;
   };
 
-  if (insertMembershipNote()) {
+  if (insertCheckoutNotes()) {
     return;
   }
 
   const observer = new MutationObserver(() => {
-    if (insertMembershipNote()) {
+    if (insertCheckoutNotes()) {
       observer.disconnect();
     }
   });

--- a/wp-content/themes/rytkoset-theme/front-page.php
+++ b/wp-content/themes/rytkoset-theme/front-page.php
@@ -11,10 +11,10 @@
         Rytkösten sukuseura ry. vaalii suvun perinteitä, kokoaa suvun jäseniä ja edistää sukututkimusta.
       </p>
       <div class="hero__actions">
-        <a href="<?php echo esc_url( home_url('/sukuseura/jaesenyys') ); ?>" class="btn btn--primary">
+        <a href="<?php echo esc_url( home_url('/sukuseura/jasenyys') ); ?>" class="btn btn--primary">
           Liity jäseneksi
         </a>
-        <a href="<?php echo esc_url( home_url('/sukuseura/sukuseura') ); ?>" class="btn btn--ghost">
+        <a href="<?php echo esc_url( home_url('/sukuseura') ); ?>" class="btn btn--ghost">
           Tutustu sukuseuraan
         </a>
       </div>
@@ -26,8 +26,13 @@
     <div class="container section__narrow">
       <h2>Tervetuloa Rytkösten sukuseuran sivuille</h2>
       <p>
+        Rytkösten sukuseura perustettiin 18.8.1963 Iisalmessa Runnin Terveyskylpylällä. Perustamisen
+        puuhamiehenä oli maanviljelijä Viljo Rytkönen, jonka kiinnostus sukututkimukseen ja suvun
+        vaiheiden tallentamiseen loi pohjaa sukuseuran toiminnalle.
+      </p>
+      <p>
         Sukuseura kokoaa yhteen Rytkösten suvun jäseniä, järjestää sukukokouksia ja tapaamisia sekä
-        tukee suvun historian ja sukututkimuksen tallentamista.
+        tukee suvun historian, kuvien ja sukututkimuksen säilymistä tuleville sukupolville.
       </p>
     </div>
   </section>
@@ -50,9 +55,9 @@
       <article class="card">
         <h3 class="card__title">Sukujuhlat Tampereella</h3>
         <p class="card__text">
-          Seuraavat sukujuhlat järjestetään ensi kesänä Tampereella. Näe suvun väkeä ja pysy ajan tasalla ohjelmasta.
+          Seuraavat sukujuhlat järjestetään Tampereella 29.8.2026. Näe suvun väkeä ja pysy ajan tasalla ohjelmasta.
         </p>
-        <a href="<?php echo esc_url( home_url('/sukujuhlat') ); ?>" class="card__link">
+        <a href="<?php echo esc_url( home_url('/tapahtumat/rytkosten-sukukokous-tampereella-29-8-2026/') ); ?>" class="card__link">
           Lue lisää sukujuhlista &rarr;
         </a>
       </article>
@@ -81,7 +86,7 @@
         </p>
       </div>
       <div class="section__cta">
-        <a href="<?php echo esc_url( home_url('/sukuseura/jaesenyys') ); ?>" class="btn btn--light">
+        <a href="<?php echo esc_url( home_url('/sukuseura/jasenyys') ); ?>" class="btn btn--light">
           Lue lisää jäsenyydestä
         </a>
       </div>

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -342,8 +342,18 @@ function rytkoset_theme_scripts() {
 			'rytkoset-theme-main',
 			'window.rytkosetCheckoutConfig = ' . wp_json_encode(
 				array(
-					'showMembershipNote' => rytkoset_theme_cart_requires_member_names(),
-					'membershipNoteHtml' => rytkoset_theme_get_membership_checkout_notice_markup(),
+					'checkoutNotes' => array_values(
+						array_filter(
+							array(
+								rytkoset_theme_cart_requires_member_names()
+									? rytkoset_theme_get_membership_checkout_notice_markup()
+									: '',
+								function_exists( 'rytkoset_theme_cart_has_tampere_2026_registration' ) && rytkoset_theme_cart_has_tampere_2026_registration()
+									? rytkoset_theme_get_tampere_2026_checkout_notice_markup()
+									: '',
+							)
+						)
+					),
 				)
 			) . ';',
 			'before'

--- a/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
@@ -56,22 +56,24 @@ function rytkoset_theme_get_event_free_participants( $event_id, $status_filter =
 		$name = rytkoset_theme_get_event_registration_meta( $registration->ID, 'name' );
 
 		$rows[] = array(
-			'name'          => '' !== $name ? $name : __( 'Nimetön osallistuja', 'rytkoset-theme' ),
-			'email'         => rytkoset_theme_get_event_registration_meta( $registration->ID, 'email' ),
-			'phone'         => '',
-			'diet'          => rytkoset_theme_get_event_registration_meta( $registration->ID, 'diet' ),
-			'notes'         => rytkoset_theme_get_event_registration_meta( $registration->ID, 'notes' ),
-			'status'        => $status,
-			'status_label'  => isset( $statuses[ $status ] ) ? $statuses[ $status ] : $statuses['pending'],
-			'source'        => 'free',
-			'created'       => get_the_date( '', $registration ),
-			'contact_name'  => '' !== $name ? $name : '',
-			'contact_email' => rytkoset_theme_get_event_registration_meta( $registration->ID, 'email' ),
-			'edit_url'      => (string) get_edit_post_link( $registration->ID, '' ),
-			'order_id'      => null,
-			'order_number'  => null,
-			'event_id'      => $event_id,
-			'event_title'   => get_the_title( $event_id ),
+			'name'             => '' !== $name ? $name : __( 'Nimetön osallistuja', 'rytkoset-theme' ),
+			'email'            => rytkoset_theme_get_event_registration_meta( $registration->ID, 'email' ),
+			'phone'            => '',
+			'diet'             => rytkoset_theme_get_event_registration_meta( $registration->ID, 'diet' ),
+			'notes'            => rytkoset_theme_get_event_registration_meta( $registration->ID, 'notes' ),
+			'participant_type' => '',
+			'friday_buffet'    => false,
+			'status'           => $status,
+			'status_label'     => isset( $statuses[ $status ] ) ? $statuses[ $status ] : $statuses['pending'],
+			'source'           => 'free',
+			'created'          => get_the_date( '', $registration ),
+			'contact_name'     => '' !== $name ? $name : '',
+			'contact_email'    => rytkoset_theme_get_event_registration_meta( $registration->ID, 'email' ),
+			'edit_url'         => (string) get_edit_post_link( $registration->ID, '' ),
+			'order_id'         => null,
+			'order_number'     => null,
+			'event_id'         => $event_id,
+			'event_title'      => get_the_title( $event_id ),
 		);
 	}
 
@@ -132,7 +134,7 @@ function rytkoset_theme_get_event_paid_participants( $event_id ) {
 				continue;
 			}
 
-			if ( (int) $item_product->get_id() === $product_id ) {
+			if ( (int) $item_product->get_id() === $product_id || (int) $item_product->get_parent_id() === $product_id ) {
 				$order_has_product = true;
 				$quantity         += (int) $item->get_quantity();
 			}
@@ -168,22 +170,24 @@ function rytkoset_theme_get_event_paid_participants( $event_id ) {
 					: __( 'Nimi puuttuu', 'rytkoset-theme' );
 
 				$rows[] = array(
-					'name'          => $participant_name,
-					'email'         => '',
-					'phone'         => '',
-					'diet'          => isset( $participant['diet'] ) ? (string) $participant['diet'] : '',
-					'notes'         => '',
-					'status'        => 'paid',
-					'status_label'  => $status_label,
-					'source'        => 'paid',
-					'created'       => $created,
-					'contact_name'  => $contact_name,
-					'contact_email' => $contact_email,
-					'edit_url'      => $edit_url,
-					'order_id'      => $order->get_id(),
-					'order_number'  => $order->get_order_number(),
-					'event_id'      => $event_id,
-					'event_title'   => get_the_title( $event_id ),
+					'name'             => $participant_name,
+					'email'            => '',
+					'phone'            => '',
+					'diet'             => isset( $participant['diet'] ) ? (string) $participant['diet'] : '',
+					'notes'            => '',
+					'participant_type' => isset( $participant['participant_type'] ) ? (string) $participant['participant_type'] : '',
+					'friday_buffet'    => ! empty( $participant['friday_buffet'] ),
+					'status'           => 'paid',
+					'status_label'     => $status_label,
+					'source'           => 'paid',
+					'created'          => $created,
+					'contact_name'     => $contact_name,
+					'contact_email'    => $contact_email,
+					'edit_url'         => $edit_url,
+					'order_id'         => $order->get_id(),
+					'order_number'     => $order->get_order_number(),
+					'event_id'         => $event_id,
+					'event_title'      => get_the_title( $event_id ),
 				);
 			}
 
@@ -194,22 +198,24 @@ function rytkoset_theme_get_event_paid_participants( $event_id ) {
 
 		for ( $i = 0; $i < $units; $i++ ) {
 			$rows[] = array(
-				'name'          => $contact_name,
-				'email'         => $contact_email,
-				'phone'         => $contact_phone,
-				'diet'          => '',
-				'notes'         => (string) $order->get_customer_note(),
-				'status'        => 'paid',
-				'status_label'  => $status_label,
-				'source'        => 'paid',
-				'created'       => $created,
-				'contact_name'  => $contact_name,
-				'contact_email' => $contact_email,
-				'edit_url'      => $edit_url,
-				'order_id'      => $order->get_id(),
-				'order_number'  => $order->get_order_number(),
-				'event_id'      => $event_id,
-				'event_title'   => get_the_title( $event_id ),
+				'name'             => $contact_name,
+				'email'            => $contact_email,
+				'phone'            => $contact_phone,
+				'diet'             => '',
+				'notes'            => (string) $order->get_customer_note(),
+				'participant_type' => '',
+				'friday_buffet'    => false,
+				'status'           => 'paid',
+				'status_label'     => $status_label,
+				'source'           => 'paid',
+				'created'          => $created,
+				'contact_name'     => $contact_name,
+				'contact_email'    => $contact_email,
+				'edit_url'         => $edit_url,
+				'order_id'         => $order->get_id(),
+				'order_number'     => $order->get_order_number(),
+				'event_id'         => $event_id,
+				'event_title'      => get_the_title( $event_id ),
 			);
 		}
 	}
@@ -446,6 +452,8 @@ function rytkoset_theme_export_event_participants_csv() {
 		array(
 			__( 'Tapahtuma', 'rytkoset-theme' ),
 			__( 'Nimi', 'rytkoset-theme' ),
+			__( 'Osallistujatyyppi', 'rytkoset-theme' ),
+			__( 'Perjantain buffet', 'rytkoset-theme' ),
 			__( 'Sähköposti', 'rytkoset-theme' ),
 			__( 'Puhelin', 'rytkoset-theme' ),
 			__( 'Ruokavalio / huomiot', 'rytkoset-theme' ),
@@ -476,6 +484,8 @@ function rytkoset_theme_export_event_participants_csv() {
 			array(
 				(string) ( $row['event_title'] ?? '' ),
 				(string) ( $row['name'] ?? '' ),
+				(string) ( $row['participant_type'] ?? '' ),
+				! empty( $row['friday_buffet'] ) ? __( 'Kyllä', 'rytkoset-theme' ) : __( 'Ei', 'rytkoset-theme' ),
 				(string) ( $row['email'] ?? '' ),
 				(string) ( $row['phone'] ?? '' ),
 				$details,
@@ -603,6 +613,8 @@ function rytkoset_theme_render_event_participants_admin_page() {
 			<thead>
 				<tr>
 					<th scope="col"><?php esc_html_e( 'Nimi', 'rytkoset-theme' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Osallistujatyyppi', 'rytkoset-theme' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Perjantain buffet', 'rytkoset-theme' ); ?></th>
 					<?php if ( $show_event_column ) : ?>
 						<th scope="col"><?php esc_html_e( 'Tapahtuma', 'rytkoset-theme' ); ?></th>
 					<?php endif; ?>
@@ -618,12 +630,20 @@ function rytkoset_theme_render_event_participants_admin_page() {
 			<tbody>
 				<?php if ( empty( $rows ) ) : ?>
 					<tr>
-						<td colspan="<?php echo $show_event_column ? 9 : 8; ?>"><?php esc_html_e( 'Ei osallistujia valitulla suodatuksella.', 'rytkoset-theme' ); ?></td>
+						<td colspan="<?php echo $show_event_column ? 11 : 10; ?>"><?php esc_html_e( 'Ei osallistujia valitulla suodatuksella.', 'rytkoset-theme' ); ?></td>
 					</tr>
 				<?php else : ?>
 					<?php foreach ( $rows as $row ) : ?>
 						<tr>
 							<td><?php echo esc_html( (string) $row['name'] ); ?></td>
+							<td><?php echo '' !== (string) $row['participant_type'] ? esc_html( (string) $row['participant_type'] ) : '&mdash;'; ?></td>
+							<td>
+								<?php
+								echo ! empty( $row['friday_buffet'] )
+									? esc_html__( 'Kyllä', 'rytkoset-theme' )
+									: esc_html__( 'Ei', 'rytkoset-theme' );
+								?>
+							</td>
 							<?php if ( $show_event_column ) : ?>
 								<td>
 									<?php

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
@@ -34,7 +34,89 @@ function rytkoset_theme_is_tampere_2026_registration_product( $product ) {
 		return true;
 	}
 
-	return rytkoset_theme_get_tampere_2026_registration_sku() === (string) $product->get_sku();
+	if ( rytkoset_theme_get_tampere_2026_registration_sku() === (string) $product->get_sku() ) {
+		return true;
+	}
+
+	$parent_id = $product->get_parent_id();
+
+	if ( $parent_id <= 0 ) {
+		return false;
+	}
+
+	$parent = wc_get_product( $parent_id );
+
+	if ( ! $parent instanceof WC_Product ) {
+		return false;
+	}
+
+	return 'tampere_2026' === $parent->get_meta( '_rytkoset_registration_mode', true )
+		|| rytkoset_theme_get_tampere_2026_registration_sku() === (string) $parent->get_sku();
+}
+
+/**
+ * Returns the parent registration product for a Tampere 2026 product or variation.
+ *
+ * @param WC_Product|null $product WooCommerce product object.
+ * @return WC_Product|null
+ */
+function rytkoset_theme_get_tampere_2026_registration_parent_product( $product ) {
+	if ( ! rytkoset_theme_is_tampere_2026_registration_product( $product ) ) {
+		return null;
+	}
+
+	if ( $product instanceof WC_Product && $product->get_parent_id() > 0 ) {
+		$parent = wc_get_product( $product->get_parent_id() );
+
+		if ( $parent instanceof WC_Product ) {
+			return $parent;
+		}
+	}
+
+	return $product instanceof WC_Product ? $product : null;
+}
+
+/**
+ * Returns all product IDs that identify Tampere 2026 registration cart items.
+ *
+ * Includes the parent product and any variations so WooCommerce Blocks
+ * conditional checkout-field schemas work for both simple and variable setups.
+ *
+ * @return array<int, int>
+ */
+function rytkoset_theme_get_tampere_2026_registration_product_ids() {
+	if ( ! function_exists( 'wc_get_product_id_by_sku' ) ) {
+		return array();
+	}
+
+	$product_id = wc_get_product_id_by_sku( rytkoset_theme_get_tampere_2026_registration_sku() );
+
+	if ( ! $product_id ) {
+		return array();
+	}
+
+	$product = wc_get_product( $product_id );
+	$ids     = array( (int) $product_id );
+
+	if ( $product instanceof WC_Product_Variable ) {
+		$ids = array_merge( $ids, array_map( 'intval', $product->get_children() ) );
+	}
+
+	$variation_ids = get_posts(
+		array(
+			'post_type'      => 'product_variation',
+			'post_parent'    => $product_id,
+			'post_status'    => array( 'publish', 'private' ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		)
+	);
+
+	if ( ! empty( $variation_ids ) ) {
+		$ids = array_merge( $ids, array_map( 'intval', $variation_ids ) );
+	}
+
+	return array_values( array_unique( array_filter( $ids ) ) );
 }
 
 /**
@@ -88,7 +170,10 @@ function rytkoset_theme_get_tampere_2026_registration_deadline( $product ) {
 		return '';
 	}
 
-	$stored_deadline = $product->get_meta( rytkoset_theme_get_tampere_2026_registration_deadline_meta_key(), true );
+	$deadline_product = rytkoset_theme_get_tampere_2026_registration_parent_product( $product );
+	$stored_deadline  = $deadline_product instanceof WC_Product
+		? $deadline_product->get_meta( rytkoset_theme_get_tampere_2026_registration_deadline_meta_key(), true )
+		: $product->get_meta( rytkoset_theme_get_tampere_2026_registration_deadline_meta_key(), true );
 	$deadline        = rytkoset_theme_normalize_registration_deadline_date( (string) $stored_deadline );
 
 	if ( '' !== $deadline ) {
@@ -286,6 +371,33 @@ function rytkoset_theme_get_tampere_2026_participant_count() {
 }
 
 /**
+ * Returns true when the current cart contains Tampere 2026 registrations.
+ *
+ * @return bool
+ */
+function rytkoset_theme_cart_has_tampere_2026_registration() {
+	return rytkoset_theme_get_tampere_2026_participant_count() > 0;
+}
+
+/**
+ * Builds the checkout notice shown for Tampere 2026 registrations.
+ *
+ * @return string
+ */
+function rytkoset_theme_get_tampere_2026_checkout_notice_markup() {
+	$notice_text = html_entity_decode(
+		'<strong>Tampere 2026 sukukokous:</strong> Täytä jokaiselle osallistujalle nimi, mahdolliset ruokarajoitteet tai allergiat sekä perjantain buffet-illallisen valinta kohdassa Tilauksen lisätiedot.',
+		ENT_QUOTES,
+		'UTF-8'
+	);
+
+	return sprintf(
+		'<div class="rytkoset-checkout-note" role="note"><p>%s</p></div>',
+		wp_kses_post( $notice_text )
+	);
+}
+
+/**
  * Filters purchasability for the Tampere 2026 registration product.
  *
  * @param bool            $is_purchasable Current purchasable state.
@@ -425,9 +537,9 @@ function rytkoset_theme_get_tampere_2026_max_participants() {
  * @return array<string, mixed>
  */
 function rytkoset_theme_get_tampere_2026_cart_presence_schema() {
-	$product_id = wc_get_product_id_by_sku( rytkoset_theme_get_tampere_2026_registration_sku() );
+	$product_ids = rytkoset_theme_get_tampere_2026_registration_product_ids();
 
-	if ( ! $product_id ) {
+	if ( empty( $product_ids ) ) {
 		return array(
 			'type' => 'object',
 			'not'  => array(),
@@ -441,7 +553,7 @@ function rytkoset_theme_get_tampere_2026_cart_presence_schema() {
 				'properties' => array(
 					'items' => array(
 						'contains' => array(
-							'const' => (int) $product_id,
+							'enum' => $product_ids,
 						),
 					),
 				),
@@ -556,8 +668,9 @@ function rytkoset_theme_register_tampere_2026_checkout_fields() {
 	}
 
 	for ( $index = 1; $index <= rytkoset_theme_get_tampere_2026_max_participants(); $index++ ) {
-		$name_field_id = sprintf( 'rytkoset/participant_%d_name', $index );
-		$diet_field_id = sprintf( 'rytkoset/participant_%d_diet', $index );
+		$name_field_id   = sprintf( 'rytkoset/participant_%d_name', $index );
+		$diet_field_id   = sprintf( 'rytkoset/participant_%d_diet', $index );
+		$buffet_field_id = sprintf( 'rytkoset/participant_%d_friday_buffet', $index );
 
 		woocommerce_register_additional_checkout_field(
 			array(
@@ -593,6 +706,18 @@ function rytkoset_theme_register_tampere_2026_checkout_fields() {
 					'data-1p-ignore' => 'true',
 					'maxLength'      => 200,
 				),
+			)
+		);
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                => $buffet_field_id,
+				'label'             => sprintf( __( 'Osallistuja %d: osallistuu perjantain 28.8. buffet-illalliselle (n. 30 €, maksu paikan päällä)', 'rytkoset-theme' ), $index ),
+				'location'          => 'order',
+				'type'              => 'checkbox',
+				'required'          => false,
+				'hidden'            => rytkoset_theme_get_tampere_2026_participant_hidden_schema( $index ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
 			)
 		);
 	}
@@ -632,6 +757,103 @@ function rytkoset_theme_get_order_additional_checkout_field_value( $order, $fiel
 }
 
 /**
+ * Returns true when an additional checkout checkbox field was checked.
+ *
+ * @param WC_Order $order    WooCommerce order object.
+ * @param string   $field_id Additional checkout field ID.
+ * @return bool
+ */
+function rytkoset_theme_get_order_additional_checkout_field_bool( $order, $field_id ) {
+	$value = rytkoset_theme_get_order_additional_checkout_field_value( $order, $field_id );
+	$value = strtolower( trim( (string) $value ) );
+
+	return in_array( $value, array( '1', 'true', 'yes', 'on' ), true );
+}
+
+/**
+ * Returns the participant type label for a Tampere 2026 variation.
+ *
+ * @param WC_Product|null $product WooCommerce product object.
+ * @return string
+ */
+function rytkoset_theme_get_tampere_2026_participant_type_label( $product ) {
+	if ( ! $product instanceof WC_Product ) {
+		return '';
+	}
+
+	$raw_value = '';
+
+	if ( $product instanceof WC_Product_Variation ) {
+		$variation_attributes = $product->get_variation_attributes();
+
+		foreach ( $variation_attributes as $attribute_name => $attribute_value ) {
+			if ( false !== strpos( (string) $attribute_name, 'osallistujatyyppi' ) ) {
+				$raw_value = (string) $attribute_value;
+				break;
+			}
+		}
+	}
+
+	if ( '' === $raw_value ) {
+		$raw_value = (string) $product->get_attribute( 'osallistujatyyppi' );
+	}
+
+	if ( '' === $raw_value ) {
+		$raw_value = (string) $product->get_attribute( 'pa_osallistujatyyppi' );
+	}
+
+	if ( '' === $raw_value ) {
+		return '';
+	}
+
+	$taxonomy = taxonomy_exists( 'pa_osallistujatyyppi' ) ? 'pa_osallistujatyyppi' : '';
+
+	if ( '' !== $taxonomy ) {
+		$term = get_term_by( 'slug', $raw_value, $taxonomy );
+
+		if ( $term && ! is_wp_error( $term ) ) {
+			return (string) $term->name;
+		}
+	}
+
+	if ( false !== strpos( $raw_value, ' ' ) ) {
+		return wc_clean( $raw_value );
+	}
+
+	return wc_clean( str_replace( '-', ' ', $raw_value ) );
+}
+
+/**
+ * Returns participant type labels in the same order as order-level participant fields.
+ *
+ * @param WC_Order $order WooCommerce order object.
+ * @return array<int, string>
+ */
+function rytkoset_theme_get_tampere_2026_order_participant_type_sequence( $order ) {
+	if ( ! $order instanceof WC_Order ) {
+		return array();
+	}
+
+	$types = array();
+
+	foreach ( $order->get_items() as $item ) {
+		$product = $item->get_product();
+
+		if ( ! rytkoset_theme_is_tampere_2026_registration_product( $product ) ) {
+			continue;
+		}
+
+		$type_label = rytkoset_theme_get_tampere_2026_participant_type_label( $product );
+
+		for ( $i = 0; $i < (int) $item->get_quantity(); $i++ ) {
+			$types[] = $type_label;
+		}
+	}
+
+	return $types;
+}
+
+/**
  * Returns Tampere 2026 participant data saved on an order.
  *
  * @param WC_Order $order WooCommerce order object.
@@ -658,7 +880,8 @@ function rytkoset_theme_get_tampere_2026_order_participants( $order ) {
 		return array();
 	}
 
-	$participants = array();
+	$participants     = array();
+	$participant_types = rytkoset_theme_get_tampere_2026_order_participant_type_sequence( $order );
 
 	for ( $index = 1; $index <= $participant_count; $index++ ) {
 		$name = trim(
@@ -673,14 +896,21 @@ function rytkoset_theme_get_tampere_2026_order_participants( $order ) {
 				sprintf( 'rytkoset/participant_%d_diet', $index )
 			)
 		);
+		$buffet = rytkoset_theme_get_order_additional_checkout_field_bool(
+			$order,
+			sprintf( 'rytkoset/participant_%d_friday_buffet', $index )
+		);
+		$type   = isset( $participant_types[ $index - 1 ] ) ? (string) $participant_types[ $index - 1 ] : '';
 
-		if ( '' === $name && '' === $diet ) {
+		if ( '' === $name && '' === $diet && ! $buffet ) {
 			continue;
 		}
 
 		$participants[] = array(
-			'name' => $name,
-			'diet' => $diet,
+			'name'             => $name,
+			'diet'             => $diet,
+			'participant_type' => $type,
+			'friday_buffet'    => $buffet,
 		);
 	}
 
@@ -805,10 +1035,21 @@ function rytkoset_theme_render_tampere_2026_order_participants_metabox( $post_or
 		echo '<li>';
 		echo '<strong>' . esc_html( $participant['name'] ) . '</strong>';
 
+		if ( ! empty( $participant['participant_type'] ) ) {
+			echo '<br>';
+			echo esc_html__( 'Osallistujatyyppi:', 'rytkoset-theme' ) . ' ' . esc_html( $participant['participant_type'] );
+		}
+
 		if ( '' !== $participant['diet'] ) {
 			echo '<br>';
 			echo esc_html__( 'Ruokarajoitteet / allergiat:', 'rytkoset-theme' ) . ' ' . esc_html( $participant['diet'] );
 		}
+
+		echo '<br>';
+		echo esc_html__( 'Perjantain buffet:', 'rytkoset-theme' ) . ' ';
+		echo ! empty( $participant['friday_buffet'] )
+			? esc_html__( 'Kyllä', 'rytkoset-theme' )
+			: esc_html__( 'Ei', 'rytkoset-theme' );
 
 		echo '</li>';
 	}
@@ -1258,9 +1499,15 @@ function rytkoset_theme_get_tampere_2026_notification_message( $order ) {
 			$participant_name = '' !== $participant['name'] ? $participant['name'] : __( 'Nimi puuttuu', 'rytkoset-theme' );
 			$lines[]          = sprintf( '%d. %s', $index + 1, $participant_name );
 
+			if ( ! empty( $participant['participant_type'] ) ) {
+				$lines[] = '   osallistujatyyppi: ' . $participant['participant_type'];
+			}
+
 			if ( '' !== $participant['diet'] ) {
 				$lines[] = '   ruokarajoitteet / allergiat: ' . $participant['diet'];
 			}
+
+			$lines[] = '   perjantain buffet: ' . ( ! empty( $participant['friday_buffet'] ) ? 'kyllä' : 'ei' );
 		}
 	}
 


### PR DESCRIPTION
## Yhteenveto

Toteuttaa Tampere 2026 -sukukokouksen ilmoittautumisen jatkokehityksen.

## Muutokset

- Muutettu `Tampere 2026 osallistumismaksu` variaatiotuotteeksi:
  - Aikuinen 49 €
  - Lapsi 3-12 vuotta 24,50 €
- Lisätty kassalle osallistujakohtaiset tiedot myös variaatiotuotteille.
- Lisätty osallistujakohtainen perjantain buffet-illallisen valinta.
- Lisätty Tampere 2026 -ohjeteksti kassalle.
- Päivitetty tapahtumasivun sisältö:
  - manuaali-ilmoittautuminen Maurille
  - puhelin ja sähköposti
  - tilisiirto-ohjeet
  - Scandic Rosendahlin majoitustiedot
- Lisätty adminin osallistujalistaan ja CSV-vientiin:
  - osallistujatyyppi
  - perjantain buffet -valinta
- Päivitetty järjestäjäilmoituksen ja tilausmetaboxin osallistujatiedot.
- Päivitetty dokumentaatio vastaamaan variaatiotuotetta ja buffet-valintaa.

## Testaus

- `php -l`:
  - `functions.php`
  - `inc/woocommerce-tampere-2026.php`
  - `inc/event-participants-admin.php`
- `node --check assets/js/main.js`
- Tarkistettu WooCommerce-tuotemalli paikallisesti:
  - parent-tuote `841`
  - variaatiot `997` ja `998`
  - hinnat 49 € ja 24,50 €
- Tarkistettu WooCommerce Blocks -checkout-säännöt:
  - osallistuja 1 ja 2 näkyvät variaatiotuotteilla
  - ylimääräiset osallistujakentät pysyvät piilossa
- Tarkistettu tapahtumasivu paikallisesti:
  - Maurin yhteystiedot
  - `mailto:`-linkki
  - tilinumero
  - buffet-maininta