### PR TITLE
feat: viimeistele WooCommerce-kaupan painikkeet ja valitsimet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerceen vuosijäsenmaksutuotteet `Yksityishenkilö` ja `Perhe`
 - WooCommerceen `Ainaisjäsenmaksu`, 100 EUR
 - Kassalle jäsenmaksuohje silloin, kun korissa on jäsenmaksutuote
+- WooCommerce-kaupan brändin mukaiset alasvetovalikko- ja painiketyylit.
 
 ### Fixed
 - Albumisivujen PhotoSwipe-lightbox käyttää nyt teeman omaa PhotoSwipe 5 -pakettia ilman WooCommercen legacy-konfliktia

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -3,8 +3,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 48px;
-  padding: 0.75rem 1.5rem;
+  min-height: 40px;
+  padding: 0.45rem 1.15rem;
   border-radius: var(--radius-pill);
   font-weight: 800;
   border: 2px solid transparent;

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.account.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.account.css
@@ -39,7 +39,7 @@
 
 .account-nav__list > li + li:last-child > a {
   min-height: 36px;
-  padding: 0.55rem 1.1rem;
+  padding: 0.45rem 1rem;
   border-radius: var(--radius-pill);
   background: var(--color-accent);
   color: var(--color-primary-deeper);

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.mobile.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.mobile.css
@@ -444,8 +444,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 48px;
-  padding: 0.75rem 0.875rem;
+  min-height: 40px;
+  padding: 0.45rem 0.875rem;
   border-radius: 999px;
   font: inherit;
   font-weight: 700;

--- a/wp-content/themes/rytkoset-theme/assets/css/shop.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/shop.css
@@ -1,0 +1,781 @@
+/* WooCommerce shop refinements */
+
+.woocommerce,
+.woocommerce-page {
+  --shop-border-soft: rgba(15, 23, 42, 0.06);
+  --shop-focus-ring: 0 0 0 3px rgba(15, 76, 129, 0.18);
+  --shop-popover-shadow: 0 1px 0 rgba(15, 23, 42, 0.04),
+    0 18px 40px rgba(8, 37, 74, 0.18);
+  --shop-accent-soft: #fef3c7;
+}
+
+:root[data-theme="dark"] .woocommerce,
+:root[data-theme="dark"] .woocommerce-page {
+  --shop-border-soft: rgba(255, 255, 255, 0.08);
+  --shop-focus-ring: 0 0 0 3px rgba(251, 191, 36, 0.24);
+  --shop-popover-shadow: 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 18px 40px rgba(0, 0, 0, 0.34);
+  --shop-accent-soft: rgba(251, 191, 36, 0.18);
+}
+
+.woocommerce a.button,
+.woocommerce button.button,
+.woocommerce input.button,
+.woocommerce #respond input#submit,
+.woocommerce-page a.button,
+.woocommerce-page button.button,
+.woocommerce-page input.button,
+.woocommerce-page #respond input#submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 40px;
+  padding: 0.45rem 1.15rem;
+  border: 1.5px solid transparent;
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-primary-deeper);
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-decoration: none;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.woocommerce a.button:hover,
+.woocommerce button.button:hover,
+.woocommerce input.button:hover,
+.woocommerce #respond input#submit:hover,
+.woocommerce-page a.button:hover,
+.woocommerce-page button.button:hover,
+.woocommerce-page input.button:hover,
+.woocommerce-page #respond input#submit:hover {
+  background: var(--color-accent-hover);
+  color: var(--color-primary-deeper);
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(251, 191, 36, 0.35);
+}
+
+.woocommerce a.button.alt,
+.woocommerce button.button.alt,
+.woocommerce input.button.alt,
+.woocommerce #respond input#submit.alt,
+.woocommerce-page a.button.alt,
+.woocommerce-page button.button.alt,
+.woocommerce-page input.button.alt,
+.woocommerce-page #respond input#submit.alt,
+.woocommerce a.checkout-button,
+.woocommerce-page a.checkout-button,
+.wp-block-woocommerce-cart .wc-block-cart__submit-button,
+.wp-block-woocommerce-cart .wc-block-components-button.wc-block-cart__submit-button,
+.wp-block-woocommerce-cart .wc-block-cart__submit-container .wc-block-components-button,
+.wp-block-woocommerce-proceed-to-checkout-block .wc-block-components-button,
+body.woocommerce-cart .wc-block-cart__submit-button,
+body.woocommerce-cart .wc-block-components-button.wc-block-cart__submit-button,
+body.woocommerce-cart .wc-block-cart__submit-container .wc-block-components-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0.45rem 1.15rem;
+  border: 1.5px solid var(--color-accent);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent);
+  color: var(--color-primary-deeper);
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-decoration: none;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.woocommerce a.button.alt:hover,
+.woocommerce button.button.alt:hover,
+.woocommerce input.button.alt:hover,
+.woocommerce #respond input#submit.alt:hover,
+.woocommerce-page a.button.alt:hover,
+.woocommerce-page button.button.alt:hover,
+.woocommerce-page input.button.alt:hover,
+.woocommerce-page #respond input#submit.alt:hover,
+.woocommerce a.checkout-button:hover,
+.woocommerce-page a.checkout-button:hover,
+.wp-block-woocommerce-cart .wc-block-cart__submit-button:hover,
+.wp-block-woocommerce-cart .wc-block-components-button.wc-block-cart__submit-button:hover,
+.wp-block-woocommerce-cart .wc-block-cart__submit-container .wc-block-components-button:hover,
+.wp-block-woocommerce-proceed-to-checkout-block .wc-block-components-button:hover,
+body.woocommerce-cart .wc-block-cart__submit-button:hover,
+body.woocommerce-cart .wc-block-components-button.wc-block-cart__submit-button:hover,
+body.woocommerce-cart .wc-block-cart__submit-container .wc-block-components-button:hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+  color: var(--color-primary-deeper);
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(251, 191, 36, 0.35);
+}
+
+.wp-block-woocommerce-cart .wc-block-cart__submit-button .wc-block-components-button__text,
+.wp-block-woocommerce-cart .wc-block-cart__submit-container .wc-block-components-button__text,
+.wp-block-woocommerce-proceed-to-checkout-block .wc-block-components-button__text,
+body.woocommerce-cart .wc-block-cart__submit-button .wc-block-components-button__text,
+body.woocommerce-cart .wc-block-cart__submit-container .wc-block-components-button__text {
+  color: inherit;
+}
+
+.woocommerce a.button.alt.disabled,
+.woocommerce a.button.alt:disabled,
+.woocommerce button.button.alt.disabled,
+.woocommerce button.button.alt:disabled,
+.woocommerce input.button.alt.disabled,
+.woocommerce input.button.alt:disabled,
+.woocommerce-page a.button.alt.disabled,
+.woocommerce-page a.button.alt:disabled,
+.woocommerce-page button.button.alt.disabled,
+.woocommerce-page button.button.alt:disabled,
+.woocommerce-page input.button.alt.disabled,
+.woocommerce-page input.button.alt:disabled,
+.woocommerce div.product form.cart .single_add_to_cart_button.disabled,
+.woocommerce div.product form.cart .single_add_to_cart_button:disabled,
+.woocommerce div.product form.cart .single_add_to_cart_button.wc-variation-selection-needed,
+.woocommerce-page div.product form.cart .single_add_to_cart_button.disabled,
+.woocommerce-page div.product form.cart .single_add_to_cart_button:disabled,
+.woocommerce-page div.product form.cart .single_add_to_cart_button.wc-variation-selection-needed {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-primary-deeper);
+  opacity: 1;
+  filter: none;
+}
+
+.woocommerce a.button.rytkoset-sold-individually-in-cart,
+.woocommerce button.button.rytkoset-sold-individually-in-cart,
+.woocommerce input.button.rytkoset-sold-individually-in-cart,
+.woocommerce-page a.button.rytkoset-sold-individually-in-cart,
+.woocommerce-page button.button.rytkoset-sold-individually-in-cart,
+.woocommerce-page input.button.rytkoset-sold-individually-in-cart,
+.woocommerce div.product form.cart .single_add_to_cart_button.rytkoset-sold-individually-in-cart,
+.woocommerce-page div.product form.cart .single_add_to_cart_button.rytkoset-sold-individually-in-cart {
+  background: var(--shop-accent-soft);
+  border-color: rgba(251, 191, 36, 0.56);
+  color: var(--color-text-mute);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: not-allowed;
+  box-shadow: none;
+  opacity: 1;
+  text-align: center;
+  transform: none;
+}
+
+.woocommerce a.button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce button.button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce input.button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce-page a.button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce-page button.button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce-page input.button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce div.product form.cart .single_add_to_cart_button.rytkoset-sold-individually-in-cart:hover,
+.woocommerce-page div.product form.cart .single_add_to_cart_button.rytkoset-sold-individually-in-cart:hover {
+  background: var(--shop-accent-soft);
+  border-color: rgba(251, 191, 36, 0.56);
+  color: var(--color-text-mute);
+  box-shadow: none;
+  transform: none;
+}
+
+.woocommerce a.button:focus-visible,
+.woocommerce button.button:focus-visible,
+.woocommerce input.button:focus-visible,
+.woocommerce #respond input#submit:focus-visible,
+.woocommerce-page a.button:focus-visible,
+.woocommerce-page button.button:focus-visible,
+.woocommerce-page input.button:focus-visible,
+.woocommerce-page #respond input#submit:focus-visible {
+  outline: none;
+  box-shadow: var(--shop-focus-ring);
+}
+
+.woocommerce div.product form.cart .button,
+.woocommerce-page div.product form.cart .button {
+  min-height: 44px;
+  padding: 0.55rem 1.45rem;
+  font-size: 0.95rem;
+}
+
+.woocommerce a.button.product_type_variable,
+.woocommerce a.button.product_type_grouped,
+.woocommerce a.button.product_type_external,
+.woocommerce-page a.button.product_type_variable,
+.woocommerce-page a.button.product_type_grouped,
+.woocommerce-page a.button.product_type_external {
+  background: var(--color-surface);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
+.woocommerce a.button.product_type_variable:hover,
+.woocommerce a.button.product_type_grouped:hover,
+.woocommerce a.button.product_type_external:hover,
+.woocommerce-page a.button.product_type_variable:hover,
+.woocommerce-page a.button.product_type_grouped:hover,
+.woocommerce-page a.button.product_type_external:hover {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-text-inverted);
+  box-shadow: none;
+}
+
+.woocommerce button.button[name="update_cart"],
+.woocommerce a.button.wc-backward,
+.woocommerce-page button.button[name="update_cart"],
+.woocommerce-page a.button.wc-backward {
+  background: transparent;
+  border-color: var(--color-border-neutral);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
+.woocommerce button.button[name="update_cart"]:hover,
+.woocommerce a.button.wc-backward:hover,
+.woocommerce-page button.button[name="update_cart"]:hover,
+.woocommerce-page a.button.wc-backward:hover {
+  background: var(--color-surface-alt);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
+.woocommerce .quantity .qty,
+.woocommerce-page .quantity .qty {
+  min-height: 44px;
+  border: 1.5px solid var(--color-border-neutral);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-weight: 700;
+}
+
+.woocommerce .quantity .qty:focus,
+.woocommerce-page .quantity .qty:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--shop-focus-ring);
+}
+
+.woocommerce .quantity .qty::-webkit-outer-spin-button,
+.woocommerce .quantity .qty::-webkit-inner-spin-button,
+.woocommerce-page .quantity .qty::-webkit-outer-spin-button,
+.woocommerce-page .quantity .qty::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.woocommerce .quantity .qty,
+.woocommerce-page .quantity .qty {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.woocommerce .quantity.rytkoset-quantity-is-fixed,
+.woocommerce-page .quantity.rytkoset-quantity-is-fixed {
+  display: none;
+}
+
+.rytkoset-quantity {
+  display: inline-grid;
+  grid-template-columns: 2.75rem 3rem 2.75rem;
+  align-items: stretch;
+  min-height: 44px;
+  overflow: hidden;
+  border: 1.5px solid var(--color-border-neutral);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+}
+
+.woocommerce .quantity .rytkoset-quantity__input,
+.woocommerce-page .quantity .rytkoset-quantity__input {
+  width: 100%;
+  min-height: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: none;
+  text-align: center;
+  font: inherit;
+  font-weight: 800;
+}
+
+.woocommerce .quantity .rytkoset-quantity__input:focus,
+.woocommerce-page .quantity .rytkoset-quantity__input:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.rytkoset-quantity:focus-within {
+  border-color: var(--color-primary);
+  box-shadow: var(--shop-focus-ring);
+}
+
+.rytkoset-quantity__button {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-mute);
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 900;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.rytkoset-quantity__button:hover,
+.rytkoset-quantity__button:focus-visible {
+  background: var(--color-surface-alt);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.rytkoset-quantity__button:disabled {
+  color: var(--color-text-mute);
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector,
+body.woocommerce-cart .wc-block-components-quantity-selector {
+  display: inline-grid;
+  grid-template-columns: 2.45rem 2.7rem 2.45rem;
+  align-items: stretch;
+  width: auto;
+  height: 36px;
+  min-height: 36px;
+  overflow: hidden;
+  border: 1.5px solid var(--color-border-neutral);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector::after,
+body.woocommerce-cart .wc-block-components-quantity-selector::after {
+  display: none;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__button,
+body.woocommerce-cart .wc-block-components-quantity-selector__button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: static;
+  width: 100%;
+  height: 36px;
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--color-text-mute);
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 900;
+  line-height: 1;
+  opacity: 1;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__button--minus,
+body.woocommerce-cart .wc-block-components-quantity-selector__button--minus {
+  order: 1;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__button--plus,
+body.woocommerce-cart .wc-block-components-quantity-selector__button--plus {
+  order: 3;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__button:hover,
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__button:focus-visible,
+body.woocommerce-cart .wc-block-components-quantity-selector__button:hover,
+body.woocommerce-cart .wc-block-components-quantity-selector__button:focus-visible {
+  background: var(--color-surface-alt);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__input,
+body.woocommerce-cart .wc-block-components-quantity-selector__input {
+  display: block;
+  order: 2;
+  width: 100%;
+  max-width: none;
+  min-width: 0;
+  min-height: 0;
+  box-sizing: border-box;
+  height: 36px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: none;
+  font: inherit;
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 36px;
+  text-align: center;
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__input::-webkit-outer-spin-button,
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector__input::-webkit-inner-spin-button,
+body.woocommerce-cart .wc-block-components-quantity-selector__input::-webkit-outer-spin-button,
+body.woocommerce-cart .wc-block-components-quantity-selector__input::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.wp-block-woocommerce-cart .wc-block-components-quantity-selector:focus-within,
+body.woocommerce-cart .wc-block-components-quantity-selector:focus-within {
+  border-color: var(--color-primary);
+  box-shadow: var(--shop-focus-ring);
+}
+
+.woocommerce ul.products,
+.woocommerce-page ul.products {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 3rem 2rem;
+}
+
+.woocommerce ul.products::before,
+.woocommerce ul.products::after,
+.woocommerce-page ul.products::before,
+.woocommerce-page ul.products::after {
+  display: none;
+}
+
+.woocommerce ul.products li.product,
+.woocommerce-page ul.products li.product {
+  float: none;
+  display: flex;
+  flex-direction: column;
+  width: auto;
+  height: 100%;
+  margin: 0;
+}
+
+.woocommerce ul.products li.product a.woocommerce-LoopProduct-link,
+.woocommerce-page ul.products li.product a.woocommerce-LoopProduct-link {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  color: inherit;
+  text-decoration: none;
+}
+
+.woocommerce ul.products li.product a img,
+.woocommerce-page ul.products li.product a img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  margin: 0 0 1.25rem;
+  background: var(--color-surface-alt);
+}
+
+.woocommerce ul.products li.product .woocommerce-loop-product__title,
+.woocommerce-page ul.products li.product .woocommerce-loop-product__title {
+  min-height: 3.2em;
+}
+
+.woocommerce ul.products li.product .price,
+.woocommerce-page ul.products li.product .price {
+  min-height: 1.5em;
+  margin-bottom: 1.2rem;
+}
+
+.woocommerce ul.products li.product .button,
+.woocommerce-page ul.products li.product .button {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: auto;
+  max-width: 100%;
+  margin-top: auto;
+  text-align: center;
+}
+
+.woocommerce ul.products li.product .button.rytkoset-sold-individually-in-cart,
+.woocommerce-page ul.products li.product .button.rytkoset-sold-individually-in-cart {
+  padding-right: 1.15rem;
+  padding-left: 1.15rem;
+}
+
+.woocommerce .rytkoset-shop-select-native,
+.woocommerce-page .rytkoset-shop-select-native {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  overflow: hidden !important;
+  white-space: nowrap !important;
+}
+
+.rytkoset-shop-select {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  font-family: var(--font-body);
+}
+
+.rytkoset-shop-select__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  min-width: min(15rem, calc(100vw - 2rem));
+  min-height: 44px;
+  padding: 0.62rem 1rem;
+  border: 1.5px solid var(--color-border-neutral);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  line-height: 1.25;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.rytkoset-shop-select__trigger:hover {
+  border-color: var(--color-primary-light);
+  background: var(--color-surface-alt);
+}
+
+.rytkoset-shop-select__trigger:focus-visible,
+.rytkoset-shop-select.is-open .rytkoset-shop-select__trigger {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--shop-focus-ring);
+}
+
+.rytkoset-shop-select__prefix {
+  flex: 0 0 auto;
+  color: var(--color-text-mute);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.rytkoset-shop-select__value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rytkoset-shop-select__caret {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+  color: var(--color-text-mute);
+  transition: transform var(--transition-fast);
+}
+
+.rytkoset-shop-select__caret svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.rytkoset-shop-select.is-open .rytkoset-shop-select__caret {
+  transform: rotate(180deg);
+}
+
+.rytkoset-shop-select__menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 50;
+  width: max(100%, 15rem);
+  max-width: calc(100vw - 2rem);
+  max-height: min(19rem, calc(100vh - 8rem));
+  margin: 0;
+  padding: 0.5rem;
+  overflow: auto;
+  list-style: none;
+  border-top: 3px solid var(--color-accent);
+  border-radius: 12px;
+  background: var(--color-surface);
+  box-shadow: var(--shop-popover-shadow);
+}
+
+.rytkoset-shop-select--align-right .rytkoset-shop-select__menu {
+  right: 0;
+  left: auto;
+}
+
+.rytkoset-shop-select__option {
+  display: flex;
+  align-items: center;
+  gap: 0.62rem;
+  min-height: 40px;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--radius-medium);
+  color: var(--color-text);
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.rytkoset-shop-select__option::before {
+  content: "";
+  flex: 0 0 0.9rem;
+  color: var(--color-primary);
+  font-weight: 900;
+}
+
+.rytkoset-shop-select__option:hover,
+.rytkoset-shop-select__option.is-active {
+  background: var(--color-surface-alt);
+}
+
+.rytkoset-shop-select__option.is-selected {
+  background: var(--shop-accent-soft);
+  color: var(--color-primary-deeper);
+  font-weight: 800;
+}
+
+.rytkoset-shop-select__option.is-selected::before {
+  content: "\2713";
+}
+
+.rytkoset-shop-select__option.is-disabled {
+  color: var(--color-text-mute);
+  cursor: not-allowed;
+  opacity: 0.68;
+}
+
+.woocommerce .woocommerce-ordering {
+  position: relative;
+  z-index: 2;
+}
+
+.woocommerce .woocommerce-ordering .rytkoset-shop-select {
+  display: block;
+}
+
+.woocommerce .woocommerce-ordering .rytkoset-shop-select__trigger {
+  min-width: min(16rem, calc(100vw - 2rem));
+}
+
+.woocommerce div.product form.cart .variations select + .rytkoset-shop-select,
+.woocommerce-page div.product form.cart .variations select + .rytkoset-shop-select {
+  width: min(100%, 18rem);
+}
+
+.woocommerce div.product form.cart .variations tr,
+.woocommerce-page div.product form.cart .variations tr {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.woocommerce div.product form.cart .variations th.label,
+.woocommerce-page div.product form.cart .variations th.label {
+  padding-right: 0.5rem;
+}
+
+.woocommerce div.product form.cart .variations .rytkoset-shop-select__trigger,
+.woocommerce-page div.product form.cart .variations .rytkoset-shop-select__trigger {
+  min-height: 44px;
+}
+
+:root[data-theme="dark"] .woocommerce a.button.product_type_variable,
+:root[data-theme="dark"] .woocommerce a.button.product_type_grouped,
+:root[data-theme="dark"] .woocommerce a.button.product_type_external,
+:root[data-theme="dark"] .woocommerce-page a.button.product_type_variable,
+:root[data-theme="dark"] .woocommerce-page a.button.product_type_grouped,
+:root[data-theme="dark"] .woocommerce-page a.button.product_type_external,
+:root[data-theme="dark"] .rytkoset-shop-select__trigger,
+:root[data-theme="dark"] .rytkoset-shop-select__menu {
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+:root[data-theme="dark"] .rytkoset-shop-select__option.is-selected {
+  color: var(--color-text-light);
+}
+
+@media (max-width: 880px) {
+  .woocommerce .woocommerce-ordering,
+  .woocommerce-page .woocommerce-ordering {
+    float: none;
+    width: 100%;
+  }
+
+  .woocommerce .woocommerce-ordering .rytkoset-shop-select,
+  .woocommerce-page .woocommerce-ordering .rytkoset-shop-select {
+    width: 100%;
+  }
+
+  .rytkoset-shop-select__trigger,
+  .woocommerce .woocommerce-ordering .rytkoset-shop-select__trigger {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .rytkoset-shop-select__menu {
+    width: 100%;
+  }
+
+  .woocommerce ul.products,
+  .woocommerce-page ul.products {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2rem 1rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .woocommerce ul.products,
+  .woocommerce-page ul.products {
+    grid-template-columns: 1fr;
+  }
+}

--- a/wp-content/themes/rytkoset-theme/assets/js/shop-select.js
+++ b/wp-content/themes/rytkoset-theme/assets/js/shop-select.js
@@ -1,0 +1,528 @@
+(function () {
+  const SELECTOR = '.woocommerce-ordering select, .variations select';
+  const QUANTITY_SELECTOR = '.woocommerce .quantity input.qty, .woocommerce-page .quantity input.qty';
+  const ADD_TO_CART_SELECTOR = '.add_to_cart_button, .single_add_to_cart_button';
+  let instanceId = 0;
+
+  const focusableKeys = ['ArrowDown', 'ArrowUp', 'Home', 'End'];
+  const shopConfig = window.rytkosetShopConfig || {};
+  const soldIndividuallyCartProductIds = new Set(
+    (shopConfig.soldIndividuallyCartProductIds || []).map((productId) => String(productId))
+  );
+
+  const getOptionLabel = (option) => option.textContent.trim() || option.value;
+
+  const getEnabledOptions = (instance) =>
+    instance.options.filter((option) => option.getAttribute('aria-disabled') !== 'true');
+
+  const setNativeValue = (select, value) => {
+    if (select.value === value) {
+      return;
+    }
+
+    select.value = value;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  };
+
+  const setActiveIndex = (instance, nextIndex) => {
+    const optionCount = instance.options.length;
+
+    if (!optionCount) {
+      return;
+    }
+
+    const clamped = Math.max(0, Math.min(nextIndex, optionCount - 1));
+    instance.activeIndex = clamped;
+    instance.trigger.setAttribute('aria-activedescendant', instance.options[clamped].id);
+
+    instance.options.forEach((option, index) => {
+      option.classList.toggle('is-active', index === clamped);
+    });
+
+    instance.options[clamped].scrollIntoView({ block: 'nearest' });
+  };
+
+  const getSelectedIndex = (instance) => {
+    const index = instance.options.findIndex((option) => option.dataset.value === instance.select.value);
+    return index >= 0 ? index : 0;
+  };
+
+  const closeSelect = (instance, returnFocus = false) => {
+    instance.root.classList.remove('is-open');
+    instance.trigger.setAttribute('aria-expanded', 'false');
+    instance.menu.hidden = true;
+
+    if (returnFocus) {
+      instance.trigger.focus();
+    }
+  };
+
+  const closeAll = (except = null) => {
+    document.querySelectorAll('.rytkoset-shop-select.is-open').forEach((root) => {
+      const instance = root.rytkosetShopSelect;
+
+      if (instance && instance !== except) {
+        closeSelect(instance);
+      }
+    });
+  };
+
+  const updateSelectedState = (instance) => {
+    const selectedOption = instance.select.options[instance.select.selectedIndex];
+    const label = selectedOption ? getOptionLabel(selectedOption) : '';
+
+    instance.value.textContent = label;
+
+    instance.options.forEach((option) => {
+      const isSelected = option.dataset.value === instance.select.value;
+      option.classList.toggle('is-selected', isSelected);
+      option.setAttribute('aria-selected', String(isSelected));
+    });
+  };
+
+  const syncOptionState = (instance) => {
+    instance.options.forEach((option, index) => {
+      const nativeOption = instance.select.options[index];
+
+      if (!nativeOption) {
+        return;
+      }
+
+      option.dataset.value = nativeOption.value;
+      option.textContent = getOptionLabel(nativeOption);
+      option.classList.toggle('is-disabled', nativeOption.disabled);
+
+      if (nativeOption.disabled) {
+        option.setAttribute('aria-disabled', 'true');
+      } else {
+        option.removeAttribute('aria-disabled');
+      }
+    });
+
+    updateSelectedState(instance);
+  };
+
+  const openSelect = (instance) => {
+    syncOptionState(instance);
+    closeAll(instance);
+    instance.root.classList.add('is-open');
+    instance.trigger.setAttribute('aria-expanded', 'true');
+    instance.menu.hidden = false;
+    setActiveIndex(instance, getSelectedIndex(instance));
+  };
+
+  const chooseOption = (instance, option) => {
+    if (!option || option.getAttribute('aria-disabled') === 'true') {
+      return;
+    }
+
+    setNativeValue(instance.select, option.dataset.value);
+    updateSelectedState(instance);
+    closeSelect(instance, true);
+  };
+
+  const moveActive = (instance, direction) => {
+    const enabledOptions = getEnabledOptions(instance);
+
+    if (!enabledOptions.length) {
+      return;
+    }
+
+    const currentOption = instance.options[instance.activeIndex];
+    const enabledIndex = enabledOptions.indexOf(currentOption);
+    const nextEnabledIndex = (enabledIndex + direction + enabledOptions.length) % enabledOptions.length;
+    const nextIndex = instance.options.indexOf(enabledOptions[nextEnabledIndex]);
+
+    setActiveIndex(instance, nextIndex);
+  };
+
+  const buildCustomSelect = (select) => {
+    if (select.dataset.rytkosetShopSelect === 'ready') {
+      return;
+    }
+
+    const id = select.id || `rytkoset-shop-select-${++instanceId}`;
+    select.id = id;
+    select.dataset.rytkosetShopSelect = 'ready';
+    select.classList.add('rytkoset-shop-select-native');
+
+    const root = document.createElement('div');
+    root.className = 'rytkoset-shop-select';
+
+    if (select.closest('.woocommerce-ordering')) {
+      root.classList.add('rytkoset-shop-select--align-right');
+    }
+
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'rytkoset-shop-select__trigger';
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-controls', `${id}-listbox`);
+
+    const prefix = document.createElement('span');
+    prefix.className = 'rytkoset-shop-select__prefix';
+    prefix.textContent = select.closest('.woocommerce-ordering') ? 'Lajittele' : '';
+
+    const value = document.createElement('span');
+    value.className = 'rytkoset-shop-select__value';
+
+    const caret = document.createElement('span');
+    caret.className = 'rytkoset-shop-select__caret';
+    caret.setAttribute('aria-hidden', 'true');
+    caret.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6" /></svg>';
+
+    if (prefix.textContent) {
+      trigger.append(prefix);
+    }
+
+    trigger.append(value, caret);
+
+    const menu = document.createElement('ul');
+    menu.id = `${id}-listbox`;
+    menu.className = 'rytkoset-shop-select__menu';
+    menu.setAttribute('role', 'listbox');
+    menu.hidden = true;
+
+    const options = Array.from(select.options).map((nativeOption, index) => {
+      const option = document.createElement('li');
+      option.id = `${id}-option-${index}`;
+      option.className = 'rytkoset-shop-select__option';
+      option.setAttribute('role', 'option');
+      option.dataset.value = nativeOption.value;
+      option.textContent = getOptionLabel(nativeOption);
+
+      if (nativeOption.disabled) {
+        option.classList.add('is-disabled');
+        option.setAttribute('aria-disabled', 'true');
+      }
+
+      menu.append(option);
+      return option;
+    });
+
+    root.append(trigger, menu);
+    select.insertAdjacentElement('afterend', root);
+
+    const instance = {
+      activeIndex: 0,
+      menu,
+      options,
+      root,
+      select,
+      trigger,
+      value,
+    };
+
+    root.rytkosetShopSelect = instance;
+
+    updateSelectedState(instance);
+
+    trigger.addEventListener('click', () => {
+      if (root.classList.contains('is-open')) {
+        closeSelect(instance);
+      } else {
+        openSelect(instance);
+      }
+    });
+
+    trigger.addEventListener('keydown', (event) => {
+      if (focusableKeys.includes(event.key)) {
+        event.preventDefault();
+
+        if (!root.classList.contains('is-open')) {
+          openSelect(instance);
+        }
+
+        if (event.key === 'ArrowDown') {
+          moveActive(instance, 1);
+        } else if (event.key === 'ArrowUp') {
+          moveActive(instance, -1);
+        } else if (event.key === 'Home') {
+          setActiveIndex(instance, 0);
+        } else if (event.key === 'End') {
+          setActiveIndex(instance, options.length - 1);
+        }
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+
+        if (!root.classList.contains('is-open')) {
+          openSelect(instance);
+          return;
+        }
+
+        chooseOption(instance, options[instance.activeIndex]);
+      }
+
+      if (event.key === 'Escape') {
+        closeSelect(instance, true);
+      }
+
+      if (event.key === 'Tab') {
+        closeSelect(instance);
+      }
+    });
+
+    options.forEach((option, index) => {
+      option.addEventListener('click', () => chooseOption(instance, option));
+      option.addEventListener('mouseenter', () => setActiveIndex(instance, index));
+    });
+
+    select.addEventListener('change', () => updateSelectedState(instance));
+  };
+
+  const initShopSelects = (root = document) => {
+    if (root.matches && root.matches(SELECTOR)) {
+      buildCustomSelect(root);
+    }
+
+    root.querySelectorAll(SELECTOR).forEach(buildCustomSelect);
+  };
+
+  const getPrecision = (value) => {
+    const stringValue = String(value);
+    const dotIndex = stringValue.indexOf('.');
+
+    return dotIndex >= 0 ? stringValue.length - dotIndex - 1 : 0;
+  };
+
+  const getQuantityStep = (input) => {
+    const step = input.getAttribute('step');
+
+    if (!step || step === 'any') {
+      return 1;
+    }
+
+    const parsed = Number.parseFloat(step);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+  };
+
+  const getQuantityBounds = (input) => {
+    const min = Number.parseFloat(input.getAttribute('min'));
+    const max = Number.parseFloat(input.getAttribute('max'));
+
+    return {
+      max: Number.isFinite(max) ? max : null,
+      min: Number.isFinite(min) ? min : 0,
+    };
+  };
+
+  const isFixedSingleQuantity = (input) => {
+    const bounds = getQuantityBounds(input);
+    const value = Number.parseFloat(input.value || input.getAttribute('value') || '1');
+
+    return (
+      input.type === 'hidden' ||
+      input.disabled ||
+      (
+        bounds.max !== null &&
+        bounds.max <= 1 &&
+        Number.isFinite(value) &&
+        value <= 1
+      )
+    );
+  };
+
+  const setQuantityValue = (input, value) => {
+    const step = getQuantityStep(input);
+    const precision = getPrecision(step);
+    const bounds = getQuantityBounds(input);
+    let nextValue = value;
+
+    if (bounds.max !== null) {
+      nextValue = Math.min(nextValue, bounds.max);
+    }
+
+    nextValue = Math.max(nextValue, bounds.min);
+    input.value = precision > 0 ? nextValue.toFixed(precision) : String(Math.round(nextValue));
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  };
+
+  const updateQuantityButtons = (control, input) => {
+    const bounds = getQuantityBounds(input);
+    const value = Number.parseFloat(input.value || '0');
+    const decrease = control.querySelector('[data-quantity-action="decrease"]');
+    const increase = control.querySelector('[data-quantity-action="increase"]');
+
+    if (decrease) {
+      decrease.disabled = Number.isFinite(value) && value <= bounds.min;
+    }
+
+    if (increase && bounds.max !== null) {
+      increase.disabled = Number.isFinite(value) && value >= bounds.max;
+    }
+  };
+
+  const buildQuantityControl = (input) => {
+    if (input.dataset.rytkosetQuantity === 'ready') {
+      return;
+    }
+
+    const quantity = input.closest('.quantity');
+
+    if (!quantity) {
+      return;
+    }
+
+    if (isFixedSingleQuantity(input)) {
+      input.dataset.rytkosetQuantity = 'ready';
+      quantity.classList.add('rytkoset-quantity-is-fixed');
+      return;
+    }
+
+    input.dataset.rytkosetQuantity = 'ready';
+    input.classList.add('rytkoset-quantity__input');
+
+    const control = document.createElement('div');
+    control.className = 'rytkoset-quantity';
+
+    const decrease = document.createElement('button');
+    decrease.type = 'button';
+    decrease.className = 'rytkoset-quantity__button';
+    decrease.dataset.quantityAction = 'decrease';
+    decrease.setAttribute('aria-label', 'V\u00e4henn\u00e4 m\u00e4\u00e4r\u00e4\u00e4');
+    decrease.textContent = '-';
+
+    const increase = document.createElement('button');
+    increase.type = 'button';
+    increase.className = 'rytkoset-quantity__button';
+    increase.dataset.quantityAction = 'increase';
+    increase.setAttribute('aria-label', 'Lis\u00e4\u00e4 m\u00e4\u00e4r\u00e4\u00e4');
+    increase.textContent = '+';
+
+    quantity.insertBefore(control, input);
+    control.append(decrease, input, increase);
+
+    const changeQuantity = (direction) => {
+      const currentValue = Number.parseFloat(input.value || '0');
+      const baseValue = Number.isFinite(currentValue) ? currentValue : getQuantityBounds(input).min;
+      const nextValue = baseValue + direction * getQuantityStep(input);
+
+      setQuantityValue(input, nextValue);
+      updateQuantityButtons(control, input);
+    };
+
+    decrease.addEventListener('click', () => changeQuantity(-1));
+    increase.addEventListener('click', () => changeQuantity(1));
+    input.addEventListener('change', () => updateQuantityButtons(control, input));
+    input.addEventListener('input', () => updateQuantityButtons(control, input));
+    updateQuantityButtons(control, input);
+  };
+
+  const initQuantityControls = (root = document) => {
+    if (root.matches && root.matches(QUANTITY_SELECTOR)) {
+      buildQuantityControl(root);
+    }
+
+    root.querySelectorAll(QUANTITY_SELECTOR).forEach(buildQuantityControl);
+  };
+
+  const getProductIdFromCartButton = (button) => {
+    const dataProductId = button.getAttribute('data-product_id');
+
+    if (dataProductId) {
+      return dataProductId;
+    }
+
+    if (button.name === 'add-to-cart' && button.value) {
+      return button.value;
+    }
+
+    const form = button.closest('form.cart');
+
+    if (!form) {
+      return '';
+    }
+
+    const addToCartField = form.querySelector('[name="add-to-cart"]');
+
+    if (addToCartField && addToCartField.value) {
+      return addToCartField.value;
+    }
+
+    const productIdField = form.querySelector('input[name="product_id"]');
+    return productIdField ? productIdField.value : '';
+  };
+
+  const disableSoldIndividuallyCartButton = (button) => {
+    if (button.dataset.rytkosetSoldIndividuallyDisabled === 'ready') {
+      return;
+    }
+
+    const label = shopConfig.soldIndividuallyInCartText || 'Jo ostoskorissa';
+    button.dataset.rytkosetSoldIndividuallyDisabled = 'ready';
+    button.dataset.rytkosetOriginalText = button.textContent.trim();
+    button.classList.add('disabled', 'rytkoset-sold-individually-in-cart');
+    button.setAttribute('aria-disabled', 'true');
+    button.setAttribute('title', label);
+    button.textContent = label;
+
+    if (button.tagName === 'BUTTON' || button.tagName === 'INPUT') {
+      button.disabled = true;
+    } else {
+      button.dataset.rytkosetOriginalHref = button.getAttribute('href') || '';
+      button.removeAttribute('href');
+      button.setAttribute('tabindex', '-1');
+    }
+  };
+
+  const initSoldIndividuallyCartButtons = (root = document) => {
+    if (!soldIndividuallyCartProductIds.size) {
+      return;
+    }
+
+    const maybeDisable = (button) => {
+      const productId = getProductIdFromCartButton(button);
+
+      if (productId && soldIndividuallyCartProductIds.has(String(productId))) {
+        disableSoldIndividuallyCartButton(button);
+      }
+    };
+
+    if (root.matches && root.matches(ADD_TO_CART_SELECTOR)) {
+      maybeDisable(root);
+    }
+
+    root.querySelectorAll(ADD_TO_CART_SELECTOR).forEach(maybeDisable);
+  };
+
+  document.addEventListener('click', (event) => {
+    const disabledCartButton = event.target.closest('.rytkoset-sold-individually-in-cart');
+
+    if (disabledCartButton) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (!event.target.closest('.rytkoset-shop-select')) {
+      closeAll();
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    initShopSelects();
+    initQuantityControls();
+    initSoldIndividuallyCartButtons();
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            initShopSelects(node);
+            initQuantityControls(node);
+            initSoldIndividuallyCartButtons(node);
+          }
+        });
+      });
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+})();

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -306,6 +306,39 @@ function rytkoset_theme_account_menu_logged_out_fallback() {
 }
 
 /**
+ * Palauttaa korissa jo olevat yksittäin ostettavat WooCommerce-tuotteet.
+ *
+ * @return array<int>
+ */
+function rytkoset_theme_get_sold_individually_cart_product_ids() {
+	if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+		return array();
+	}
+
+	$product_ids = array();
+
+	foreach ( WC()->cart->get_cart() as $cart_item ) {
+		$product_id   = isset( $cart_item['product_id'] ) ? absint( $cart_item['product_id'] ) : 0;
+		$variation_id = isset( $cart_item['variation_id'] ) ? absint( $cart_item['variation_id'] ) : 0;
+		$product      = isset( $cart_item['data'] ) && $cart_item['data'] instanceof WC_Product
+			? $cart_item['data']
+			: null;
+
+		if ( ! $product_id || ! $product || ! $product->is_sold_individually() ) {
+			continue;
+		}
+
+		$product_ids[] = $product_id;
+
+		if ( $variation_id ) {
+			$product_ids[] = $variation_id;
+		}
+	}
+
+	return array_values( array_unique( $product_ids ) );
+}
+
+/**
  * Lataa tyylit ja skriptit.
  */
 function rytkoset_theme_scripts() {
@@ -327,6 +360,37 @@ function rytkoset_theme_scripts() {
         $theme_version,
         true // footer
     );
+
+	if (
+		function_exists( 'is_woocommerce' )
+		&& ( is_woocommerce() || is_cart() || is_checkout() )
+	) {
+		wp_enqueue_style(
+			'rytkoset-theme-shop',
+			get_template_directory_uri() . '/assets/css/shop.css',
+			array( 'rytkoset-theme-style' ),
+			$theme_version
+		);
+
+		wp_enqueue_script(
+			'rytkoset-theme-shop-select',
+			get_template_directory_uri() . '/assets/js/shop-select.js',
+			array(),
+			$theme_version,
+			true
+		);
+
+		wp_add_inline_script(
+			'rytkoset-theme-shop-select',
+			'window.rytkosetShopConfig = ' . wp_json_encode(
+				array(
+					'soldIndividuallyCartProductIds' => rytkoset_theme_get_sold_individually_cart_product_ids(),
+					'soldIndividuallyInCartText'    => __( 'Jo ostoskorissa', 'rytkoset-theme' ),
+				)
+			) . ';',
+			'before'
+		);
+	}
 
 	if ( is_post_type_archive( 'digital_magazine' ) || is_singular( 'digital_magazine' ) ) {
 		wp_enqueue_style(


### PR DESCRIPTION
## Summary
- Lisätään WooCommerce-kauppaan brändin mukaiset painike-, tuotekortti- ja valitsintyylit.
- Korvataan kaupan lajittelu- ja tuotesivun variaatiovalitsimet saavutettavalla custom select -komponentilla.
- Yhdenmukaistetaan määrävalitsimet ja piilotetaan ne tuotteilta, joita voi ostaa vain yhden kappaleen.
- Estetään yksittäin ostettavan tuotteen uudelleenlisäys, jos se on jo ostoskorissa.
- Päivitetään globaalien keltaisten nappien pystypadding teemavalitsimen mittaan.

## Changes
- Uusi `shop.css` WooCommerce-sivujen tyyleille.
- Uusi `shop-select.js` custom selecteille, määrävalitsimille ja “Jo ostoskorissa” -tilalle.
- WooCommerce shop -assetit jonotetaan vain WooCommerce-, ostoskori- ja kassasivuilla.
- Tuotelistauksen kortit saivat kevyen reunuksen/varjon ja vakaamman AJAX add-to-cart -tilan.
- `CHANGELOG.md` päivitetty.

## Testing
- `node --check wp-content/themes/rytkoset-theme/assets/js/shop-select.js`
- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/functions.php`
- Visuaalista palautetta iteroitu paikallisista `/kauppa/`, tuotesivu- ja ostoskorinäkymistä.