### PR TITLE
fix(events): prevent duplicate registrations and enforce deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- Maksuttomille tapahtumille oma ilmoittautumisen määräpäivä, jolla julkinen lomake sulkeutuu automaattisesti
 - Dokumentaatio tietosuojaselosteen julkaisusta ja suomenkielinen seloste-pohja: `docs/tietosuoja.md`
 - Tapahtumailmoittautumisen GDPR-tekstiin automaattinen linkki tietosuojaselosteeseen, kun sivu on asetettu WP:n tietosuojasivuksi
 - Dokumentaatio tapahtumakokonaisuuden toteutuksesta, käyttöönotosta ja ylläpidon toimintamallista: `docs/events.md`
@@ -18,9 +19,12 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerce-kaupan brändin mukaiset alasvetovalikko- ja painiketyylit.
 
 ### Changed
+- Tapahtuman yhteenvetokortti piilottaa ilmoittautumisen määräpäivän menneiltä tapahtumilta ja käyttää mennyttä aikamuotoa määräpäivän jälkeen.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.
 
 ### Fixed
+- Tapahtumailmoittautuminen estää aktiiviset kaksoisilmoittautumiset samalla sähköpostilla ja huomioi ilmoittautumisajan päättymisen
+- Maksuttoman tapahtuman ilmoittautumislomake ei enää renderöidy kahteen kertaan
 - Albumisivujen PhotoSwipe-lightbox käyttää nyt teeman omaa PhotoSwipe 5 -pakettia ilman WooCommercen legacy-konfliktia
 - Albumisivujen YouTube-upotukset eivät käynnisty automaattisesti
 - Albumisivujen YouTube-upotukset käyttävät privacy-enhanced `youtube-nocookie.com` -osoitetta

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,10 @@ Use CSS variables for colors and spacing. No Bootstrap dependency.
   - `_rytkoset_event_location` — location
   - `_rytkoset_event_fee_type` — `free` | `paid`
   - `_rytkoset_event_price_text` — price text for display
+  - `_rytkoset_event_registration_deadline` — free event registration deadline `YYYY-MM-DD`; empty falls back to event date for the public form cutoff
+  - `_rytkoset_event_product_id` — linked WooCommerce product for paid registration/payment
+
+Free event registration forms close after the event registration deadline. Paid event pages read the deadline and availability state from the linked WooCommerce product instead of duplicating that data on the event.
 
 ### Gallery Album (`gallery_album`)
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -59,6 +59,7 @@ Tapahtuman lisätiedot tallennetaan WordPressin post metaan:
 | Paikka             | `_rytkoset_event_location`   | vapaa teksti                         | Julkinen tapahtumatieto                   |
 | Maksullisuus       | `_rytkoset_event_fee_type`   | `free`, `paid` tai tyhjä             | Julkinen hintatieto                       |
 | Hintateksti        | `_rytkoset_event_price_text` | vapaa teksti, esim. `49 € / henkilö` | Julkinen hintatieto                       |
+| Ilmoittautumisen määräpäivä | `_rytkoset_event_registration_deadline` | `YYYY-MM-DD` | Maksuttoman tapahtuman lomakkeen sulkeminen |
 | Maksutuote         | `_rytkoset_event_product_id` | WooCommerce-tuotteen ID              | Linkki ilmoittautumis-/maksutuotteeseen   |
 
 Tallennuksessa tarkistetaan nonce, käyttäjän `edit_post`-oikeus ja kenttäkohtaiset muodot. Tyhjä kenttä poistaa vastaavan metatiedon.
@@ -85,7 +86,7 @@ Yksittäisellä tapahtumasivulla näytetään:
 
 - tapahtuman artikkelikuva ja otsikko
 - editoriin kirjoitettu sisältö
-- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi eikä siihen ole linkitetty maksutuotetta — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38); onnistumisen jälkeen lomake korvataan vahvistusosiolla, joka näyttää tapahtuman tiedot (#32)
+- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi, siihen ei ole linkitetty maksutuotetta ja ilmoittautumisen määräpäivää ei ole ohitettu — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38); onnistumisen jälkeen lomake korvataan vahvistusosiolla, joka näyttää tapahtuman tiedot (#32)
 - sivupalkin yhteenvetokortti, jos tapahtumalla on perustietoja tai maksutuote
 - jakopainikkeet
 
@@ -95,7 +96,10 @@ Yhteenvetokortissa näytetään täytetyt perustiedot:
 - kellonaika tai aikaväli
 - paikka
 - hinta
+- ilmoittautumisen määräpäivä, jos sellainen voidaan päätellä tapahtumalta tai linkitetyltä tuotteelta ja tapahtumapäivä ei ole vielä mennyt; määräpäivän jälkeen mutta ennen tapahtumaa tekstinä on `Ilmoittautuminen päättyi`
 - `Ilmoittaudu ja maksa` -painike, jos tapahtumaan on linkitetty maksutuote
+
+Jos linkitetyn WooCommerce-tuotteen ilmoittautuminen on päättynyt tai tuote ei muuten ole ostettavissa, tapahtumasivu näyttää tilaviestinä syyn eikä tarjoa aktiivista maksupainiketta.
 
 Tapahtuma-arkistossa `/tapahtumat/` tapahtumat jaetaan kolmeen osioon:
 
@@ -119,9 +123,10 @@ Tulevat tapahtumat näytetään lähimmästä tulevasta tapahtumasta alkaen. Men
    - paikka
    - maksullisuus
    - hintateksti
-8. Jos tapahtumaan liittyy ilmoittautuminen tai maksu, valitse sivupalkin `Maksutuote`-laatikosta oikea WooCommerce-tuote.
-9. Julkaise tai päivitä tapahtuma.
-10. Tarkista julkinen tapahtumasivu ja tapahtuma-arkisto.
+8. Jos maksuton tapahtuma käyttää lomakeilmoittautumista, täytä sivupalkin `Tapahtumapäivä`-laatikosta `Maksuttoman ilmoittautumisen määräpäivä`.
+9. Jos tapahtumaan liittyy ilmoittautuminen tai maksu, valitse sivupalkin `Maksutuote`-laatikosta oikea WooCommerce-tuote.
+10. Julkaise tai päivitä tapahtuma.
+11. Tarkista julkinen tapahtumasivu ja tapahtuma-arkisto.
 
 ### Suositeltu minimitieto
 
@@ -144,7 +149,7 @@ Maksulliselle tapahtumalle kannattaa lisäksi täyttää:
 
 Ilmaisten tapahtumien ilmoittautumiset tallennetaan `event_registration`-sisältötyyppiin. Ylläpitäjä voi luoda ja muokata ilmoittautumisia käsin WordPress-adminissa kohdassa `Tapahtumat > Ilmoittautumiset`.
 
-Julkinen ilmoittautumislomake näkyy maksuttomissa tapahtumissa, jos tapahtumaan ei ole linkitetty WooCommerce-maksutuotetta. Lomake tarkistaa noncen, tapahtuman, nimen ja sähköpostiosoitteen ennen tallennusta. Uudet ilmoittautumiset tallentuvat aluksi tilaan `pending`, jotta ylläpitäjä voi käsitellä ne adminissa.
+Julkinen ilmoittautumislomake näkyy maksuttomissa tapahtumissa, jos tapahtumaan ei ole linkitetty WooCommerce-maksutuotetta ja ilmoittautumisen määräpäivä ei ole ohitettu. Jos määräpäivä on tyhjä, lomake sulkeutuu tapahtumapäivän jälkeen. Lomake tarkistaa noncen, tapahtuman, nimen, sähköpostiosoitteen ja GDPR-hyväksynnän ennen tallennusta. Sama sähköpostiosoite voi luoda vain yhden aktiivisen (`pending` tai `confirmed`) ilmoittautumisen samaan tapahtumaan; `cancelled`-tilainen ilmoittautuminen sallii uuden ilmoittautumisen. Uudet ilmoittautumiset tallentuvat aluksi tilaan `pending`, jotta ylläpitäjä voi käsitellä ne adminissa.
 
 Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkitetty maksutuote:
 
@@ -153,6 +158,8 @@ Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkit
 3. tapahtumasivulle tulee `Ilmoittaudu ja maksa` -painike
 4. käyttäjä siirtyy WooCommerce-tuotesivulle ja ostaa tuotteen
 5. ilmoittautumistiedot tallentuvat WooCommerce-tilaukselle
+
+Maksullisen tapahtuman ilmoittautumisen määräpäivä luetaan linkitetyltä WooCommerce-tuotteelta, kun tuotteella on tapahtumailmoittautumisen oma deadline-logiikka. Tapahtumaan ei tallenneta samaa deadlinea erikseen, jotta tuotteen ostettavuus ja tapahtumasivun viesti eivät eriydy.
 
 Tapahtuman ja WooCommerce-tuotteen välinen linkitys on dokumentoitu tarkemmin tiedostossa `docs/woocommerce-event-product-link.md`.
 

--- a/docs/woocommerce-event-product-link.md
+++ b/docs/woocommerce-event-product-link.md
@@ -29,6 +29,8 @@ Kun tapahtumalle on valittu maksutuote, tapahtumasivulla näkyy painike:
 
 Painike vie WooCommerce-tuotteen julkiselle tuotesivulle. Se ei lisää tuotetta automaattisesti ostoskoriin eikä ohjaa suoraan kassalle.
 
+Jos linkitetty tuote ei ole ostettavissa, tapahtumasivulla ei näytetä aktiivista maksupainiketta. Esimerkiksi Tampere 2026 -tuotteen ilmoittautumisen määräpäivä luetaan suoraan tuotteelta, jolloin tapahtumasivu voi näyttää viestin `Ilmoittautuminen on päättynyt.` ilman että sama deadline tallennetaan tapahtumalle erikseen.
+
 ## Rajaus
 
 Tässä vaiheessa toteutetaan vain linkitys yhteen WooCommerce-tuotteeseen.
@@ -41,4 +43,4 @@ Ei toteuteta vielä:
 - tapahtumakohtaista kapasiteettilogiikkaa
 - lippuja tai QR-koodeja
 
-Tampere 2026 -tuotteen määräpäivä ja kapasiteetti hallitaan edelleen WooCommerce-tuotteen omilla asetuksilla.
+Tampere 2026 -tuotteen määräpäivä ja kapasiteetti hallitaan edelleen WooCommerce-tuotteen omilla asetuksilla. Tapahtuma lukee näitä tietoja vain julkisen tapahtumasivun näyttöä varten.

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -602,6 +602,17 @@
   border-top: 1px solid var(--color-border-neutral);
 }
 
+.event-summary-card__notice,
+.event-product-cta__notice {
+  margin: 1.1rem 0 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-small);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-weight: 700;
+}
+
 .event-summary-card__button {
   box-sizing: border-box;
   width: 100%;

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -467,7 +467,64 @@ function rytkoset_theme_event_can_show_free_registration_form( $event_id ) {
 		return false;
 	}
 
+	if (
+		function_exists( 'rytkoset_theme_is_event_registration_deadline_passed' )
+		&& rytkoset_theme_is_event_registration_deadline_passed( $event_id )
+	) {
+		return false;
+	}
+
 	return true;
+}
+
+/**
+ * Checks whether an active registration already exists for an event email.
+ *
+ * Cancelled registrations are intentionally ignored so a cancelled participant
+ * can register again.
+ *
+ * @param int    $event_id Event post ID.
+ * @param string $email    Registration email.
+ * @return bool
+ */
+function rytkoset_theme_event_has_active_registration_for_email( $event_id, $email ) {
+	$event_id = absint( $event_id );
+	$email    = sanitize_email( $email );
+
+	if ( $event_id <= 0 || '' === $email ) {
+		return false;
+	}
+
+	$meta_keys = rytkoset_theme_get_event_registration_meta_keys();
+	$existing  = get_posts(
+		array(
+			'post_type'              => 'event_registration',
+			'post_status'            => array( 'publish', 'future', 'draft', 'pending', 'private' ),
+			'posts_per_page'         => 1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			'meta_query'             => array(
+				'relation' => 'AND',
+				array(
+					'key'   => $meta_keys['event_id'],
+					'value' => $event_id,
+				),
+				array(
+					'key'   => $meta_keys['email'],
+					'value' => $email,
+				),
+				array(
+					'key'     => $meta_keys['status'],
+					'value'   => array( 'pending', 'confirmed' ),
+					'compare' => 'IN',
+				),
+			),
+		)
+	);
+
+	return ! empty( $existing );
 }
 
 /**
@@ -524,6 +581,10 @@ function rytkoset_theme_handle_event_registration_submission() {
 		rytkoset_theme_handle_event_registration_error( $event_id, 'missing_consent' );
 	}
 
+	if ( rytkoset_theme_event_has_active_registration_for_email( $event_id, $email ) ) {
+		rytkoset_theme_handle_event_registration_error( $event_id, 'already_registered' );
+	}
+
 	$meta_keys       = rytkoset_theme_get_event_registration_meta_keys();
 	$registration_id = wp_insert_post(
 		array(
@@ -576,7 +637,8 @@ function rytkoset_theme_get_event_registration_feedback() {
 	$messages = array(
 		'missing_name'    => __( 'Tarkista ilmoittautumisen tiedot. Nimi on pakollinen.', 'rytkoset-theme' ),
 		'invalid_email'   => __( 'Tarkista ilmoittautumisen tiedot. Sähköpostiosoite ei ole kelvollinen.', 'rytkoset-theme' ),
-		'missing_consent' => __( 'Hyväksy tietosuojakäytäntö ennen lomakkeen lähettämistä.', 'rytkoset-theme' ),
+		'missing_consent'    => __( 'Hyväksy tietosuojakäytäntö ennen lomakkeen lähettämistä.', 'rytkoset-theme' ),
+		'already_registered' => __( 'Tällä sähköpostiosoitteella on jo aktiivinen ilmoittautuminen tähän tapahtumaan.', 'rytkoset-theme' ),
 	);
 
 	return array(

--- a/wp-content/themes/rytkoset-theme/inc/events.php
+++ b/wp-content/themes/rytkoset-theme/inc/events.php
@@ -114,6 +114,89 @@ function rytkoset_theme_get_event_date_display( $event_id ) {
 }
 
 /**
+ * Returns the meta key used for free event registration deadlines.
+ *
+ * @return string
+ */
+function rytkoset_theme_get_event_registration_deadline_meta_key() {
+	return '_rytkoset_event_registration_deadline';
+}
+
+/**
+ * Normalizes an event registration deadline date into YYYY-MM-DD format.
+ *
+ * @param string $raw_date Raw date value.
+ * @return string
+ */
+function rytkoset_theme_normalize_event_registration_deadline_date( $raw_date ) {
+	$raw_date = trim( (string) $raw_date );
+
+	if ( '' === $raw_date ) {
+		return '';
+	}
+
+	$date = DateTimeImmutable::createFromFormat( '!Y-m-d', $raw_date, wp_timezone() );
+
+	if ( ! $date ) {
+		return '';
+	}
+
+	return $date->format( 'Y-m-d' );
+}
+
+/**
+ * Returns the stored free event registration deadline.
+ *
+ * @param int $event_id Event post ID.
+ * @return string
+ */
+function rytkoset_theme_get_free_event_registration_deadline_raw( $event_id ) {
+	$deadline = get_post_meta( $event_id, rytkoset_theme_get_event_registration_deadline_meta_key(), true );
+
+	return rytkoset_theme_normalize_event_registration_deadline_date( is_scalar( $deadline ) ? (string) $deadline : '' );
+}
+
+/**
+ * Returns the cutoff datetime for a YYYY-MM-DD deadline.
+ *
+ * The registration remains open until the end of the configured day.
+ *
+ * @param string $deadline Deadline date.
+ * @return DateTimeImmutable|null
+ */
+function rytkoset_theme_get_registration_deadline_cutoff_from_date( $deadline ) {
+	$deadline = rytkoset_theme_normalize_event_registration_deadline_date( $deadline );
+
+	if ( '' === $deadline ) {
+		return null;
+	}
+
+	$date = DateTimeImmutable::createFromFormat( '!Y-m-d', $deadline, wp_timezone() );
+
+	if ( ! $date ) {
+		return null;
+	}
+
+	return $date->modify( '+1 day' )->setTime( 0, 0, 0 );
+}
+
+/**
+ * Checks whether the event date has passed.
+ *
+ * @param int $event_id Event post ID.
+ * @return bool
+ */
+function rytkoset_theme_is_event_date_passed( $event_id ) {
+	$cutoff = rytkoset_theme_get_registration_deadline_cutoff_from_date( rytkoset_theme_get_event_date_raw( $event_id ) );
+
+	if ( ! $cutoff instanceof DateTimeImmutable ) {
+		return false;
+	}
+
+	return current_datetime() >= $cutoff;
+}
+
+/**
  * Returns meta keys used for event details.
  *
  * @return array
@@ -282,6 +365,7 @@ function rytkoset_theme_get_event_detail_items( $event_id ) {
 	$time_display = rytkoset_theme_get_event_time_display( $event_id );
 	$location     = rytkoset_theme_get_event_location( $event_id );
 	$fee_display  = rytkoset_theme_get_event_fee_display( $event_id );
+	$deadline     = rytkoset_theme_get_event_registration_deadline_display( $event_id );
 
 	if ( '' !== $date_display ) {
 		$items[] = array(
@@ -309,6 +393,14 @@ function rytkoset_theme_get_event_detail_items( $event_id ) {
 		$items[] = array(
 			'label' => __( 'Hinta', 'rytkoset-theme' ),
 			'value' => $fee_display,
+		);
+	}
+
+	if ( '' !== $deadline['value'] ) {
+		$items[] = array(
+			'label'    => $deadline['label'],
+			'value'    => $deadline['value'],
+			'datetime' => $deadline['datetime'],
 		);
 	}
 
@@ -365,7 +457,8 @@ add_action( 'add_meta_boxes_rytkoset_event', 'rytkoset_theme_register_event_date
  * @param WP_Post $post Event post object.
  */
 function rytkoset_theme_render_event_date_metabox( $post ) {
-	$date = rytkoset_theme_get_event_date_raw( $post->ID );
+	$date                  = rytkoset_theme_get_event_date_raw( $post->ID );
+	$registration_deadline = rytkoset_theme_get_free_event_registration_deadline_raw( $post->ID );
 
 	wp_nonce_field( 'rytkoset_save_event_date', 'rytkoset_event_date_nonce' );
 	?>
@@ -383,6 +476,22 @@ function rytkoset_theme_render_event_date_metabox( $post ) {
 	/>
 	<p class="description">
 		<?php esc_html_e( 'Käytetään tapahtuma-arkiston järjestämiseen. Muoto tallennuksessa on YYYY-MM-DD.', 'rytkoset-theme' ); ?>
+	</p>
+	<hr />
+	<p>
+		<label for="rytkoset_event_registration_deadline">
+			<?php esc_html_e( 'Maksuttoman ilmoittautumisen määräpäivä', 'rytkoset-theme' ); ?>
+		</label>
+	</p>
+	<input
+		type="date"
+		id="rytkoset_event_registration_deadline"
+		name="rytkoset_event_registration_deadline"
+		value="<?php echo esc_attr( $registration_deadline ); ?>"
+		class="widefat"
+	/>
+	<p class="description">
+		<?php esc_html_e( 'Koskee maksuttomia lomakeilmoittautumisia. Jos kenttä on tyhjä, lomake sulkeutuu tapahtumapäivän jälkeen.', 'rytkoset-theme' ); ?>
 	</p>
 	<?php
 }
@@ -418,6 +527,20 @@ function rytkoset_theme_save_event_date( $post_id ) {
 	$date = isset( $_POST['rytkoset_event_date'] )
 		? sanitize_text_field( wp_unslash( $_POST['rytkoset_event_date'] ) )
 		: '';
+
+	$registration_deadline = isset( $_POST['rytkoset_event_registration_deadline'] )
+		? sanitize_text_field( wp_unslash( $_POST['rytkoset_event_registration_deadline'] ) )
+		: '';
+
+	if ( '' === $registration_deadline ) {
+		delete_post_meta( $post_id, rytkoset_theme_get_event_registration_deadline_meta_key() );
+	} else {
+		$registration_deadline = rytkoset_theme_normalize_event_registration_deadline_date( $registration_deadline );
+
+		if ( '' !== $registration_deadline ) {
+			update_post_meta( $post_id, rytkoset_theme_get_event_registration_deadline_meta_key(), $registration_deadline );
+		}
+	}
 
 	if ( '' === $date ) {
 		delete_post_meta( $post_id, rytkoset_theme_get_event_date_meta_key() );
@@ -695,6 +818,7 @@ function rytkoset_theme_print_event_admin_styles() {
 	?>
 	<style>
 		#rytkoset_event_date_field,
+		#rytkoset_event_registration_deadline,
 		#rytkoset_event_product_id,
 		#rytkoset_event_start_time,
 		#rytkoset_event_end_time,
@@ -943,21 +1067,155 @@ function rytkoset_theme_get_event_product_url( $event_id ) {
 }
 
 /**
+ * Returns the registration deadline stored on a linked WooCommerce product.
+ *
+ * @param WC_Product|null $product WooCommerce product object.
+ * @return string
+ */
+function rytkoset_theme_get_event_product_registration_deadline( $product ) {
+	if (
+		! class_exists( 'WC_Product' )
+		|| ! $product instanceof WC_Product
+		|| ! function_exists( 'rytkoset_theme_get_tampere_2026_registration_deadline' )
+		|| ! function_exists( 'rytkoset_theme_is_tampere_2026_registration_product' )
+		|| ! rytkoset_theme_is_tampere_2026_registration_product( $product )
+	) {
+		return '';
+	}
+
+	return rytkoset_theme_get_tampere_2026_registration_deadline( $product );
+}
+
+/**
+ * Returns the registration deadline date used on the event page.
+ *
+ * Paid events read the deadline from the linked product. Free events read the
+ * event meta and fall back to the event date.
+ *
+ * @param int $event_id Event post ID.
+ * @return string
+ */
+function rytkoset_theme_get_event_registration_deadline_raw( $event_id ) {
+	$product = rytkoset_theme_get_event_linked_product( $event_id );
+
+	if ( class_exists( 'WC_Product' ) && $product instanceof WC_Product ) {
+		return rytkoset_theme_get_event_product_registration_deadline( $product );
+	}
+
+	if ( 'free' !== rytkoset_theme_get_event_fee_type( $event_id ) ) {
+		return '';
+	}
+
+	$deadline = rytkoset_theme_get_free_event_registration_deadline_raw( $event_id );
+
+	if ( '' !== $deadline ) {
+		return $deadline;
+	}
+
+	return rytkoset_theme_get_event_date_raw( $event_id );
+}
+
+/**
+ * Returns a display-ready event registration deadline.
+ *
+ * @param int $event_id Event post ID.
+ * @return array
+ */
+function rytkoset_theme_get_event_registration_deadline_display( $event_id ) {
+	$deadline = rytkoset_theme_get_event_registration_deadline_raw( $event_id );
+
+	if ( '' === $deadline || rytkoset_theme_is_event_date_passed( $event_id ) ) {
+		return array(
+			'label'    => '',
+			'value'    => '',
+			'datetime' => '',
+		);
+	}
+
+	$date = DateTimeImmutable::createFromFormat( '!Y-m-d', $deadline, wp_timezone() );
+
+	if ( ! $date ) {
+		return array(
+			'label'    => '',
+			'value'    => '',
+			'datetime' => '',
+		);
+	}
+
+	return array(
+		'label'    => rytkoset_theme_is_event_registration_deadline_passed( $event_id )
+			? __( 'Ilmoittautuminen päättyi', 'rytkoset-theme' )
+			: __( 'Ilmoittautuminen päättyy', 'rytkoset-theme' ),
+		'value'    => wp_date( get_option( 'date_format' ), $date->getTimestamp() ),
+		'datetime' => $deadline,
+	);
+}
+
+/**
+ * Checks whether the event registration deadline has passed.
+ *
+ * @param int $event_id Event post ID.
+ * @return bool
+ */
+function rytkoset_theme_is_event_registration_deadline_passed( $event_id ) {
+	$cutoff = rytkoset_theme_get_registration_deadline_cutoff_from_date( rytkoset_theme_get_event_registration_deadline_raw( $event_id ) );
+
+	if ( ! $cutoff instanceof DateTimeImmutable ) {
+		return false;
+	}
+
+	return current_datetime() >= $cutoff;
+}
+
+/**
+ * Returns the linked product unavailability message for an event.
+ *
+ * @param int $event_id Event post ID.
+ * @return string
+ */
+function rytkoset_theme_get_event_product_unavailability_message( $event_id ) {
+	$product = rytkoset_theme_get_event_linked_product( $event_id );
+
+	if ( ! class_exists( 'WC_Product' ) || ! $product instanceof WC_Product ) {
+		return '';
+	}
+
+	if ( function_exists( 'rytkoset_theme_get_tampere_2026_registration_unavailability_message' ) ) {
+		$message = rytkoset_theme_get_tampere_2026_registration_unavailability_message( $product );
+
+		if ( '' !== $message ) {
+			return $message;
+		}
+	}
+
+	if ( ! $product->is_purchasable() ) {
+		return __( 'Ilmoittautuminen ei ole tällä hetkellä avoinna.', 'rytkoset-theme' );
+	}
+
+	return '';
+}
+
+/**
  * Renders the linked product CTA for an event.
  *
  * @param int $event_id Event post ID.
  */
 function rytkoset_theme_render_event_product_cta( $event_id ) {
 	$product_url = rytkoset_theme_get_event_product_url( $event_id );
+	$message     = rytkoset_theme_get_event_product_unavailability_message( $event_id );
 
-	if ( ! $product_url ) {
+	if ( ! $product_url && '' === $message ) {
 		return;
 	}
 	?>
 	<div class="event-product-cta">
-		<a class="btn btn--primary" href="<?php echo esc_url( $product_url ); ?>">
-			<?php esc_html_e( 'Ilmoittaudu ja maksa', 'rytkoset-theme' ); ?>
-		</a>
+		<?php if ( '' !== $message ) : ?>
+			<p class="event-product-cta__notice"><?php echo esc_html( $message ); ?></p>
+		<?php else : ?>
+			<a class="btn btn--primary" href="<?php echo esc_url( $product_url ); ?>">
+				<?php esc_html_e( 'Ilmoittaudu ja maksa', 'rytkoset-theme' ); ?>
+			</a>
+		<?php endif; ?>
 	</div>
 	<?php
 }
@@ -969,8 +1227,11 @@ function rytkoset_theme_render_event_product_cta( $event_id ) {
  * @return bool
  */
 function rytkoset_theme_event_has_summary_card( $event_id ) {
+	$product_message = rytkoset_theme_get_event_product_unavailability_message( $event_id );
+
 	return ! empty( rytkoset_theme_get_event_detail_items( $event_id ) )
-		|| '' !== rytkoset_theme_get_event_product_url( $event_id );
+		|| '' !== rytkoset_theme_get_event_product_url( $event_id )
+		|| '' !== $product_message;
 }
 
 /**
@@ -979,10 +1240,11 @@ function rytkoset_theme_event_has_summary_card( $event_id ) {
  * @param int $event_id Event post ID.
  */
 function rytkoset_theme_render_event_summary_card( $event_id ) {
-	$items       = rytkoset_theme_get_event_detail_items( $event_id );
-	$product_url = rytkoset_theme_get_event_product_url( $event_id );
+	$items           = rytkoset_theme_get_event_detail_items( $event_id );
+	$product_url     = rytkoset_theme_get_event_product_url( $event_id );
+	$product_message = rytkoset_theme_get_event_product_unavailability_message( $event_id );
 
-	if ( empty( $items ) && '' === $product_url ) {
+	if ( empty( $items ) && '' === $product_url && '' === $product_message ) {
 		return;
 	}
 
@@ -1010,7 +1272,9 @@ function rytkoset_theme_render_event_summary_card( $event_id ) {
 			</dl>
 		<?php endif; ?>
 
-		<?php if ( '' !== $product_url ) : ?>
+		<?php if ( '' !== $product_message ) : ?>
+			<p class="event-summary-card__notice"><?php echo esc_html( $product_message ); ?></p>
+		<?php elseif ( '' !== $product_url ) : ?>
 			<div class="event-summary-card__cta">
 				<a class="btn btn--primary event-summary-card__button" href="<?php echo esc_url( $product_url ); ?>">
 					<?php esc_html_e( 'Ilmoittaudu ja maksa', 'rytkoset-theme' ); ?>

--- a/wp-content/themes/rytkoset-theme/single-rytkoset_event.php
+++ b/wp-content/themes/rytkoset-theme/single-rytkoset_event.php
@@ -62,12 +62,6 @@ if ( have_posts() ) :
 							<?php rytkoset_theme_render_free_event_registration_form( $event_id ); ?>
 
 							<?php
-							if ( function_exists( 'rytkoset_theme_render_free_event_registration_form' ) ) {
-								rytkoset_theme_render_free_event_registration_form( $event_id );
-							}
-							?>
-
-							<?php
 							rytkoset_theme_share_buttons(
 								array(
 									'heading' => __( 'Jaa tapahtuma', 'rytkoset-theme' ),


### PR DESCRIPTION
## Summary

- Prevent active duplicate free event registrations with the same email address.
- Add a registration deadline for free events and hide the public form after the deadline.
- Remove duplicate rendering of the free event registration form.
- Read paid event deadline and availability from the linked WooCommerce product instead of duplicating deadline data on the event.
- Improve event summary deadline text:
  - before deadline: `Ilmoittautuminen päättyy`
  - after deadline but before event date: `Ilmoittautuminen päättyi`
  - after event date: hide the deadline row

## Tests

- `docker compose exec -T wordpress php -l wp-content/themes/rytkoset-theme/inc/events.php`
- `docker compose exec -T wordpress php -l wp-content/themes/rytkoset-theme/inc/event-registrations.php`
- `docker compose exec -T wordpress php -l wp-content/themes/rytkoset-theme/single-rytkoset_event.php`
- `git diff --check`
- Local smoke:
  - past free event: no registration form and no deadline row
  - future free event: one registration form
  - paid Tampere 2026 event reads product deadline
  - duplicate helper detects active existing registration