### PR TITLE
feat(gdpr): lisää tapahtumailmoittautumisten anonymisointi (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- WordPress Privacy Tools -export ja anonymisoiva eraser maksuttomille tapahtumailmoittautumisille sekä tapahtumakohtainen maksuttomien ilmoittautumisten massaanonymisointi adminiin
 - Maksuttomille tapahtumille oma ilmoittautumisen määräpäivä, jolla julkinen lomake sulkeutuu automaattisesti
 - Dokumentaatio tietosuojaselosteen julkaisusta ja suomenkielinen seloste-pohja: `docs/tietosuoja.md`
 - Tapahtumailmoittautumisen GDPR-tekstiin automaattinen linkki tietosuojaselosteeseen, kun sivu on asetettu WP:n tietosuojasivuksi

--- a/docs/event-participants-admin.md
+++ b/docs/event-participants-admin.md
@@ -76,6 +76,14 @@ Sarakkeet:
 | Yhteyshenkilön sähköposti | Tilaajan sähköposti (maksullisissa) |
 | Tilausnumero | WooCommerce-tilausnumero (maksullisissa) |
 
+### GDPR-anonymisointi
+
+Kun yksittäinen tapahtuma on valittuna, sivulla näkyy **GDPR: maksuttomien ilmoittautumisten anonymisointi** -toiminto. Se anonymisoi valitun tapahtuman maksuttomat `event_registration`-ilmoittautumiset kaikista statuksista (`pending`, `confirmed`, `cancelled`).
+
+Anonymisointi poistaa osallistujan nimen, sähköpostiosoitteen, ruokarajoitteet ja lisätiedot. Ilmoittautumisrivi, tapahtumaviittaus ja status säilyvät raportointia varten. Toiminto vaatii erillisen checkbox-vahvistuksen ja nonce-tarkistuksen.
+
+Toiminto ei koske WooCommerce-tilauksia, Tampere 2026 -osallistujakenttiä tai maksullisten tapahtumien tilaajatietoja.
+
 ## Lähteet ja normalisointi
 
 Näkymä yhdistää kaksi eri lähdettä yhtenäiseen rivi­rakenteeseen:
@@ -134,6 +142,10 @@ Pääfunktiot:
 - `rytkoset_theme_render_event_participants_admin_page()` — renderöi sivun
 - `rytkoset_theme_render_event_participants_export_form()` — renderöi CSV-vientipainikkeen
 - `rytkoset_theme_export_event_participants_csv()` — `admin_post`-handleri, joka tuottaa CSV-tiedoston
+- `rytkoset_theme_render_event_participants_anonymization_form()` — renderöi tapahtumakohtaisen anonymisointilomakkeen
+- `rytkoset_theme_handle_event_free_registrations_anonymization()` — `admin_post`-handleri, joka anonymisoi valitun tapahtuman maksuttomat ilmoittautumiset
+
+GDPR-exporter, eraser ja yhteinen anonymisointihelper ovat tiedostossa `wp-content/themes/rytkoset-theme/inc/event-registration-privacy.php`.
 
 ## Liittyvät toiminnot
 
@@ -142,5 +154,6 @@ Pääfunktiot:
 
 ## Rajaus tässä vaiheessa
 
-- Ei muita massatoimintoja osallistujille tällä sivulla (viestintä on omalla sivullaan)
+- Ei muita massatoimintoja osallistujille tällä sivulla kuin maksuttomien ilmoittautumisten anonymisointi (viestintä on omalla sivullaan)
 - Ei ilmoittautumisten tilamuutosta suoraan listanäkymästä (tehdään `event_registration`-postilomakkeella)
+- Ei WooCommerce-tilausten tai Tampere 2026 -osallistujakenttien anonymisointia tästä näkymästä

--- a/docs/events.md
+++ b/docs/events.md
@@ -68,15 +68,16 @@ Tallennuksessa tarkistetaan nonce, käyttäjän `edit_post`-oikeus ja kenttäkoh
 
 Ilmoittautumisen tiedot tallennetaan WordPressin post metaan:
 
-| Kenttä ylläpidossa           | Meta-avain                            | Muoto / arvot                       | Käyttö                                                        |
-| ---------------------------- | ------------------------------------- | ----------------------------------- | ------------------------------------------------------------- |
-| Tapahtuma                    | `_rytkoset_registration_event_id`     | `event`-postauksen ID               | Viittaus tapahtumaan                                          |
-| Osallistujan nimi            | `_rytkoset_registration_name`         | vapaa teksti                        | Osallistujalista ja admin-otsikko                             |
-| Sähköposti                   | `_rytkoset_registration_email`        | sähköpostiosoite                    | Yhteydenpito ja myöhempi vahvistus                            |
-| Ruokarajoitteet ja allergiat | `_rytkoset_registration_diet`         | vapaa teksti                        | Käytännön järjestelyt                                         |
-| Lisätieto                    | `_rytkoset_registration_notes`        | vapaa teksti                        | Ylläpidon lisätiedot                                          |
-| Tila                         | `_rytkoset_registration_status`       | `pending`, `confirmed`, `cancelled` | Ilmoittautumisen käsittelytila                                |
-| GDPR-hyväksyntä              | `_rytkoset_registration_gdpr_consent` | Unix-aikaleima                      | Tallennetaan, kun käyttäjä hyväksyy tietosuojakäytännön (#38) |
+| Kenttä ylläpidossa           | Meta-avain                              | Muoto / arvot                       | Käyttö                                                        |
+| ---------------------------- | --------------------------------------- | ----------------------------------- | ------------------------------------------------------------- |
+| Tapahtuma                    | `_rytkoset_registration_event_id`       | `event`-postauksen ID               | Viittaus tapahtumaan                                          |
+| Osallistujan nimi            | `_rytkoset_registration_name`           | vapaa teksti                        | Osallistujalista ja admin-otsikko                             |
+| Sähköposti                   | `_rytkoset_registration_email`          | sähköpostiosoite                    | Yhteydenpito ja myöhempi vahvistus                            |
+| Ruokarajoitteet ja allergiat | `_rytkoset_registration_diet`           | vapaa teksti                        | Käytännön järjestelyt                                         |
+| Lisätieto                    | `_rytkoset_registration_notes`          | vapaa teksti                        | Ylläpidon lisätiedot                                          |
+| Tila                         | `_rytkoset_registration_status`         | `pending`, `confirmed`, `cancelled` | Ilmoittautumisen käsittelytila                                |
+| GDPR-hyväksyntä              | `_rytkoset_registration_gdpr_consent`   | Unix-aikaleima                      | Tallennetaan, kun käyttäjä hyväksyy tietosuojakäytännön (#38) |
+| Anonymisointiaika            | `_rytkoset_registration_anonymized_at`  | MySQL-aikaleima                     | Tallennetaan, kun henkilötiedot anonymisoidaan (#250)         |
 
 Ilmoittautumisen otsikko muodostetaan automaattisesti muodossa `Osallistujan nimi - Tapahtuman nimi`, jotta admin-lista pysyy luettavana.
 
@@ -150,6 +151,8 @@ Maksulliselle tapahtumalle kannattaa lisäksi täyttää:
 Ilmaisten tapahtumien ilmoittautumiset tallennetaan `event_registration`-sisältötyyppiin. Ylläpitäjä voi luoda ja muokata ilmoittautumisia käsin WordPress-adminissa kohdassa `Tapahtumat > Ilmoittautumiset`.
 
 Julkinen ilmoittautumislomake näkyy maksuttomissa tapahtumissa, jos tapahtumaan ei ole linkitetty WooCommerce-maksutuotetta ja ilmoittautumisen määräpäivä ei ole ohitettu. Jos määräpäivä on tyhjä, lomake sulkeutuu tapahtumapäivän jälkeen. Lomake tarkistaa noncen, tapahtuman, nimen, sähköpostiosoitteen ja GDPR-hyväksynnän ennen tallennusta. Sama sähköpostiosoite voi luoda vain yhden aktiivisen (`pending` tai `confirmed`) ilmoittautumisen samaan tapahtumaan; `cancelled`-tilainen ilmoittautuminen sallii uuden ilmoittautumisen. Uudet ilmoittautumiset tallentuvat aluksi tilaan `pending`, jotta ylläpitäjä voi käsitellä ne adminissa.
+
+Maksuttomat `event_registration`-ilmoittautumiset ovat mukana WordPressin Privacy Tools -viennissä ja poistopyynnössä sähköpostiosoitteen perusteella. Poistopyyntö anonymisoi ilmoittautumisen: nimi korvataan arvolla `Anonymisoitu osallistuja`, sähköposti, ruokarajoitteet ja lisätiedot poistetaan, mutta tapahtumaviittaus ja status säilytetään raportointia varten. Yksittäisen tapahtuman maksuttomat ilmoittautumiset voi anonymisoida myös adminissa kohdassa `Tapahtumat > Osallistujat`, kun tapahtuma on valittuna.
 
 Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkitetty maksutuote:
 

--- a/docs/tietosuoja.md
+++ b/docs/tietosuoja.md
@@ -88,7 +88,7 @@ Kun ilmoittaudut tapahtumaan, tallennamme:
 
 Nimi ja sähköpostiosoite ovat pakollisia tapahtumailmoittautumisen käsittelyä varten. Ilman niitä ilmoittautumista ei voida vastaanottaa. Ruokarajoitteet ja lisätiedot ovat vapaaehtoisia.
 
-Tietoja käytetään yksinomaan kyseisen tapahtuman järjestämiseen. Tietoja käsittelevät vain ne yhdistyksen vastuuhenkilöt ja sivuston ylläpitäjät, jotka tarvitsevat tietoja tapahtuman käytännön järjestelyihin. Tietoja ei luovuteta ulkopuolisille tahoille. Tiedot poistetaan, kun niitä ei enää tarvita tapahtuman jälkikäsittelyyn, viimeistään 12 kuukauden kuluttua tapahtumasta.
+Tietoja käytetään yksinomaan kyseisen tapahtuman järjestämiseen. Tietoja käsittelevät vain ne yhdistyksen vastuuhenkilöt ja sivuston ylläpitäjät, jotka tarvitsevat tietoja tapahtuman käytännön järjestelyihin. Tietoja ei luovuteta ulkopuolisille tahoille. Tiedot poistetaan tai anonymisoidaan, kun niitä ei enää tarvita tapahtuman jälkikäsittelyyn, viimeistään 12 kuukauden kuluttua tapahtumasta. Tiedot voidaan anonymisoida myös rekisteröidyn pyynnön perusteella.
 
 ### Jäsenmaksut ja muut WooCommerce-tilaukset
 
@@ -142,7 +142,7 @@ Henkilötietoihin pääsevät yhdistyksen sisällä vain ne henkilöt, joilla on
 ## Kuinka kauan säilytämme tietoja
 
 - Käyttäjätilien tiedot säilytetään niin kauan kuin tilisi on aktiivinen. Voit pyytää tilisi poistamista milloin tahansa.
-- Tapahtumailmoittautumisten tiedot poistetaan viimeistään 12 kuukauden kuluttua tapahtumasta.
+- Tapahtumailmoittautumisten tiedot poistetaan tai anonymisoidaan viimeistään 12 kuukauden kuluttua tapahtumasta.
 - Verkkokaupan tilaustiedot säilytetään kirjanpitolain mukaisesti 6 vuotta tilikauden päättymisestä.
 - Uutiskirjetilaajien tiedot säilytetään niin kauan kuin tilaus on voimassa.
 

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -14,6 +14,7 @@ require_once get_template_directory() . '/inc/media-library.php';
 require_once get_template_directory() . '/inc/event-roles.php';
 require_once get_template_directory() . '/inc/events.php';
 require_once get_template_directory() . '/inc/event-registrations.php';
+require_once get_template_directory() . '/inc/event-registration-privacy.php';
 require_once get_template_directory() . '/inc/event-participants-admin.php';
 require_once get_template_directory() . '/inc/event-participants-messaging.php';
 require_once get_template_directory() . '/inc/digital-magazines.php';

--- a/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php
@@ -373,6 +373,98 @@ function rytkoset_theme_render_event_participants_export_form( $selected_event, 
 }
 
 /**
+ * Renders feedback for event registration mass anonymization.
+ *
+ * @return void
+ */
+function rytkoset_theme_render_event_participants_anonymization_notice() {
+	$notice = isset( $_GET['rytkoset_anonymize_notice'] ) ? sanitize_key( wp_unslash( $_GET['rytkoset_anonymize_notice'] ) ) : '';
+
+	if ( '' === $notice ) {
+		return;
+	}
+
+	$count = isset( $_GET['rytkoset_anonymize_count'] ) ? absint( wp_unslash( $_GET['rytkoset_anonymize_count'] ) ) : 0;
+
+	if ( 'success' === $notice ) {
+		printf(
+			'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+			esc_html(
+				sprintf(
+					/* translators: %d: anonymized registration count */
+					_n( '%d maksuton ilmoittautuminen anonymisoitiin.', '%d maksutonta ilmoittautumista anonymisoitiin.', $count, 'rytkoset-theme' ),
+					$count
+				)
+			)
+		);
+		return;
+	}
+
+	if ( 'missing_confirmation' === $notice ) {
+		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__( 'Anonymisointia ei tehty, koska vahvistus puuttui.', 'rytkoset-theme' ) . '</p></div>';
+		return;
+	}
+
+	echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__( 'Ilmoittautumisten anonymisointi epäonnistui.', 'rytkoset-theme' ) . '</p></div>';
+}
+
+/**
+ * Renders the event-specific free registration anonymization form.
+ *
+ * @param int $selected_event Selected event ID.
+ * @return void
+ */
+function rytkoset_theme_render_event_participants_anonymization_form( $selected_event ) {
+	$selected_event = absint( $selected_event );
+
+	if ( $selected_event <= 0 || 'rytkoset_event' !== get_post_type( $selected_event ) ) {
+		return;
+	}
+
+	$count = function_exists( 'rytkoset_theme_get_event_registration_ids_for_event_anonymization' )
+		? count( rytkoset_theme_get_event_registration_ids_for_event_anonymization( $selected_event ) )
+		: 0;
+	?>
+	<div class="postbox" style="margin-top:16px; max-width:760px;">
+		<div class="inside">
+			<h2><?php esc_html_e( 'GDPR: maksuttomien ilmoittautumisten anonymisointi', 'rytkoset-theme' ); ?></h2>
+			<p>
+				<?php esc_html_e( 'Toiminto anonymisoi valitun tapahtuman maksuttomat ilmoittautumiset. Se poistaa nimet, sähköpostiosoitteet, ruokarajoitteet ja lisätiedot, mutta säilyttää ilmoittautumisrivit, tapahtuman ja statuksen raportointia varten.', 'rytkoset-theme' ); ?>
+			</p>
+			<p>
+				<strong><?php esc_html_e( 'Huom:', 'rytkoset-theme' ); ?></strong>
+				<?php esc_html_e( 'Toiminto ei koske WooCommerce-tilauksia tai Tampere 2026 -osallistujakenttiä.', 'rytkoset-theme' ); ?>
+			</p>
+			<?php if ( $count > 0 ) : ?>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="rytkoset_anonymize_event_free_registrations" />
+					<input type="hidden" name="event_id" value="<?php echo esc_attr( (string) $selected_event ); ?>" />
+					<?php wp_nonce_field( 'rytkoset_anonymize_event_free_registrations', 'rytkoset_event_anonymize_nonce' ); ?>
+					<p>
+						<label>
+							<input type="checkbox" name="confirm_anonymization" value="1" required />
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %d: anonymizable registration count */
+									_n( 'Vahvistan, että haluan anonymisoida %d maksuttoman ilmoittautumisen.', 'Vahvistan, että haluan anonymisoida %d maksutonta ilmoittautumista.', $count, 'rytkoset-theme' ),
+									$count
+								)
+							);
+							?>
+						</label>
+					</p>
+					<?php submit_button( __( 'Anonymisoi maksuttomat ilmoittautumiset', 'rytkoset-theme' ), 'delete', '', false ); ?>
+				</form>
+			<?php else : ?>
+				<p><?php esc_html_e( 'Tällä tapahtumalla ei ole anonymisoimattomia maksuttomia ilmoittautumisia. Mahdolliset alla näkyvät maksuttomat rivit on jo anonymisoitu.', 'rytkoset-theme' ); ?></p>
+			<?php endif; ?>
+		</div>
+	</div>
+	<?php
+}
+
+/**
  * Builds a filename for the participants CSV export.
  *
  * @param int    $event_id        Event ID or 0 for all events.
@@ -548,6 +640,7 @@ function rytkoset_theme_render_event_participants_admin_page() {
 	<div class="wrap">
 		<h1><?php esc_html_e( 'Tapahtumien osallistujat', 'rytkoset-theme' ); ?></h1>
 		<p><?php esc_html_e( 'Valitse tapahtuma nähdäksesi sekä maksuttomat että maksulliset ilmoittautumiset yhtenäisenä listana.', 'rytkoset-theme' ); ?></p>
+		<?php rytkoset_theme_render_event_participants_anonymization_notice(); ?>
 
 		<div class="tablenav top">
 			<div class="alignleft actions" style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
@@ -607,6 +700,8 @@ function rytkoset_theme_render_event_participants_admin_page() {
 			</div>
 			<br class="clear" />
 		</div>
+
+		<?php rytkoset_theme_render_event_participants_anonymization_form( $selected_event ); ?>
 
 		<?php $show_event_column = 0 === $selected_event; ?>
 		<table class="widefat striped">

--- a/wp-content/themes/rytkoset-theme/inc/event-registration-privacy.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registration-privacy.php
@@ -1,0 +1,348 @@
+<?php
+/**
+ * GDPR export and anonymization helpers for event registrations.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Returns the display name used for anonymized event registrations.
+ *
+ * @return string
+ */
+function rytkoset_theme_get_anonymized_event_registration_name() {
+	return __( 'Anonymisoitu osallistuja', 'rytkoset-theme' );
+}
+
+/**
+ * Returns registration IDs for a given participant email.
+ *
+ * @param string $email    Participant email address.
+ * @param int    $page     Result page.
+ * @param int    $per_page Results per page.
+ * @return int[]
+ */
+function rytkoset_theme_get_event_registration_ids_by_email( $email, $page = 1, $per_page = 50 ) {
+	$email    = sanitize_email( $email );
+	$page     = max( 1, absint( $page ) );
+	$per_page = max( 1, absint( $per_page ) );
+
+	if ( '' === $email || ! is_email( $email ) ) {
+		return array();
+	}
+
+	$meta_keys = rytkoset_theme_get_event_registration_meta_keys();
+
+	return get_posts(
+		array(
+			'post_type'              => 'event_registration',
+			'post_status'            => 'any',
+			'posts_per_page'         => $per_page,
+			'offset'                 => ( $page - 1 ) * $per_page,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'             => array(
+				array(
+					'key'   => $meta_keys['email'],
+					'value' => $email,
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Returns non-anonymized free registration IDs for an event.
+ *
+ * @param int $event_id Event post ID.
+ * @return int[]
+ */
+function rytkoset_theme_get_event_registration_ids_for_event_anonymization( $event_id ) {
+	$event_id = absint( $event_id );
+
+	if ( $event_id <= 0 ) {
+		return array();
+	}
+
+	$meta_keys = rytkoset_theme_get_event_registration_meta_keys();
+
+	return get_posts(
+		array(
+			'post_type'              => 'event_registration',
+			'post_status'            => 'any',
+			'posts_per_page'         => -1,
+			'fields'                 => 'ids',
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'             => array(
+				'relation' => 'AND',
+				array(
+					'key'   => $meta_keys['event_id'],
+					'value' => $event_id,
+				),
+				array(
+					'key'     => $meta_keys['anonymized_at'],
+					'compare' => 'NOT EXISTS',
+				),
+			),
+		)
+	);
+}
+
+/**
+ * Anonymizes a single event registration while keeping event and status metadata.
+ *
+ * @param int $registration_id Registration post ID.
+ * @return bool
+ */
+function rytkoset_theme_anonymize_event_registration( $registration_id ) {
+	$registration_id = absint( $registration_id );
+
+	if ( $registration_id <= 0 || 'event_registration' !== get_post_type( $registration_id ) ) {
+		return false;
+	}
+
+	$meta_keys       = rytkoset_theme_get_event_registration_meta_keys();
+	$event_id        = absint( rytkoset_theme_get_event_registration_meta( $registration_id, 'event_id' ) );
+	$anonymized_name = rytkoset_theme_get_anonymized_event_registration_name();
+	$title           = rytkoset_theme_build_event_registration_title( $anonymized_name, $event_id );
+	$updated         = wp_update_post(
+		array(
+			'ID'         => $registration_id,
+			'post_title' => $title,
+		),
+		true
+	);
+
+	if ( is_wp_error( $updated ) ) {
+		return false;
+	}
+
+	update_post_meta( $registration_id, $meta_keys['name'], $anonymized_name );
+	delete_post_meta( $registration_id, $meta_keys['email'] );
+	delete_post_meta( $registration_id, $meta_keys['diet'] );
+	delete_post_meta( $registration_id, $meta_keys['notes'] );
+	update_post_meta( $registration_id, $meta_keys['anonymized_at'], current_time( 'mysql' ) );
+
+	return true;
+}
+
+/**
+ * Formats a stored GDPR consent timestamp for exports.
+ *
+ * @param string $timestamp Raw timestamp.
+ * @return string
+ */
+function rytkoset_theme_format_event_registration_consent_timestamp( $timestamp ) {
+	$timestamp = absint( $timestamp );
+
+	if ( $timestamp <= 0 ) {
+		return '';
+	}
+
+	return wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp );
+}
+
+/**
+ * Registers the event registration personal data exporter.
+ *
+ * @param array $exporters Registered exporters.
+ * @return array
+ */
+function rytkoset_theme_register_event_registration_personal_data_exporter( $exporters ) {
+	$exporters['rytkoset-event-registrations'] = array(
+		'exporter_friendly_name' => __( 'Tapahtumailmoittautumiset', 'rytkoset-theme' ),
+		'callback'               => 'rytkoset_theme_export_event_registration_personal_data',
+	);
+
+	return $exporters;
+}
+add_filter( 'wp_privacy_personal_data_exporters', 'rytkoset_theme_register_event_registration_personal_data_exporter' );
+
+/**
+ * Exports event registration personal data for a participant email.
+ *
+ * @param string $email_address Email address.
+ * @param int    $page          Result page.
+ * @return array
+ */
+function rytkoset_theme_export_event_registration_personal_data( $email_address, $page = 1 ) {
+	$per_page         = 50;
+	$registration_ids = rytkoset_theme_get_event_registration_ids_by_email( $email_address, $page, $per_page );
+	$statuses         = rytkoset_theme_get_event_registration_statuses();
+	$items            = array();
+
+	foreach ( $registration_ids as $registration_id ) {
+		$event_id      = absint( rytkoset_theme_get_event_registration_meta( $registration_id, 'event_id' ) );
+		$status        = rytkoset_theme_get_event_registration_meta( $registration_id, 'status' );
+		$consent       = rytkoset_theme_get_event_registration_meta( $registration_id, 'gdpr_consent' );
+		$consent_label = rytkoset_theme_format_event_registration_consent_timestamp( $consent );
+		$data          = array(
+			array(
+				'name'  => __( 'Tapahtuma', 'rytkoset-theme' ),
+				'value' => $event_id > 0 ? get_the_title( $event_id ) : '',
+			),
+			array(
+				'name'  => __( 'Nimi', 'rytkoset-theme' ),
+				'value' => rytkoset_theme_get_event_registration_meta( $registration_id, 'name' ),
+			),
+			array(
+				'name'  => __( 'Sähköposti', 'rytkoset-theme' ),
+				'value' => rytkoset_theme_get_event_registration_meta( $registration_id, 'email' ),
+			),
+			array(
+				'name'  => __( 'Ruokarajoitteet ja allergiat', 'rytkoset-theme' ),
+				'value' => rytkoset_theme_get_event_registration_meta( $registration_id, 'diet' ),
+			),
+			array(
+				'name'  => __( 'Lisätieto', 'rytkoset-theme' ),
+				'value' => rytkoset_theme_get_event_registration_meta( $registration_id, 'notes' ),
+			),
+			array(
+				'name'  => __( 'Tila', 'rytkoset-theme' ),
+				'value' => isset( $statuses[ $status ] ) ? $statuses[ $status ] : $status,
+			),
+			array(
+				'name'  => __( 'Ilmoittautumispäivä', 'rytkoset-theme' ),
+				'value' => get_the_date( '', $registration_id ) . ' ' . get_the_time( '', $registration_id ),
+			),
+			array(
+				'name'  => __( 'Tietosuojasuostumus', 'rytkoset-theme' ),
+				'value' => $consent_label,
+			),
+		);
+
+		$items[] = array(
+			'group_id'    => 'rytkoset-event-registrations',
+			'group_label' => __( 'Tapahtumailmoittautumiset', 'rytkoset-theme' ),
+			'item_id'     => 'event-registration-' . $registration_id,
+			'data'        => $data,
+		);
+	}
+
+	return array(
+		'data' => $items,
+		'done' => count( $registration_ids ) < $per_page,
+	);
+}
+
+/**
+ * Registers the event registration personal data eraser.
+ *
+ * @param array $erasers Registered erasers.
+ * @return array
+ */
+function rytkoset_theme_register_event_registration_personal_data_eraser( $erasers ) {
+	$erasers['rytkoset-event-registrations'] = array(
+		'eraser_friendly_name' => __( 'Tapahtumailmoittautumiset', 'rytkoset-theme' ),
+		'callback'             => 'rytkoset_theme_erase_event_registration_personal_data',
+	);
+
+	return $erasers;
+}
+add_filter( 'wp_privacy_personal_data_erasers', 'rytkoset_theme_register_event_registration_personal_data_eraser' );
+
+/**
+ * Erases event registration personal data for a participant email by anonymizing rows.
+ *
+ * @param string $email_address Email address.
+ * @param int    $page          Result page. Intentionally ignored to avoid skipped rows after anonymization.
+ * @return array
+ */
+function rytkoset_theme_erase_event_registration_personal_data( $email_address, $page = 1 ) {
+	unset( $page );
+
+	$per_page         = 50;
+	$registration_ids = rytkoset_theme_get_event_registration_ids_by_email( $email_address, 1, $per_page );
+	$removed          = 0;
+	$retained         = 0;
+	$messages         = array();
+
+	foreach ( $registration_ids as $registration_id ) {
+		if ( rytkoset_theme_anonymize_event_registration( $registration_id ) ) {
+			$removed++;
+			continue;
+		}
+
+		$retained++;
+	}
+
+	if ( $removed > 0 ) {
+		$messages[] = sprintf(
+			/* translators: %d: anonymized registration count */
+			_n( '%d tapahtumailmoittautuminen anonymisoitiin.', '%d tapahtumailmoittautumista anonymisoitiin.', $removed, 'rytkoset-theme' ),
+			$removed
+		);
+	}
+
+	if ( $retained > 0 ) {
+		$messages[] = 1 === $retained
+			? __( 'Yhtä tapahtumailmoittautumista ei voitu anonymisoida.', 'rytkoset-theme' )
+			: sprintf(
+				/* translators: %d: retained registration count */
+				__( '%d tapahtumailmoittautumista ei voitu anonymisoida.', 'rytkoset-theme' ),
+				$retained
+			);
+	}
+
+	return array(
+		'items_removed'  => $removed > 0,
+		'items_retained' => $retained > 0,
+		'messages'       => $messages,
+		'done'           => count( $registration_ids ) < $per_page,
+	);
+}
+
+/**
+ * Handles event-specific free registration mass anonymization from the participants admin page.
+ *
+ * @return void
+ */
+function rytkoset_theme_handle_event_free_registrations_anonymization() {
+	if ( ! current_user_can( 'edit_others_event_registrations' ) ) {
+		wp_die( esc_html__( 'Sinulla ei ole oikeutta anonymisoida ilmoittautumisia.', 'rytkoset-theme' ) );
+	}
+
+	check_admin_referer( 'rytkoset_anonymize_event_free_registrations', 'rytkoset_event_anonymize_nonce' );
+
+	$event_id = isset( $_POST['event_id'] ) ? absint( wp_unslash( $_POST['event_id'] ) ) : 0;
+	$confirm  = isset( $_POST['confirm_anonymization'] ) && '1' === wp_unslash( $_POST['confirm_anonymization'] );
+	$notice   = 'error';
+	$count    = 0;
+
+	if ( $event_id > 0 && 'rytkoset_event' === get_post_type( $event_id ) && $confirm ) {
+		$registration_ids = rytkoset_theme_get_event_registration_ids_for_event_anonymization( $event_id );
+
+		foreach ( $registration_ids as $registration_id ) {
+			if ( rytkoset_theme_anonymize_event_registration( $registration_id ) ) {
+				$count++;
+			}
+		}
+
+		$notice = 'success';
+	} elseif ( ! $confirm ) {
+		$notice = 'missing_confirmation';
+	}
+
+	$redirect_url = add_query_arg(
+		array(
+			'post_type'                 => 'rytkoset_event',
+			'page'                      => 'rytkoset-event-participants',
+			'event_id'                  => $event_id,
+			'rytkoset_anonymize_notice' => $notice,
+			'rytkoset_anonymize_count'  => $count,
+		),
+		admin_url( 'edit.php' )
+	);
+
+	wp_safe_redirect( $redirect_url );
+	exit;
+}
+add_action( 'admin_post_rytkoset_anonymize_event_free_registrations', 'rytkoset_theme_handle_event_free_registrations_anonymization' );

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -14,13 +14,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function rytkoset_theme_get_event_registration_meta_keys() {
 	return array(
-		'event_id'     => '_rytkoset_registration_event_id',
-		'name'         => '_rytkoset_registration_name',
-		'email'        => '_rytkoset_registration_email',
-		'diet'         => '_rytkoset_registration_diet',
-		'notes'        => '_rytkoset_registration_notes',
-		'status'       => '_rytkoset_registration_status',
-		'gdpr_consent' => '_rytkoset_registration_gdpr_consent',
+		'event_id'      => '_rytkoset_registration_event_id',
+		'name'          => '_rytkoset_registration_name',
+		'email'         => '_rytkoset_registration_email',
+		'diet'          => '_rytkoset_registration_diet',
+		'notes'         => '_rytkoset_registration_notes',
+		'status'        => '_rytkoset_registration_status',
+		'gdpr_consent'  => '_rytkoset_registration_gdpr_consent',
+		'anonymized_at' => '_rytkoset_registration_anonymized_at',
 	);
 }
 


### PR DESCRIPTION
## Yhteenveto

- Lisätty WordPress Privacy Tools -exporter maksuttomille `event_registration`-ilmoittautumisille sähköpostiosoitteen perusteella
- Lisätty WordPress Privacy Tools -eraser, joka anonymisoi maksuttomat tapahtumailmoittautumiset poistamisen sijaan
- Lisätty `Tapahtumat > Osallistujat` -näkymään tapahtumakohtainen maksuttomien ilmoittautumisten massaanonymisointi
- Lisätty anonymisointiajan meta-avain `_rytkoset_registration_anonymized_at`
- Päivitetty dokumentaatio ja changelog

## Toteutus

Anonymisointi säilyttää ilmoittautumisrivin, tapahtumaviittauksen ja statuksen raportointia varten, mutta poistaa henkilötiedot:

- nimi korvataan arvolla `Anonymisoitu osallistuja`
- sähköposti poistetaan
- ruokarajoitteet ja allergiat poistetaan
- lisätiedot poistetaan

Massaanonymisointi näkyy vain, kun `Tapahtumat > Osallistujat` -näkymässä on valittuna yksittäinen tapahtuma. Toiminto vaatii nonce-tarkistuksen, oikeuden `edit_others_event_registrations` ja erillisen checkbox-vahvistuksen.

WooCommerce-tilaukset ja Tampere 2026 -osallistujakentät on rajattu tämän muutoksen ulkopuolelle.

## Testaus

- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/inc/event-registration-privacy.php`
- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/inc/event-participants-admin.php`
- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/inc/event-registrations.php`
- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/functions.php`
- Koko teeman PHP-lint:
  - `docker compose exec wordpress sh -c "find /var/www/html/wp-content/themes/rytkoset-theme -name '*.php' -print0 | xargs -0 -n1 php -l"`
- `git diff --check`
- Paikallinen etusivu vastasi `HTTP 200`
- Manuaalisesti tarkistettu, että tapahtumakohtainen anonymisointi muuttaa rivit anonyymeiksi ja säilyttää ne osallistujalistalla

## Huomiot

- `phpcs` ei ole paikallisessa kontissa käytettävissä
- `wp` / WP-CLI ei ole paikallisessa kontissa käytettävissä
- Privacy Tools löytyvät WP-administa:
  - `Työkalut → Vie henkilötiedot`
  - `Työkalut → Poista henkilötiedot`

Closes #250