### PR TITLE
fix(login): korjaa kirjautumissivun asettelu ja Rekisteröidy-napin koko

### DIFF
--- a/wp-content/themes/rytkoset-theme/assets/css/login.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/login.css
@@ -317,6 +317,13 @@ body.login .privacy-policy-link:hover {
   color: var(--color-accent);
 }
 
+/* Pidetään #login keskitettynä vaikka plugin/WordPress injektoisi body-lapsia */
+body.login > *:not(#login) {
+  position: absolute;
+  left: -9999px;
+  visibility: hidden;
+}
+
 @media (max-width: 480px) {
   body.login {
     padding: 1.5rem 1rem;

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.account.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.account.css
@@ -20,12 +20,16 @@
 }
 
 .account-nav__list > li > a {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
   min-height: 36px;
   padding: 0.45rem 0.4rem;
   border-radius: 6px;
   color: var(--color-text-inverted);
   font-size: 0.875rem;
   font-weight: 700;
+  line-height: 1;
   text-decoration: none;
   white-space: nowrap;
 }
@@ -38,12 +42,15 @@
 }
 
 .account-nav__list > li + li:last-child > a {
+  display: inline-flex;
+  align-items: center;
   min-height: 36px;
   padding: 0.45rem 1rem;
   border-radius: var(--radius-pill);
   background: var(--color-accent);
   color: var(--color-primary-deeper);
   font-weight: 800;
+  line-height: 1;
   text-decoration: none;
   box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.92);
   transition: background var(--transition-hover), transform var(--transition-hover), box-shadow var(--transition-hover);

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.desktop.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.desktop.css
@@ -57,8 +57,7 @@
   position: relative;
 }
 
-.site-nav__list > li > a,
-.account-nav__list > li > a {
+.site-nav__list > li > a {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;

--- a/wp-content/themes/rytkoset-theme/inc/login.php
+++ b/wp-content/themes/rytkoset-theme/inc/login.php
@@ -173,6 +173,11 @@ function rytkoset_theme_login_finnish_strings( $translated, $original, $domain )
 add_filter( 'gettext', 'rytkoset_theme_login_finnish_strings', 10, 3 );
 
 /**
+ * Piilotetaan WordPressin sisäinen kielenvalitsin — sivusto on suomenkielinen.
+ */
+add_filter( 'login_display_language_dropdown', '__return_false' );
+
+/**
  * Varmistetaan, että back-linkki on suomeksi, vaikka gettext ei osuisi.
  */
 function rytkoset_theme_login_backlink_text() {


### PR DESCRIPTION
## Yhteenveto

- Korjaa Rekisteröidy-napin korkeus utility-barissa: poistettu `.account-nav__list > li > a` `nav.desktop.css`:n kombinoidusta selektorista, joka asetti `min-height: 44px` (päänavin arvo) myös utility-baarin napille. Account-nav käyttää nyt vain omia tyylejään (`min-height: 36px`, `line-height: 1`, `display: inline-flex`), jolloin Rekisteröidy-nappi vastaa Vaalea-teemavalitsimen kokoa.
- Korjaa kirjautumis- ja rekisteröintisivun asettelu: WordPressin kielenvalitsinlomake injektoitiin `body.login`-elementin suoraksi lapseksi `#login`:in rinnalle, jolloin flexbox asetti ne vierekkäin ja lomake siirtyi vasemmalle. Poistettu kielenvalitsin PHP-filterillä (`login_display_language_dropdown`) — sivusto on suomenkielinen, joten valitsin on tarpeeton. Lisätty myös CSS-varmuusratkaisu mahdollisille tuleville body-tason injektioille.

## Testausohje

- [ ] Utility-barin Rekisteröidy-nappi on saman korkuinen kuin Vaalea-teemavalitsin
- [ ] Kirjautumissivu (`/wp-login.php`) on keskitetty oikein, ei kielenvalitsinta
- [ ] Rekisteröitymissivu (`/wp-login.php?action=register`) on keskitetty oikein
- [ ] Salasanan palautussivu toimii normaalisti
- [ ] Kirjautunut käyttäjä: tilivalikko toimii edelleen normaalisti