### PR TITLE
feat(events): add free registration receipt email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- Maksuttoman tapahtumailmoittautumisen kuittisähköposti ilmoittautujalle sekä erillinen selvitystiketti AcyMailing-tapahtumaviestinnälle (#107, #264)
 - GitHub PR -kuvauspohja yhtenäiselle muutosten, testien ja lisähuomioiden kuvaukselle.
 - WordPress Privacy Tools -export ja anonymisoiva eraser maksuttomille tapahtumailmoittautumisille sekä tapahtumakohtainen maksuttomien ilmoittautumisten massaanonymisointi adminiin
 - Maksuttomille tapahtumille oma ilmoittautumisen määräpäivä, jolla julkinen lomake sulkeutuu automaattisesti

--- a/docs/events.md
+++ b/docs/events.md
@@ -11,6 +11,7 @@ Tapahtumakokonaisuus on tässä vaiheessa kevyt MVP:
 - tapahtuman julkinen sisältö kirjoitetaan WordPress-editorissa
 - ilmaisten tapahtumien ilmoittautumisille on oma ei-julkinen `event_registration`-sisältötyyppi
 - maksuttomien tapahtumien sivulla voidaan näyttää ilmoittautumislomake, jonka tiedot tallentuvat ilmoittautumisiksi
+- maksuttoman tapahtumailmoittautumisen jälkeen ilmoittautujalle lähetetään kevyt kuittisähköposti
 - maksullisen tapahtuman ilmoittautuminen ja maksaminen ohjataan WooCommerce-tuotteelle
 - osallistujat näkee tapahtumakohtaisesti `Tapahtumat > Osallistujat` -näkymästä, joka yhdistää ilmaiset ja maksulliset ilmoittautumiset
 - Tampere 2026 -osallistujien hallintaan on lisäksi oma WooCommerce-pikalinkkinäkymä
@@ -87,7 +88,7 @@ Yksittäisellä tapahtumasivulla näytetään:
 
 - tapahtuman artikkelikuva ja otsikko
 - editoriin kirjoitettu sisältö
-- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi, siihen ei ole linkitetty maksutuotetta ja ilmoittautumisen määräpäivää ei ole ohitettu — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38); onnistumisen jälkeen lomake korvataan vahvistusosiolla, joka näyttää tapahtuman tiedot (#32)
+- maksuttoman tapahtuman ilmoittautumislomake, jos tapahtuma on merkitty maksuttomaksi, siihen ei ole linkitetty maksutuotetta ja ilmoittautumisen määräpäivää ei ole ohitettu — lomake sisältää GDPR-tietosuojatekstin ja pakollisen hyväksyntächeckboxin (#38); onnistumisen jälkeen lomake korvataan vahvistusosiolla, joka näyttää tapahtuman tiedot (#32), ja ilmoittautujalle lähetetään tekstimuotoinen kuittisähköposti (#107)
 - sivupalkin yhteenvetokortti, jos tapahtumalla on perustietoja tai maksutuote
 - jakopainikkeet
 
@@ -150,7 +151,7 @@ Maksulliselle tapahtumalle kannattaa lisäksi täyttää:
 
 Ilmaisten tapahtumien ilmoittautumiset tallennetaan `event_registration`-sisältötyyppiin. Ylläpitäjä voi luoda ja muokata ilmoittautumisia käsin WordPress-adminissa kohdassa `Tapahtumat > Ilmoittautumiset`.
 
-Julkinen ilmoittautumislomake näkyy maksuttomissa tapahtumissa, jos tapahtumaan ei ole linkitetty WooCommerce-maksutuotetta ja ilmoittautumisen määräpäivä ei ole ohitettu. Jos määräpäivä on tyhjä, lomake sulkeutuu tapahtumapäivän jälkeen. Lomake tarkistaa honeypot-kentän, noncen, tapahtuman, nimen, sähköpostiosoitteen ja GDPR-hyväksynnän ennen tallennusta. Sama sähköpostiosoite voi luoda vain yhden aktiivisen (`pending` tai `confirmed`) ilmoittautumisen samaan tapahtumaan; `cancelled`-tilainen ilmoittautuminen sallii uuden ilmoittautumisen. Uudet ilmoittautumiset tallentuvat aluksi tilaan `pending`, jotta ylläpitäjä voi käsitellä ne adminissa.
+Julkinen ilmoittautumislomake näkyy maksuttomissa tapahtumissa, jos tapahtumaan ei ole linkitetty WooCommerce-maksutuotetta ja ilmoittautumisen määräpäivä ei ole ohitettu. Jos määräpäivä on tyhjä, lomake sulkeutuu tapahtumapäivän jälkeen. Lomake tarkistaa honeypot-kentän, noncen, tapahtuman, nimen, sähköpostiosoitteen ja GDPR-hyväksynnän ennen tallennusta. Sama sähköpostiosoite voi luoda vain yhden aktiivisen (`pending` tai `confirmed`) ilmoittautumisen samaan tapahtumaan; `cancelled`-tilainen ilmoittautuminen sallii uuden ilmoittautumisen. Uudet ilmoittautumiset tallentuvat aluksi tilaan `pending`, jotta ylläpitäjä voi käsitellä ne adminissa. Onnistuneen maksuttoman ilmoittautumisen jälkeen ilmoittautujalle lähetetään `wp_mail()`-pohjainen tekstimuotoinen kuittisähköposti, jossa kerrotaan ilmoittautumisen vastaanotosta ja näytetään tapahtuman perustiedot.
 
 Maksuttomat `event_registration`-ilmoittautumiset ovat mukana WordPressin Privacy Tools -viennissä ja poistopyynnössä sähköpostiosoitteen perusteella. Poistopyyntö anonymisoi ilmoittautumisen: nimi korvataan arvolla `Anonymisoitu osallistuja`, sähköposti, ruokarajoitteet ja lisätiedot poistetaan, mutta tapahtumaviittaus ja status säilytetään raportointia varten. Yksittäisen tapahtuman maksuttomat ilmoittautumiset voi anonymisoida myös adminissa kohdassa `Tapahtumat > Osallistujat`, kun tapahtuma on valittuna.
 
@@ -207,6 +208,8 @@ Näkymässä voi valita yksittäisen tapahtuman tai katsella kaikkien tapahtumie
 
 Tarkempi kuvaus on tiedostossa `docs/event-participants-admin.md`. Saman valikon alta löytyy myös `Tapahtumat > Viestintä`, jolla voi lähettää sähköpostiviestin valitun tapahtuman osallistujille (`docs/event-participants-messaging.md`).
 
+AcyMailingia ei käytetä #107:n kuittisähköposteihin eikä nykyiseen tapahtumaviestintään. Tapahtumaviestinnän mahdollinen AcyMailing-integraatio selvitetään erillisessä tiketissä #264.
+
 ### Mitä ylläpitäjä tekee ilmoittautumisille
 
 1. Avaa `Tapahtumat > Osallistujat`.
@@ -236,6 +239,7 @@ Tässä vaiheessa on toteutettu:
 - `event_registration`-sisältötyyppi ilmaisten tapahtumien osallistujille
 - maksuttoman tapahtuman julkinen ilmoittautumislomake
 - maksuttoman tapahtuman ilmoittautumisen validointi ja frontend-tallennus
+- maksuttoman tapahtumailmoittautumisen kuittisähköposti ilmoittautujalle
 - tapahtuman yksittäinen sivupohja
 - tapahtuma-arkisto, jossa on tulevat, menneet ja päivämäärättömät tapahtumat
 - tapahtumapäivän metakenttä

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -529,6 +529,99 @@ function rytkoset_theme_event_has_active_registration_for_email( $event_id, $ema
 }
 
 /**
+ * Sends a lightweight receipt email after a successful free event registration.
+ *
+ * The email confirms receipt only. Registration status remains pending until
+ * an organizer handles it in the admin.
+ *
+ * @param int    $event_id Event post ID.
+ * @param string $name     Participant name.
+ * @param string $email    Participant email.
+ * @return bool Whether WordPress accepted the email for sending.
+ */
+function rytkoset_theme_send_event_registration_receipt_email( $event_id, $name, $email ) {
+	$event_id = absint( $event_id );
+	$name     = trim( (string) $name );
+	$email    = sanitize_email( $email );
+
+	if ( $event_id <= 0 || '' === $email || ! is_email( $email ) ) {
+		return false;
+	}
+
+	$event_title = get_the_title( $event_id );
+
+	if ( '' === $event_title ) {
+		$event_title = __( 'Tapahtuma', 'rytkoset-theme' );
+	}
+
+	$event_title_plain = wp_specialchars_decode( $event_title, ENT_QUOTES );
+	$subject           = sprintf(
+		/* translators: %s: event title. */
+		__( 'Ilmoittautuminen vastaanotettu: %s', 'rytkoset-theme' ),
+		$event_title_plain
+	);
+
+	$lines = array(
+		'' !== $name
+			? sprintf(
+				/* translators: %s: participant name. */
+				__( 'Hei %s,', 'rytkoset-theme' ),
+				$name
+			)
+			: __( 'Hei,', 'rytkoset-theme' ),
+		'',
+		__( 'Kiitos ilmoittautumisesta. Ilmoittautumisesi on vastaanotettu.', 'rytkoset-theme' ),
+		__( 'Järjestäjä ottaa tarvittaessa yhteyttä sähköpostitse.', 'rytkoset-theme' ),
+		'',
+		__( 'Tapahtuman tiedot:', 'rytkoset-theme' ),
+		sprintf(
+			/* translators: %s: event title. */
+			__( 'Tapahtuma: %s', 'rytkoset-theme' ),
+			$event_title_plain
+		),
+	);
+
+	$date     = rytkoset_theme_get_event_date_display( $event_id );
+	$time     = rytkoset_theme_get_event_time_display( $event_id );
+	$location = rytkoset_theme_get_event_location( $event_id );
+
+	if ( '' !== $date ) {
+		$lines[] = sprintf(
+			/* translators: %s: event date. */
+			__( 'Päivämäärä: %s', 'rytkoset-theme' ),
+			$date
+		);
+	}
+
+	if ( '' !== $time ) {
+		$lines[] = sprintf(
+			/* translators: %s: event time. */
+			__( 'Aika: %s', 'rytkoset-theme' ),
+			$time
+		);
+	}
+
+	if ( '' !== $location ) {
+		$lines[] = sprintf(
+			/* translators: %s: event location. */
+			__( 'Paikka: %s', 'rytkoset-theme' ),
+			$location
+		);
+	}
+
+	$lines[] = '';
+	$lines[] = __( 'Terveisin', 'rytkoset-theme' );
+	$lines[] = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
+
+	return wp_mail(
+		$email,
+		$subject,
+		implode( "\n", $lines ),
+		array( 'Content-Type: text/plain; charset=UTF-8' )
+	);
+}
+
+/**
  * Redirects back to the event page with a frontend registration error.
  *
  * @param int    $event_id Event post ID.
@@ -622,6 +715,8 @@ function rytkoset_theme_handle_event_registration_submission() {
 	if ( is_wp_error( $registration_id ) || $registration_id <= 0 ) {
 		rytkoset_theme_handle_event_registration_error( $event_id, 'save_failed' );
 	}
+
+	rytkoset_theme_send_event_registration_receipt_email( $event_id, $name, $email );
 
 	wp_safe_redirect( rytkoset_theme_get_event_registration_redirect_url( $event_id, 'success' ) );
 	exit;


### PR DESCRIPTION
## Summary

- Added a lightweight receipt email for successful free event registrations.
- Documented that #107 does not introduce AcyMailing event messaging.
- Created follow-up investigation issue #264 for possible AcyMailing integration.

## Tests

- `docker compose exec -T wordpress sh -lc "find /var/www/html/wp-content/themes/rytkoset-theme -name '*.php' -exec php -l {} \;"`

## Notes

- Free registrations still remain in `pending` status after submission.
- Paid event confirmations remain handled by WooCommerce.