### PR TITLE
- Update `CLAUDE.md` if the change affects theme architecture, file s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerce-kaupan brändin mukaiset alasvetovalikko- ja painiketyylit.
 
 ### Changed
+- Päivitetty `CLAUDE.md`:n `inc/`-moduulitaulukko ja WooCommerce-arkkitehtuurihuomio vastaamaan nykyistä `functions.php`-include-listaa.
 - Tapahtuman yhteenvetokortti piilottaa ilmoittautumisen määräpäivän menneiltä tapahtumilta ja käyttää mennyttä aikamuotoa määräpäivän jälkeen.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ The theme `wp-content/themes/rytkoset-theme/` is the only versioned codebase. Wo
 | -------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `inc/events.php`                       | Event CPT, meta field registration and getters                                             |
 | `inc/event-registrations.php`          | Free event registration CPT and form                                                       |
+| `inc/event-registration-privacy.php`    | Privacy Tools export, erasure and anonymization for free event registrations               |
 | `inc/event-participants-admin.php`     | `Events > Participants` admin view                                                         |
 | `inc/event-participants-messaging.php` | `Events > Messaging` bulk email                                                            |
 | `inc/event-roles.php`                  | `event_organizer` role and capabilities                                                    |
@@ -89,6 +90,8 @@ The theme `wp-content/themes/rytkoset-theme/` is the only versioned codebase. Wo
 | `inc/woocommerce-mollie.php`           | Mollie Finnish translations, RF reference normalization                                    |
 | `inc/woocommerce-membership.php`       | Membership products, checkout notice, admin column and metabox                             |
 | `inc/woocommerce-tampere-2026.php`     | Tampere 2026 participation fee: product, checkout fields, admin, organizer notifications   |
+| `inc/woocommerce-product-sync.php`      | WooCommerce product sync tool for local <-> dev                                           |
+| `inc/customizer-contact.php`            | Customizer contact fields for footer and admin email                                       |
 
 All functions use `if ( ! function_exists('rytkoset_theme_...') )` guard and `rytkoset_theme_` prefix.
 
@@ -146,7 +149,7 @@ Free event registration forms close after the event registration deadline. Paid 
 
 ## WooCommerce integration
 
-WooCommerce code currently lives in `functions.php` (not yet in `inc/` modules). Key areas:
+WooCommerce-specific logic lives in `inc/woocommerce-*.php` modules, with small shared helpers still in `functions.php`. Key areas:
 
 - **Membership products** — annual and lifetime membership; checkout notice when product is in cart
 - **Tampere 2026 event fee** — custom checkout fields, participant list in admin, CSV export, organizer email notifications


### PR DESCRIPTION
## Yhteenveto

- Päivitetty `CLAUDE.md`:n `inc/`-moduulitaulukko vastaamaan nykyistä `functions.php`:n include-listaa
- Lisätty puuttuvat moduulit:
  - `inc/event-registration-privacy.php`
  - `inc/woocommerce-product-sync.php`
  - `inc/customizer-contact.php`
- Korjattu vanhentunut WooCommerce-huomio: WooCommerce-logiikka on nykyisin `inc/woocommerce-*.php`-moduuleissa, ja `functions.php`:ssä on vain pieniä jaettuja helpereitä
- Päivitetty `CHANGELOG.md`

## Testaus

- `rg`-haulla varmistettu, ettei vanhaa “WooCommerce code currently lives in functions.php” -väitettä jäänyt `CLAUDE.md`:ään
- `git diff --check`

## Huomiot

- Tämä on dokumentaatiomuutos, ei muuta ajonaikaista koodia
- `AGENTS.md` sisältää jo ohjeen päivittää `CLAUDE.md`, kun muutos vaikuttaa arkkitehtuuriin, tiedostorakenteeseen, CPT:ihin, työnkulkuun tai muuhun agentille olennaiseen projektitietoon

Closes #251