### PR TITLE
feat(events): add event-specific organizer notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- Maksullisille tapahtumille tapahtumakohtaiset järjestäjäilmoitusten vastaanottajat ja yleinen WooCommerce-tilausilmoitus (#269)
 - Maksuttoman tapahtumailmoittautumisen kuittisähköposti ilmoittautujalle sekä erillinen selvitystiketti AcyMailing-tapahtumaviestinnälle (#107, #264)
 - GitHub PR -kuvauspohja yhtenäiselle muutosten, testien ja lisähuomioiden kuvaukselle.
 - WordPress Privacy Tools -export ja anonymisoiva eraser maksuttomille tapahtumailmoittautumisille sekä tapahtumakohtainen maksuttomien ilmoittautumisten massaanonymisointi adminiin
@@ -22,6 +23,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerce-kaupan brändin mukaiset alasvetovalikko- ja painiketyylit.
 
 ### Changed
+- Tampere 2026 -järjestäjäilmoitusten vastaanottajat siirretty globaalista asetuksesta tapahtuman omaan `Järjestäjäilmoitukset`-kenttään (#269)
 - Päivitetty `CLAUDE.md`:n `inc/`-moduulitaulukko ja WooCommerce-arkkitehtuurihuomio vastaamaan nykyistä `functions.php`-include-listaa.
 - Tapahtuman yhteenvetokortti piilottaa ilmoittautumisen määräpäivän menneiltä tapahtumilta ja käyttää mennyttä aikamuotoa määräpäivän jälkeen.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Use CSS variables for colors and spacing. No Bootstrap dependency.
   - `_rytkoset_event_price_text` — price text for display
   - `_rytkoset_event_registration_deadline` — free event registration deadline `YYYY-MM-DD`; empty falls back to event date for the public form cutoff
   - `_rytkoset_event_product_id` — linked WooCommerce product for paid registration/payment
+  - `_rytkoset_event_organizer_notification_recipients` — event-specific organizer notification email recipients for paid event orders
 
 Free event registration forms close after the event registration deadline. Paid event pages read the deadline and availability state from the linked WooCommerce product instead of duplicating that data on the event.
 
@@ -152,7 +153,7 @@ Free event registration forms close after the event registration deadline. Paid 
 WooCommerce-specific logic lives in `inc/woocommerce-*.php` modules, with small shared helpers still in `functions.php`. Key areas:
 
 - **Membership products** — annual and lifetime membership; checkout notice when product is in cart
-- **Tampere 2026 event fee** — custom checkout fields, participant list in admin, CSV export, organizer email notifications
+- **Paid event fees / Tampere 2026** — linked event products, Tampere-specific checkout fields, participant list in admin, CSV export, event-specific organizer email notifications
 - **Mollie payments** — Finnish language texts, output buffering on `thankyou` page for bank transfer instructions
 - **PhotoSwipe conflict** — WooCommerce registers PhotoSwipe 4 scripts; theme actively dequeues them to avoid conflicts
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -62,6 +62,7 @@ Tapahtuman lisätiedot tallennetaan WordPressin post metaan:
 | Hintateksti        | `_rytkoset_event_price_text` | vapaa teksti, esim. `49 € / henkilö` | Julkinen hintatieto                       |
 | Ilmoittautumisen määräpäivä | `_rytkoset_event_registration_deadline` | `YYYY-MM-DD` | Maksuttoman tapahtuman lomakkeen sulkeminen |
 | Maksutuote         | `_rytkoset_event_product_id` | WooCommerce-tuotteen ID              | Linkki ilmoittautumis-/maksutuotteeseen   |
+| Järjestäjäilmoitusten vastaanottajat | `_rytkoset_event_organizer_notification_recipients` | sähköpostiosoitteet, yksi per rivi | Maksullisen tapahtuman tilausilmoitusten vastaanottajat |
 
 Tallennuksessa tarkistetaan nonce, käyttäjän `edit_post`-oikeus ja kenttäkohtaiset muodot. Tyhjä kenttä poistaa vastaavan metatiedon.
 
@@ -165,6 +166,8 @@ Ilmoittautumiset kulkevat WooCommercen kautta silloin, kun tapahtumaan on linkit
 
 Maksullisen tapahtuman ilmoittautumisen määräpäivä luetaan linkitetyltä WooCommerce-tuotteelta, kun tuotteella on tapahtumailmoittautumisen oma deadline-logiikka. Tapahtumaan ei tallenneta samaa deadlinea erikseen, jotta tuotteen ostettavuus ja tapahtumasivun viesti eivät eriydy.
 
+Maksullisen tapahtuman järjestäjäilmoitukset lähetetään tapahtumalle asetetuille vastaanottajille, kun linkitetyn maksutuotteen tilaus saavuttaa tilan `on-hold`, `processing` tai `completed`. Ilmoitus lähetetään vain kerran per tapahtuma per tilaus. Jos vastaanottajia ei ole asetettu, sähköpostia ei lähetetä ja tilaukselle kirjataan private order note.
+
 Tapahtuman ja WooCommerce-tuotteen välinen linkitys on dokumentoitu tarkemmin tiedostossa `docs/woocommerce-event-product-link.md`.
 
 ### Event Organizer -rooli
@@ -178,6 +181,7 @@ Rooli saa:
 - muuttaa ilmoittautumisen tilaa, esimerkiksi `pending`, `confirmed` tai `cancelled`
 - lisätä tapahtuman artikkelikuvan mediakirjastosta
 - linkittää tapahtumaan olemassa olevan WooCommerce-maksutuotteen
+- määrittää tapahtumakohtaiset järjestäjäilmoitusten vastaanottajat
 
 Rooli ei saa:
 
@@ -194,7 +198,7 @@ Tampere 2026 -tapahtuman ilmoittautuminen on toteutettu WooCommercen päälle er
 - osallistumismaksutuote: `docs/woocommerce-tampere-2026-product.md`
 - checkoutin osallistujakentät: `docs/woocommerce-tampere-2026-checkout-fields.md`
 - määräpäivä ja kapasiteetti: `docs/woocommerce-tampere-2026-management.md`
-- järjestäjäilmoitukset: `docs/woocommerce-tampere-2026-notifications.md`
+- maksullisten tapahtumien järjestäjäilmoitukset: `docs/woocommerce-tampere-2026-notifications.md`
 
 Tampere 2026 -osallistujat näkyvät yhteisessä osallistujalistassa (katso alla). Vanha `WooCommerce > Tampere 2026 osallistujat` -pikalinkkisivu poistettiin tiketissä `#194`, kun sama tieto on saatavilla rajatuilla oikeuksilla yhteisestä näkymästä.
 
@@ -227,9 +231,11 @@ Kun uusi maksullinen tapahtuma otetaan käyttöön:
 2. Luo WooCommerce-tuote, jos ilmoittautuminen tai maksu tarvitaan.
 3. Aseta tuotteelle hinta, varasto ja muut myyntiasetukset.
 4. Linkitä tuote tapahtuman `Maksutuote`-kentässä.
-5. Testaa julkiselta tapahtumasivulta, että painike vie oikealle tuotteelle.
-6. Testaa ostoskori ja kassa.
-7. Tarkista, että ilmoittautumistiedot näkyvät WooCommerce-tilauksella ja mahdollisessa tapahtumakohtaisessa osallistujanäkymässä.
+5. Lisää tapahtuman `Järjestäjäilmoitukset`-kenttään vastaanottajat.
+6. Testaa julkiselta tapahtumasivulta, että painike vie oikealle tuotteelle.
+7. Testaa ostoskori ja kassa.
+8. Tarkista, että ilmoittautumistiedot näkyvät WooCommerce-tilauksella ja mahdollisessa tapahtumakohtaisessa osallistujanäkymässä.
+9. Tarkista, että tilaukselle kirjautuu järjestäjäilmoituksen private order note.
 
 ## Mitä on tehty
 
@@ -251,7 +257,7 @@ Tässä vaiheessa on toteutettu:
 - Tampere 2026 -ilmoittautumisen WooCommerce-pohjainen MVP
 - Tampere 2026 -osallistujalista adminissa
 - Tampere 2026 -osallistujien CSV-vienti
-- Tampere 2026 -järjestäjäilmoitukset
+- maksullisten tapahtumien tapahtumakohtaiset järjestäjäilmoitukset
 - rajattu `Event Organizer` -rooli tapahtumien ja ilmoittautumisten hallintaan
 - yhdistetty `Tapahtumat > Osallistujat` -näkymä ilmaisten ja maksullisten tapahtumien osallistujille
 

--- a/docs/woocommerce-setup.md
+++ b/docs/woocommerce-setup.md
@@ -50,7 +50,7 @@ Tämä dokumentti kuvaa ensimmäisen WooCommerce-slicen paikallisessa Docker-ymp
 - Tampere 2026 -checkout-kentät on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-checkout-fields.md`.
 - Tampere 2026 -tapahtumamaksun hallinta on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-management.md`.
 - Tampere 2026 -osallistujat näkyvät yhteisessä `Tapahtumat > Osallistujat` -näkymässä; katso `docs/event-participants-admin.md`.
-- Tampere 2026 -järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
+- Maksullisten tapahtumien tapahtumakohtaiset järjestäjäilmoitukset on dokumentoitu erikseen tiedostossa `docs/woocommerce-tampere-2026-notifications.md`.
 - Mollie-maksutapojen paikallinen testikäyttöönotto on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-payments.md`.
 - Mollien dev-live käyttöönotto ja hyväksymistestaus on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-go-live.md`.
 - Mollie MobilePay -käyttöönotto ja mahdolliset tilikohtaiset blockerit on dokumentoitu erikseen tiedostossa `docs/woocommerce-mollie-mobilepay.md`.

--- a/docs/woocommerce-tampere-2026-notifications.md
+++ b/docs/woocommerce-tampere-2026-notifications.md
@@ -1,51 +1,59 @@
-# WooCommerce: Tampere 2026 järjestäjäilmoitukset
+# WooCommerce: maksullisten tapahtumien järjestäjäilmoitukset
 
-Tämä dokumentti kuvaa tiketin `#150` toteutusmallin.
+Tämä dokumentti kuvaa alun perin Tampere 2026 -ilmoituksia varten tehtyä toiminnallisuutta. Tiketissä `#269` se muutettiin yleiseksi maksullisten tapahtumien järjestäjäilmoitukseksi.
 
 ## Tavoite
 
-Kun Tampere 2026 -ilmoittautumistilaus siirtyy tilaan `on-hold`, juhlajärjestelytoimikunnalle lähtee yksi plain text -sähköposti ilman, että tilausta täytyy avata käsin WooCommerce-adminissa.
+Kun WooCommerce-tilaus sisältää tapahtumaan linkitetyn maksutuotteen, tapahtuman järjestäjille lähtee yksi plain text -sähköposti ilman, että tilausta täytyy avata käsin WooCommerce-adminissa.
 
 ## Lähetyslogiikka
 
-- Ilmoitus lähetetään vain Tampere 2026 -tilauksista.
-- Ilmoitus lähetetään, kun tilaus siirtyy tilaan `on-hold`.
-- Ilmoitus lähetetään vain kerran per tilaus.
-- Lähetyksen deduplikointi tehdään order-metalla `_rytkoset_tampere_2026_notification_sent_at`.
-- Käytetty vastaanottajalista tallennetaan order-metana avaimeen `_rytkoset_tampere_2026_notification_recipients`.
+- Ilmoitus lähetetään WooCommerce-tilauksista, joissa on jonkin tapahtuman `Maksutuote`-kenttään linkitetty tuote tai sen variaatio.
+- Ilmoitus lähetetään, kun tilaus saavuttaa ensimmäisen aktiivisen tilan: `on-hold`, `processing` tai `completed`.
+- Ilmoitus lähetetään vain kerran per tapahtuma per tilaus.
+- Lähetyksen deduplikointi tehdään order-metalla `_rytkoset_event_organizer_notification_sent_at_{event_id}`.
+- Käytetty vastaanottajalista tallennetaan order-metana avaimeen `_rytkoset_event_organizer_notification_recipients_{event_id}`.
+- Jos samassa tilauksessa on usean eri tapahtuman maksutuotteita, jokaiselle tapahtumalle lähetetään oma ilmoitus sen omille vastaanottajille.
 
 ## Vastaanottajat
 
-- Vastaanottajat hallitaan WordPress-adminissa kohdassa `Asetukset > Yleiset`.
-- Asetuksen nimi on `Tampere 2026 järjestäjäilmoitusten vastaanottajat`.
+- Vastaanottajat hallitaan tapahtuman muokkausnäkymässä metaboxissa `Järjestäjäilmoitukset`.
+- Kentän nimi on `Järjestäjäilmoitusten vastaanottajat`.
+- Tapahtuman meta-avain on `_rytkoset_event_organizer_notification_recipients`.
 - Osoitteet voidaan syöttää pilkuilla tai rivinvaihdoilla eroteltuna.
 - Tallennuksessa säilytetään vain kelvolliset uniikit sähköpostiosoitteet.
 - Jos vastaanottajia ei ole asetettu, sähköpostia ei lähetetä ja tilaukselle lisätään private order note.
+- Vanhaa `Asetukset > Yleiset` -sivun Tampere 2026 -vastaanottajakenttää ei enää näytetä eikä käytetä.
 
 ## Sähköpostin sisältö
 
 Ilmoitusviesti sisältää vähintään:
 
+- tapahtuman nimen
+- tapahtuman päivämäärän
+- tapahtuman paikan
 - tilausnumeron
 - tilauksen päivämäärän
 - tilan
 - maksutavan
 - yhteyshenkilön nimen
-- sähköpostin
-- puhelinnumeron
-- osallistujien nimet
-- ruokarajoitteet / allergiat, jos niitä on annettu
+- yhteyshenkilön sähköpostin
+- yhteyshenkilön puhelinnumeron
+- osallistujat
 - asiakkaan lisätiedot, jos niitä on annettu
 - linkin tilaukseen adminissa, jos sellainen voidaan muodostaa
+
+Tampere 2026 -tilauksissa osallistujat puretaan edelleen checkoutin osallistujakentistä. Muissa maksullisissa tapahtumissa osallistujat muodostetaan tilaajan yhteystiedoista ja tapahtumatuotteen ostetusta määrästä.
 
 ## Audit trail
 
 - Onnistuneesta lähetyksestä lisätään private order note.
 - Epäonnistuneesta lähetyksestä lisätään private order note.
 - Puuttuvista vastaanottajista lisätään private order note.
+- Onnistuneen lähetyksen ajankohta ja käytetty vastaanottajalista tallennetaan tilauksen metaan tapahtumakohtaisesti.
 
 ## Debug local/dev-ympäristössä
 
 - Jos `wp_mail` epäonnistuu local- tai dev-ympäristössä, tilaukselle lisätään private order noteen myös debug-esikatselu.
-- Debug-notessa näkyvät virhesyy, sähköpostin aiherivi ja viestin sisältö.
-- Tarkoitus on helpottaa lokaalissa kehityksessä sen varmistamista, mitä sähköpostia järjestelmää oli yrittämässä lähettää.
+- Debug-notessa näkyvät tapahtuma, virhesyy, sähköpostin aiherivi ja viestin sisältö.
+- Tarkoitus on helpottaa lokaalissa kehityksessä sen varmistamista, mitä sähköpostia järjestelmä yritti lähettää.

--- a/wp-content/themes/rytkoset-theme/inc/events.php
+++ b/wp-content/themes/rytkoset-theme/inc/events.php
@@ -8,6 +8,41 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Normalizes a raw email list into unique, valid recipient addresses.
+ *
+ * @param string $raw_value Raw textarea value.
+ * @return array<int, string>
+ */
+function rytkoset_theme_normalize_email_list( $raw_value ) {
+	$parts   = preg_split( '/[\r\n,;]+/', (string) $raw_value );
+	$emails  = array();
+	$results = array();
+
+	if ( ! is_array( $parts ) ) {
+		return array();
+	}
+
+	foreach ( $parts as $part ) {
+		$email = sanitize_email( trim( (string) $part ) );
+
+		if ( '' === $email || ! is_email( $email ) ) {
+			continue;
+		}
+
+		$index = strtolower( $email );
+
+		if ( isset( $emails[ $index ] ) ) {
+			continue;
+		}
+
+		$emails[ $index ] = true;
+		$results[]        = $email;
+	}
+
+	return $results;
+}
+
+/**
  * Rekisteröi tapahtumien CPT:n.
  */
 function rytkoset_theme_register_event_cpt() {
@@ -746,6 +781,39 @@ function rytkoset_theme_get_event_product_meta_key() {
 }
 
 /**
+ * Returns the meta key used for event organizer notification recipients.
+ *
+ * @return string
+ */
+function rytkoset_theme_get_event_organizer_notification_recipients_meta_key() {
+	return '_rytkoset_event_organizer_notification_recipients';
+}
+
+/**
+ * Sanitizes event organizer notification recipients for storage.
+ *
+ * @param string $raw_value Raw textarea value.
+ * @return string
+ */
+function rytkoset_theme_sanitize_event_organizer_notification_recipients( $raw_value ) {
+	$emails = rytkoset_theme_normalize_email_list( $raw_value );
+
+	return implode( "\n", $emails );
+}
+
+/**
+ * Returns configured organizer notification recipients for an event.
+ *
+ * @param int $event_id Event post ID.
+ * @return array<int, string>
+ */
+function rytkoset_theme_get_event_organizer_notification_recipients( $event_id ) {
+	$value = get_post_meta( absint( $event_id ), rytkoset_theme_get_event_organizer_notification_recipients_meta_key(), true );
+
+	return rytkoset_theme_normalize_email_list( is_scalar( $value ) ? (string) $value : '' );
+}
+
+/**
  * Returns the WooCommerce product linked to an event.
  *
  * @param int $event_id Event post ID.
@@ -807,6 +875,21 @@ function rytkoset_theme_register_event_product_metabox() {
 add_action( 'add_meta_boxes_rytkoset_event', 'rytkoset_theme_register_event_product_metabox' );
 
 /**
+ * Adds the event organizer notifications metabox.
+ */
+function rytkoset_theme_register_event_organizer_notifications_metabox() {
+	add_meta_box(
+		'rytkoset_event_organizer_notifications',
+		__( 'Järjestäjäilmoitukset', 'rytkoset-theme' ),
+		'rytkoset_theme_render_event_organizer_notifications_metabox',
+		'rytkoset_event',
+		'side',
+		'default'
+	);
+}
+add_action( 'add_meta_boxes_rytkoset_event', 'rytkoset_theme_register_event_organizer_notifications_metabox' );
+
+/**
  * Prints small editor-only styles for event admin metaboxes.
  */
 function rytkoset_theme_print_event_admin_styles() {
@@ -820,6 +903,7 @@ function rytkoset_theme_print_event_admin_styles() {
 		#rytkoset_event_date_field,
 		#rytkoset_event_registration_deadline,
 		#rytkoset_event_product_id,
+		#rytkoset_event_organizer_notification_recipients,
 		#rytkoset_event_start_time,
 		#rytkoset_event_end_time,
 		#rytkoset_event_fee_type {
@@ -1001,6 +1085,35 @@ function rytkoset_theme_render_event_product_metabox( $post ) {
 }
 
 /**
+ * Renders the event organizer notifications metabox.
+ *
+ * @param WP_Post $post Event post object.
+ * @return void
+ */
+function rytkoset_theme_render_event_organizer_notifications_metabox( $post ) {
+	$meta_key = rytkoset_theme_get_event_organizer_notification_recipients_meta_key();
+	$value    = (string) get_post_meta( $post->ID, $meta_key, true );
+
+	wp_nonce_field( 'rytkoset_save_event_organizer_notifications', 'rytkoset_event_organizer_notifications_nonce' );
+	?>
+	<p>
+		<label for="rytkoset_event_organizer_notification_recipients">
+			<?php esc_html_e( 'Järjestäjäilmoitusten vastaanottajat', 'rytkoset-theme' ); ?>
+		</label>
+	</p>
+	<textarea
+		id="rytkoset_event_organizer_notification_recipients"
+		name="rytkoset_event_organizer_notification_recipients"
+		rows="5"
+		class="widefat"
+	><?php echo esc_textarea( $value ); ?></textarea>
+	<p class="description">
+		<?php esc_html_e( 'Anna järjestäjäilmoitusten vastaanottajaosoitteet pilkuilla tai rivinvaihdoilla eroteltuna.', 'rytkoset-theme' ); ?>
+	</p>
+	<?php
+}
+
+/**
  * Saves the WooCommerce product linked to an event.
  *
  * @param int $post_id Event post ID.
@@ -1047,6 +1160,50 @@ function rytkoset_theme_save_event_product_link( $post_id ) {
 	update_post_meta( $post_id, rytkoset_theme_get_event_product_meta_key(), $product_id );
 }
 add_action( 'save_post_rytkoset_event', 'rytkoset_theme_save_event_product_link' );
+
+/**
+ * Saves event organizer notification recipients.
+ *
+ * @param int $post_id Event post ID.
+ * @return void
+ */
+function rytkoset_theme_save_event_organizer_notifications( $post_id ) {
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	if ( wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+
+	if ( ! isset( $_POST['rytkoset_event_organizer_notifications_nonce'] ) ) {
+		return;
+	}
+
+	$nonce = sanitize_text_field( wp_unslash( $_POST['rytkoset_event_organizer_notifications_nonce'] ) );
+
+	if ( ! wp_verify_nonce( $nonce, 'rytkoset_save_event_organizer_notifications' ) ) {
+		return;
+	}
+
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	$raw_recipients = isset( $_POST['rytkoset_event_organizer_notification_recipients'] )
+		? sanitize_textarea_field( wp_unslash( $_POST['rytkoset_event_organizer_notification_recipients'] ) )
+		: '';
+	$recipients     = rytkoset_theme_sanitize_event_organizer_notification_recipients( $raw_recipients );
+	$meta_key       = rytkoset_theme_get_event_organizer_notification_recipients_meta_key();
+
+	if ( '' === $recipients ) {
+		delete_post_meta( $post_id, $meta_key );
+		return;
+	}
+
+	update_post_meta( $post_id, $meta_key, $recipients );
+}
+add_action( 'save_post_rytkoset_event', 'rytkoset_theme_save_event_organizer_notifications' );
 
 /**
  * Returns the linked product URL for an event.

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
@@ -1134,122 +1134,6 @@ add_action( 'manage_shop_order_posts_custom_column', 'rytkoset_theme_render_tamp
 add_action( 'manage_woocommerce_page_wc-orders_custom_column', 'rytkoset_theme_render_tampere_2026_orders_column', 25, 2 );
 
 /**
- * Returns the option name used for Tampere 2026 organizer notification recipients.
- *
- * @return string
- */
-function rytkoset_theme_get_tampere_2026_notification_recipients_option_name() {
-	return 'rytkoset_tampere_2026_notification_recipients';
-}
-
-/**
- * Normalizes a raw email list into unique, valid recipient addresses.
- *
- * @param string $raw_value Raw textarea value.
- * @return array<int, string>
- */
-function rytkoset_theme_normalize_email_list( $raw_value ) {
-	$parts   = preg_split( '/[\r\n,;]+/', (string) $raw_value );
-	$emails  = array();
-	$results = array();
-
-	if ( ! is_array( $parts ) ) {
-		return array();
-	}
-
-	foreach ( $parts as $part ) {
-		$email = sanitize_email( trim( (string) $part ) );
-
-		if ( '' === $email || ! is_email( $email ) ) {
-			continue;
-		}
-
-		$index = strtolower( $email );
-
-		if ( isset( $emails[ $index ] ) ) {
-			continue;
-		}
-
-		$emails[ $index ] = true;
-		$results[]        = $email;
-	}
-
-	return $results;
-}
-
-/**
- * Sanitizes the organizer notification recipients option.
- *
- * @param string $raw_value Raw textarea value.
- * @return string
- */
-function rytkoset_theme_sanitize_tampere_2026_notification_recipients_option( $raw_value ) {
-	$emails = rytkoset_theme_normalize_email_list( $raw_value );
-
-	return implode( "\n", $emails );
-}
-
-/**
- * Returns the configured organizer notification recipients.
- *
- * @return array<int, string>
- */
-function rytkoset_theme_get_tampere_2026_notification_recipients() {
-	$value = get_option( rytkoset_theme_get_tampere_2026_notification_recipients_option_name(), '' );
-
-	return rytkoset_theme_normalize_email_list( (string) $value );
-}
-
-/**
- * Renders the General Settings field for organizer notification recipients.
- *
- * @return void
- */
-function rytkoset_theme_render_tampere_2026_notification_recipients_setting() {
-	$option_name = rytkoset_theme_get_tampere_2026_notification_recipients_option_name();
-	$value       = (string) get_option( $option_name, '' );
-	?>
-	<textarea
-		name="<?php echo esc_attr( $option_name ); ?>"
-		id="<?php echo esc_attr( $option_name ); ?>"
-		rows="5"
-		cols="50"
-		class="large-text"
-	><?php echo esc_textarea( $value ); ?></textarea>
-	<p class="description">
-		<?php esc_html_e( 'Anna vastaanottajaosoitteet pilkuilla tai rivinvaihdoilla eroteltuna. Vain kelvolliset sähköpostiosoitteet tallennetaan.', 'rytkoset-theme' ); ?>
-	</p>
-	<?php
-}
-
-/**
- * Registers the General Settings field for organizer notification recipients.
- *
- * @return void
- */
-function rytkoset_theme_register_tampere_2026_notification_recipients_setting() {
-	$option_name = rytkoset_theme_get_tampere_2026_notification_recipients_option_name();
-
-	register_setting(
-		'general',
-		$option_name,
-		array(
-			'type'              => 'string',
-			'sanitize_callback' => 'rytkoset_theme_sanitize_tampere_2026_notification_recipients_option',
-			'default'           => '',
-		)
-	);
-
-	add_settings_field(
-		$option_name,
-		__( 'Tampere 2026 järjestäjäilmoitusten vastaanottajat', 'rytkoset-theme' ),
-		'rytkoset_theme_render_tampere_2026_notification_recipients_setting',
-		'general'
-	);
-}
-add_action( 'admin_init', 'rytkoset_theme_register_tampere_2026_notification_recipients_setting' );
-
-/**
  * Returns true when the current site runs in a local or development environment.
  *
  * @return bool
@@ -1313,23 +1197,27 @@ function rytkoset_theme_format_wp_mail_failure( $error ) {
  * Adds a local/dev-only debug note for organizer notification failures.
  *
  * @param WC_Order $order         WooCommerce order object.
+ * @param int      $event_id      Event post ID.
  * @param string   $subject       Email subject.
  * @param string   $message       Email body.
  * @param string   $error_summary Formatted wp_mail failure summary.
  * @return void
  */
-function rytkoset_theme_add_tampere_2026_notification_debug_note( $order, $subject, $message, $error_summary ) {
+function rytkoset_theme_add_event_organizer_notification_debug_note( $order, $event_id, $subject, $message, $error_summary ) {
 	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_local_or_dev_environment() ) {
 		return;
 	}
 
+	$event_title = $event_id > 0 ? get_the_title( $event_id ) : '';
+
 	$note_lines = array(
-		__( 'Tampere 2026 -jarjestajailmoituksen debug (local/dev).', 'rytkoset-theme' ),
+		__( 'Tapahtuman järjestäjäilmoituksen debug (local/dev).', 'rytkoset-theme' ),
+		__( 'Tapahtuma:', 'rytkoset-theme' ) . ' ' . ( '' !== $event_title ? $event_title : __( 'Ei tiedossa', 'rytkoset-theme' ) ),
 		__( 'Virhe:', 'rytkoset-theme' ) . ' ' . $error_summary,
 		'',
 		__( 'Aihe:', 'rytkoset-theme' ) . ' ' . $subject,
 		'',
-		__( 'Lahetyksen viestisisalto:', 'rytkoset-theme' ),
+		__( 'Lähetyksen viestisisältö:', 'rytkoset-theme' ),
 		$message,
 	);
 
@@ -1337,90 +1225,39 @@ function rytkoset_theme_add_tampere_2026_notification_debug_note( $order, $subje
 }
 
 /**
- * Captures outgoing Tampere 2026 organizer notification email arguments.
- *
- * @param array<string, mixed> $mail_atts wp_mail arguments.
- * @return array<string, mixed>
- */
-function rytkoset_theme_capture_tampere_2026_notification_mail_args( $mail_atts ) {
-	$subject = isset( $mail_atts['subject'] ) ? (string) $mail_atts['subject'] : '';
-
-	if ( 0 === strpos( $subject, 'Tampere 2026 ilmoittautuminen #' ) ) {
-		$GLOBALS['rytkoset_theme_last_tampere_2026_mail_args'] = $mail_atts;
-	}
-
-	return $mail_atts;
-}
-add_filter( 'wp_mail', 'rytkoset_theme_capture_tampere_2026_notification_mail_args' );
-
-/**
- * Attempts to resolve a WooCommerce order from captured notification mail args.
- *
- * @param array<string, mixed> $mail_atts wp_mail arguments.
- * @return WC_Order|false
- */
-function rytkoset_theme_get_tampere_2026_order_from_mail_args( $mail_atts ) {
-	if ( ! is_array( $mail_atts ) ) {
-		return false;
-	}
-
-	$message = isset( $mail_atts['message'] ) ? (string) $mail_atts['message'] : '';
-	$subject = isset( $mail_atts['subject'] ) ? (string) $mail_atts['subject'] : '';
-
-	if ( preg_match( '/[?&]id=(\d+)/', $message, $matches ) ) {
-		return wc_get_order( (int) $matches[1] );
-	}
-
-	if ( preg_match( '/[?&]post=(\d+)/', $message, $matches ) ) {
-		return wc_get_order( (int) $matches[1] );
-	}
-
-	if ( preg_match( '/#(\d+)\s*$/', $subject, $matches ) ) {
-		return wc_get_order( (int) $matches[1] );
-	}
-
-	return false;
-}
-
-/**
- * Adds a local/dev-only debug note when wp_mail fails for Tampere 2026 notifications.
+ * Adds a local/dev-only debug note when wp_mail fails for event organizer notifications.
  *
  * @param WP_Error $error wp_mail failure object.
  * @return void
  */
-function rytkoset_theme_maybe_log_tampere_2026_notification_mail_failure( $error ) {
+function rytkoset_theme_maybe_log_event_organizer_notification_mail_failure( $error ) {
 	if ( ! rytkoset_theme_is_local_or_dev_environment() ) {
 		return;
 	}
 
-	$mail_atts = isset( $GLOBALS['rytkoset_theme_last_tampere_2026_mail_args'] ) && is_array( $GLOBALS['rytkoset_theme_last_tampere_2026_mail_args'] )
-		? $GLOBALS['rytkoset_theme_last_tampere_2026_mail_args']
+	$context = isset( $GLOBALS['rytkoset_theme_current_event_organizer_notification'] ) && is_array( $GLOBALS['rytkoset_theme_current_event_organizer_notification'] )
+		? $GLOBALS['rytkoset_theme_current_event_organizer_notification']
 		: null;
 
-	unset( $GLOBALS['rytkoset_theme_last_tampere_2026_mail_args'] );
-
-	if ( ! is_array( $mail_atts ) ) {
+	if ( ! is_array( $context ) ) {
 		return;
 	}
 
-	$subject = isset( $mail_atts['subject'] ) ? (string) $mail_atts['subject'] : '';
-
-	if ( 0 !== strpos( $subject, 'Tampere 2026 ilmoittautuminen #' ) ) {
-		return;
-	}
-
-	$order = rytkoset_theme_get_tampere_2026_order_from_mail_args( $mail_atts );
+	$order_id = isset( $context['order_id'] ) ? absint( $context['order_id'] ) : 0;
+	$event_id = isset( $context['event_id'] ) ? absint( $context['event_id'] ) : 0;
+	$order    = $order_id > 0 ? wc_get_order( $order_id ) : false;
 
 	if ( ! $order instanceof WC_Order ) {
 		return;
 	}
 
-	$message       = isset( $mail_atts['message'] ) ? (string) $mail_atts['message'] : '';
+	$subject       = isset( $context['subject'] ) ? (string) $context['subject'] : '';
+	$message       = isset( $context['message'] ) ? (string) $context['message'] : '';
 	$error_summary = rytkoset_theme_format_wp_mail_failure( $error );
 
-	rytkoset_theme_add_tampere_2026_notification_debug_note( $order, $subject, $message, $error_summary );
+	rytkoset_theme_add_event_organizer_notification_debug_note( $order, $event_id, $subject, $message, $error_summary );
 }
-add_action( 'wp_mail_failed', 'rytkoset_theme_maybe_log_tampere_2026_notification_mail_failure' );
+add_action( 'wp_mail_failed', 'rytkoset_theme_maybe_log_event_organizer_notification_mail_failure' );
 
 /**
  * Returns the edit URL for an order in the current admin configuration.
@@ -1445,24 +1282,212 @@ function rytkoset_theme_get_order_admin_edit_url( $order ) {
 }
 
 /**
- * Builds the organizer notification email subject for a Tampere 2026 order.
+ * Returns the order meta key used to deduplicate organizer notifications per event.
  *
- * @param WC_Order $order WooCommerce order object.
+ * @param int $event_id Event post ID.
  * @return string
  */
-function rytkoset_theme_get_tampere_2026_notification_subject( $order ) {
-	return sprintf( 'Tampere 2026 ilmoittautuminen #%s', $order->get_order_number() );
+function rytkoset_theme_get_event_organizer_notification_sent_at_meta_key( $event_id ) {
+	return '_rytkoset_event_organizer_notification_sent_at_' . absint( $event_id );
 }
 
 /**
- * Builds the organizer notification email body for a Tampere 2026 order.
+ * Returns the order meta key used to store the recipients used per event.
  *
- * @param WC_Order $order WooCommerce order object.
+ * @param int $event_id Event post ID.
  * @return string
  */
-function rytkoset_theme_get_tampere_2026_notification_message( $order ) {
-	$participants   = rytkoset_theme_get_tampere_2026_order_participants( $order );
+function rytkoset_theme_get_event_organizer_notification_recipients_order_meta_key( $event_id ) {
+	return '_rytkoset_event_organizer_notification_recipients_' . absint( $event_id );
+}
+
+/**
+ * Returns product IDs that identify an order item, including variations and parents.
+ *
+ * @param mixed $item WooCommerce order item.
+ * @return array<int, int>
+ */
+function rytkoset_theme_get_order_item_product_reference_ids( $item ) {
+	$ids = array();
+
+	if ( is_object( $item ) && method_exists( $item, 'get_product_id' ) ) {
+		$ids[] = absint( $item->get_product_id() );
+	}
+
+	if ( is_object( $item ) && method_exists( $item, 'get_variation_id' ) ) {
+		$ids[] = absint( $item->get_variation_id() );
+	}
+
+	$product = is_object( $item ) && method_exists( $item, 'get_product' ) ? $item->get_product() : null;
+
+	if ( $product instanceof WC_Product ) {
+		$ids[] = absint( $product->get_id() );
+		$ids[] = absint( $product->get_parent_id() );
+	}
+
+	return array_values( array_unique( array_filter( $ids ) ) );
+}
+
+/**
+ * Returns product IDs represented in an order.
+ *
+ * @param WC_Order $order WooCommerce order object.
+ * @return array<int, int>
+ */
+function rytkoset_theme_get_order_product_reference_ids( $order ) {
+	if ( ! $order instanceof WC_Order ) {
+		return array();
+	}
+
+	$product_ids = array();
+
+	foreach ( $order->get_items() as $item ) {
+		$product_ids = array_merge( $product_ids, rytkoset_theme_get_order_item_product_reference_ids( $item ) );
+	}
+
+	return array_values( array_unique( array_filter( array_map( 'absint', $product_ids ) ) ) );
+}
+
+/**
+ * Returns paid events linked to products in an order.
+ *
+ * @param WC_Order $order WooCommerce order object.
+ * @return array<int, int>
+ */
+function rytkoset_theme_get_order_paid_event_ids( $order ) {
+	$product_ids = rytkoset_theme_get_order_product_reference_ids( $order );
+
+	if ( empty( $product_ids ) ) {
+		return array();
+	}
+
+	$event_ids = get_posts(
+		array(
+			'post_type'      => 'rytkoset_event',
+			'post_status'    => array( 'publish', 'private' ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query'     => array(
+				array(
+					'key'     => rytkoset_theme_get_event_product_meta_key(),
+					'value'   => $product_ids,
+					'compare' => 'IN',
+					'type'    => 'NUMERIC',
+				),
+			),
+		)
+	);
+
+	return array_values( array_unique( array_map( 'absint', $event_ids ) ) );
+}
+
+/**
+ * Returns the ordered quantity for the WooCommerce product linked to an event.
+ *
+ * @param WC_Order $order    WooCommerce order object.
+ * @param int      $event_id Event post ID.
+ * @return int
+ */
+function rytkoset_theme_get_order_event_product_quantity( $order, $event_id ) {
+	if ( ! $order instanceof WC_Order ) {
+		return 0;
+	}
+
+	$product_id = absint( get_post_meta( absint( $event_id ), rytkoset_theme_get_event_product_meta_key(), true ) );
+
+	if ( $product_id <= 0 ) {
+		return 0;
+	}
+
+	$quantity = 0;
+
+	foreach ( $order->get_items() as $item ) {
+		if ( ! in_array( $product_id, rytkoset_theme_get_order_item_product_reference_ids( $item ), true ) ) {
+			continue;
+		}
+
+		$quantity += is_object( $item ) && method_exists( $item, 'get_quantity' ) ? absint( $item->get_quantity() ) : 0;
+	}
+
+	return $quantity;
+}
+
+/**
+ * Returns participant rows for an event organizer notification.
+ *
+ * @param WC_Order $order    WooCommerce order object.
+ * @param int      $event_id Event post ID.
+ * @return array<int, array<string, mixed>>
+ */
+function rytkoset_theme_get_event_order_notification_participants( $order, $event_id ) {
+	$product = rytkoset_theme_get_event_linked_product( $event_id );
+
+	if (
+		function_exists( 'rytkoset_theme_is_tampere_2026_registration_product' )
+		&& function_exists( 'rytkoset_theme_get_tampere_2026_order_participants' )
+		&& rytkoset_theme_is_tampere_2026_registration_product( $product )
+	) {
+		return rytkoset_theme_get_tampere_2026_order_participants( $order );
+	}
+
+	$quantity     = max( 1, rytkoset_theme_get_order_event_product_quantity( $order, $event_id ) );
+	$contact_name = trim( $order->get_formatted_billing_full_name() );
+	$participants = array();
+
+	if ( '' === $contact_name ) {
+		$contact_name = __( 'Nimi puuttuu', 'rytkoset-theme' );
+	}
+
+	for ( $index = 0; $index < $quantity; $index++ ) {
+		$participants[] = array(
+			'name'             => $contact_name,
+			'email'            => (string) $order->get_billing_email(),
+			'phone'            => (string) $order->get_billing_phone(),
+			'diet'             => '',
+			'participant_type' => '',
+			'friday_buffet'    => null,
+		);
+	}
+
+	return $participants;
+}
+
+/**
+ * Builds the organizer notification email subject for an event order.
+ *
+ * @param WC_Order $order    WooCommerce order object.
+ * @param int      $event_id Event post ID.
+ * @return string
+ */
+function rytkoset_theme_get_event_organizer_notification_subject( $order, $event_id ) {
+	$event_title = wp_strip_all_tags( get_the_title( $event_id ) );
+
+	if ( '' === $event_title ) {
+		$event_title = __( 'Tapahtuma', 'rytkoset-theme' );
+	}
+
+	return sprintf(
+		/* translators: 1: event title, 2: order number. */
+		__( 'Tapahtumailmoittautuminen: %1$s / tilaus #%2$s', 'rytkoset-theme' ),
+		$event_title,
+		$order->get_order_number()
+	);
+}
+
+/**
+ * Builds the organizer notification email body for an event order.
+ *
+ * @param WC_Order $order    WooCommerce order object.
+ * @param int      $event_id Event post ID.
+ * @return string
+ */
+function rytkoset_theme_get_event_organizer_notification_message( $order, $event_id ) {
+	$participants   = rytkoset_theme_get_event_order_notification_participants( $order, $event_id );
 	$admin_edit_url = rytkoset_theme_get_order_admin_edit_url( $order );
+	$event_title    = wp_strip_all_tags( get_the_title( $event_id ) );
+	$event_date     = rytkoset_theme_get_event_date_display( $event_id );
+	$event_location = rytkoset_theme_get_event_location( $event_id );
 	$contact_name   = trim( $order->get_formatted_billing_full_name() );
 	$email          = trim( (string) $order->get_billing_email() );
 	$phone          = trim( (string) $order->get_billing_phone() );
@@ -1472,7 +1497,11 @@ function rytkoset_theme_get_tampere_2026_notification_message( $order ) {
 	$created_text   = $created_at ? wp_date( 'j.n.Y H:i', $created_at->getTimestamp(), wp_timezone() ) : __( 'Ei tiedossa', 'rytkoset-theme' );
 	$status_name    = function_exists( 'wc_get_order_status_name' ) ? wc_get_order_status_name( $order->get_status() ) : $order->get_status();
 	$lines          = array(
-		'Rytkösten sukuseura / Tampere 2026 ilmoittautuminen',
+		'Rytkösten sukuseura / tapahtumailmoittautuminen',
+		'',
+		'tapahtuma: ' . ( '' !== $event_title ? $event_title : __( 'Ei tiedossa', 'rytkoset-theme' ) ),
+		'tapahtumapäivä: ' . ( '' !== $event_date ? $event_date : __( 'Ei tiedossa', 'rytkoset-theme' ) ),
+		'paikka: ' . ( '' !== $event_location ? $event_location : __( 'Ei tiedossa', 'rytkoset-theme' ) ),
 		'',
 		'tilausnumero: #' . $order->get_order_number(),
 		'päiväys: ' . $created_text,
@@ -1496,18 +1525,32 @@ function rytkoset_theme_get_tampere_2026_notification_message( $order ) {
 		$lines[] = '- Osallistujatietoja ei löytynyt tilaukselta.';
 	} else {
 		foreach ( $participants as $index => $participant ) {
-			$participant_name = '' !== $participant['name'] ? $participant['name'] : __( 'Nimi puuttuu', 'rytkoset-theme' );
+			if ( ! is_array( $participant ) ) {
+				continue;
+			}
+
+			$participant_name = isset( $participant['name'] ) && '' !== $participant['name'] ? (string) $participant['name'] : __( 'Nimi puuttuu', 'rytkoset-theme' );
 			$lines[]          = sprintf( '%d. %s', $index + 1, $participant_name );
 
 			if ( ! empty( $participant['participant_type'] ) ) {
 				$lines[] = '   osallistujatyyppi: ' . $participant['participant_type'];
 			}
 
-			if ( '' !== $participant['diet'] ) {
+			if ( ! empty( $participant['email'] ) ) {
+				$lines[] = '   sähköposti: ' . $participant['email'];
+			}
+
+			if ( ! empty( $participant['phone'] ) ) {
+				$lines[] = '   puhelin: ' . $participant['phone'];
+			}
+
+			if ( ! empty( $participant['diet'] ) ) {
 				$lines[] = '   ruokarajoitteet / allergiat: ' . $participant['diet'];
 			}
 
-			$lines[] = '   perjantain buffet: ' . ( ! empty( $participant['friday_buffet'] ) ? 'kyllä' : 'ei' );
+			if ( array_key_exists( 'friday_buffet', $participant ) && null !== $participant['friday_buffet'] ) {
+				$lines[] = '   perjantain buffet: ' . ( ! empty( $participant['friday_buffet'] ) ? 'kyllä' : 'ei' );
+			}
 		}
 	}
 
@@ -1521,43 +1564,61 @@ function rytkoset_theme_get_tampere_2026_notification_message( $order ) {
 }
 
 /**
- * Sends the Tampere 2026 organizer notification for an order.
+ * Sends the organizer notification for a paid event order.
  *
- * @param WC_Order $order WooCommerce order object.
+ * @param WC_Order $order    WooCommerce order object.
+ * @param int      $event_id Event post ID.
  * @return bool
  */
-function rytkoset_theme_send_tampere_2026_organizer_notification( $order ) {
-	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+function rytkoset_theme_send_event_organizer_notification( $order, $event_id ) {
+	$event_id = absint( $event_id );
+
+	if ( ! $order instanceof WC_Order || $event_id <= 0 || 'rytkoset_event' !== get_post_type( $event_id ) ) {
 		return false;
 	}
 
-	$sent_at = (string) $order->get_meta( '_rytkoset_tampere_2026_notification_sent_at', true );
+	$sent_at_meta_key = rytkoset_theme_get_event_organizer_notification_sent_at_meta_key( $event_id );
+	$sent_at          = (string) $order->get_meta( $sent_at_meta_key, true );
 
 	if ( '' !== $sent_at ) {
 		return false;
 	}
 
-	$recipients = rytkoset_theme_get_tampere_2026_notification_recipients();
+	$recipients  = rytkoset_theme_get_event_organizer_notification_recipients( $event_id );
+	$event_title = wp_strip_all_tags( get_the_title( $event_id ) );
 
 	if ( empty( $recipients ) ) {
 		$order->add_order_note(
-			__( 'Tampere 2026 -järjestäjäilmoitusta ei lähetetty, koska vastaanottajaosoitteita ei ole asetettu kohdassa Asetukset > Yleiset.', 'rytkoset-theme' ),
+			sprintf(
+				/* translators: %s: event title. */
+				__( 'Tapahtuman järjestäjäilmoitusta ei lähetetty tapahtumalle "%s", koska tapahtumalle ei ole asetettu vastaanottajia.', 'rytkoset-theme' ),
+				'' !== $event_title ? $event_title : __( 'Ei tiedossa', 'rytkoset-theme' )
+			),
 			false
 		);
 		return false;
 	}
 
-	$sent = wp_mail(
-		$recipients,
-		rytkoset_theme_get_tampere_2026_notification_subject( $order ),
-		rytkoset_theme_get_tampere_2026_notification_message( $order )
+	$subject = rytkoset_theme_get_event_organizer_notification_subject( $order, $event_id );
+	$message = rytkoset_theme_get_event_organizer_notification_message( $order, $event_id );
+
+	$GLOBALS['rytkoset_theme_current_event_organizer_notification'] = array(
+		'order_id' => $order->get_id(),
+		'event_id' => $event_id,
+		'subject'  => $subject,
+		'message'  => $message,
 	);
+
+	$sent = wp_mail( $recipients, $subject, $message );
+
+	unset( $GLOBALS['rytkoset_theme_current_event_organizer_notification'] );
 
 	if ( ! $sent ) {
 		$order->add_order_note(
 			sprintf(
-				/* translators: %s: recipient email list. */
-				__( 'Tampere 2026 -järjestäjäilmoituksen lähetys epäonnistui. Vastaanottajat: %s', 'rytkoset-theme' ),
+				/* translators: 1: event title, 2: recipient email list. */
+				__( 'Tapahtuman järjestäjäilmoituksen lähetys epäonnistui tapahtumalle "%1$s". Vastaanottajat: %2$s', 'rytkoset-theme' ),
+				'' !== $event_title ? $event_title : __( 'Ei tiedossa', 'rytkoset-theme' ),
 				implode( ', ', $recipients )
 			),
 			false
@@ -1565,14 +1626,15 @@ function rytkoset_theme_send_tampere_2026_organizer_notification( $order ) {
 		return false;
 	}
 
-	$order->update_meta_data( '_rytkoset_tampere_2026_notification_sent_at', current_time( 'mysql' ) );
-	$order->update_meta_data( '_rytkoset_tampere_2026_notification_recipients', implode( ', ', $recipients ) );
+	$order->update_meta_data( $sent_at_meta_key, current_time( 'mysql' ) );
+	$order->update_meta_data( rytkoset_theme_get_event_organizer_notification_recipients_order_meta_key( $event_id ), implode( ', ', $recipients ) );
 	$order->save();
 
 	$order->add_order_note(
 		sprintf(
-			/* translators: %s: recipient email list. */
-			__( 'Tampere 2026 -järjestäjäilmoitus lähetettiin osoitteisiin: %s', 'rytkoset-theme' ),
+			/* translators: 1: event title, 2: recipient email list. */
+			__( 'Tapahtuman järjestäjäilmoitus lähetettiin tapahtumalle "%1$s" osoitteisiin: %2$s', 'rytkoset-theme' ),
+			'' !== $event_title ? $event_title : __( 'Ei tiedossa', 'rytkoset-theme' ),
 			implode( ', ', $recipients )
 		),
 		false
@@ -1582,13 +1644,13 @@ function rytkoset_theme_send_tampere_2026_organizer_notification( $order ) {
 }
 
 /**
- * Sends the Tampere 2026 organizer notification when an order moves to on-hold.
+ * Sends paid event organizer notifications when an order reaches an active status.
  *
  * @param int      $order_id WooCommerce order ID.
  * @param WC_Order $order    WooCommerce order object.
  * @return void
  */
-function rytkoset_theme_maybe_send_tampere_2026_organizer_notification( $order_id, $order ) {
+function rytkoset_theme_maybe_send_event_organizer_notifications( $order_id, $order ) {
 	if ( ! $order instanceof WC_Order ) {
 		$order = wc_get_order( $order_id );
 	}
@@ -1597,6 +1659,10 @@ function rytkoset_theme_maybe_send_tampere_2026_organizer_notification( $order_i
 		return;
 	}
 
-	rytkoset_theme_send_tampere_2026_organizer_notification( $order );
+	foreach ( rytkoset_theme_get_order_paid_event_ids( $order ) as $event_id ) {
+		rytkoset_theme_send_event_organizer_notification( $order, $event_id );
+	}
 }
-add_action( 'woocommerce_order_status_on-hold', 'rytkoset_theme_maybe_send_tampere_2026_organizer_notification', 10, 2 );
+add_action( 'woocommerce_order_status_on-hold', 'rytkoset_theme_maybe_send_event_organizer_notifications', 10, 2 );
+add_action( 'woocommerce_order_status_processing', 'rytkoset_theme_maybe_send_event_organizer_notifications', 10, 2 );
+add_action( 'woocommerce_order_status_completed', 'rytkoset_theme_maybe_send_event_organizer_notifications', 10, 2 );


### PR DESCRIPTION
## Summary
- Add event-specific organizer notification recipients for paid events
- Replace the old global Tampere 2026 recipient setting with a per-event metabox
- Generalize WooCommerce organizer notifications for all paid events linked via `Maksutuote`

## Changes
- Added `_rytkoset_event_organizer_notification_recipients` event meta
- Added `Järjestäjäilmoitukset` metabox to event admin
- Sends organizer notifications once per event per order when order reaches `on-hold`, `processing`, or `completed`
- Keeps Tampere 2026 participant-specific email details
- Adds order notes for successful sends, failed sends, and missing recipients
- Updated docs, `CLAUDE.md`, and `CHANGELOG.md`

## Testing
- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/inc/events.php`
- `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php`
- `git diff --check`
- Manual PHP smoke test for recipient normalization, event lookup, mail capture, and dedupe
- Manual PHP smoke test for multi-event order handling and missing recipients

## Notes
- `phpcs` was not run because it is not installed in the container.