### PR TITLE
fix: prevent privacy page mobile overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.
 
 ### Fixed
+- Tietosuojaselosteen pitkät linkit, sähköpostiosoitteet ja koodimaiset tekstipätkät rivittyvät mobiilileveydellä ilman vaakasuuntaista overflow’ta (#267)
 - Maksuttoman tapahtuman julkinen ilmoittautumislomake hylkää honeypot-kentän täyttävät bottimaiset lähetykset ilman ilmoittautumisen tallennusta.
 - Tapahtumailmoittautuminen estää aktiiviset kaksoisilmoittautumiset samalla sähköpostilla ja huomioi ilmoittautumisajan päättymisen
 - Maksuttoman tapahtuman ilmoittautumislomake ei enää renderöidy kahteen kertaan

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -120,6 +120,22 @@
 .article__content {
   display: grid;
   gap: 1rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.article__content > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.article__content :where(a, code) {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.article__content :where(img, iframe, video, table) {
+  max-width: 100%;
 }
 
 .article--event {


### PR DESCRIPTION
## Summary

- Fixes the mobile horizontal overflow on the privacy policy page.
- Closes #267.

## Changes

- Allows long article content such as links, email addresses, inline code, and media to wrap within the content container.
- Keeps the fix scoped to normal article/page content instead of adding a privacy-page-specific template.
- Updates the changelog entry for #267.

## Testing

- Verified `/tietosuoja/` locally at 360 px, 400 px, and desktop width.
- Verified both light and dark theme states.
- Verified keyboard focus outline remains visible.
- Compared against the front page to check that the basic layout still fits.
- Result: horizontal overflow was `0 px` in tested viewports.

## Notes

- The fix targets the general `.article__content` overflow behavior, because the issue is caused by unbroken content fragments rather than the privacy page structure itself.