### PR TITLE
fix: hide extra Tampere 2026 participant fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.
 
 ### Fixed
+- Tampere 2026 -tilausten ylimääräiset osallistujien 2-10 buffet-kentät piilotetaan tilausvahvistuksesta, sähköposteista ja administa sekä siivotaan uusilta Store API -tilauksilta (#271)
 - Tietosuojaselosteen pitkät linkit, sähköpostiosoitteet ja koodimaiset tekstipätkät rivittyvät mobiilileveydellä ilman vaakasuuntaista overflow’ta (#267)
 - Maksuttoman tapahtuman julkinen ilmoittautumislomake hylkää honeypot-kentän täyttävät bottimaiset lähetykset ilman ilmoittautumisen tallennusta.
 - Tapahtumailmoittautuminen estää aktiiviset kaksoisilmoittautumiset samalla sähköpostilla ja huomioi ilmoittautumisajan päättymisen

--- a/docs/woocommerce-tampere-2026-checkout-fields.md
+++ b/docs/woocommerce-tampere-2026-checkout-fields.md
@@ -40,6 +40,8 @@ Osallistujatyyppi (`Aikuinen` tai `Lapsi 3-12 vuotta`) tulee tuotteen variaatios
 - Kenttien määrä perustuu Tampere 2026 -variaatioiden yhteenlaskettuun kappalemäärään.
 - Tunnistus tehdään ensisijaisesti parent-tuotteen SKU:lla `tampere-2026-osallistumismaksu`.
 - Kentät tallentuvat tilauksen lisäkentiksiin order-metana.
+- Piilotettuja ylimääräisiä osallistujakenttiä ei näytetä tilausvahvistuksessa, sähköposteissa tai WooCommerce-adminissa.
+- Uusilta Store API -tilauksilta poistetaan ylimääräisten osallistujien lisäkenttämetat, jos WooCommerce Blocks on tallentanut tyhjiä checkbox-arvoja.
 - Osallistujatiedot näytetään myös WooCommerce-adminissa tilauksen yhteydessä.
 - Osallistujatyyppi puretaan tilauksen rivien variaatioista samassa järjestyksessä kuin osallistujakohtaiset checkout-kentät.
 - Kenttien autocomplete on tarkoituksella rajattu pois, jotta selaimen autofill ei kirjoita nimiä ruokarajoitekenttiin.
@@ -55,6 +57,10 @@ Osallistujatyyppi (`Aikuinen` tai `Lapsi 3-12 vuotta`) tulee tuotteen variaatios
 
 ## Testaus
 
+- Lisää Tampere 2026 -tuotetta ostoskoriin yksi osallistuja
+- Tee testitilaus loppuun
+- Varmista, että tilausvahvistuksessa, sähköpostissa ja adminissa näkyvät vain osallistujan 1 kentät
+- Varmista, ettei osallistujien 2-10 tyhjiä buffet-kenttiä näytetä arvolla `Ei`
 - Lisää Tampere 2026 -tuotetta ostoskoriin yksi aikuinen ja yksi lapsi
 - Varmista, että kassalla näkyy 2 osallistujan kentät
 - Täytä molempien osallistujien nimet
@@ -62,3 +68,4 @@ Osallistujatyyppi (`Aikuinen` tai `Lapsi 3-12 vuotta`) tulee tuotteen variaatios
 - Merkitse toiselle perjantain buffet-illallinen
 - Tee testitilaus loppuun
 - Varmista administa, että molemmat osallistujat näkyvät tilauksella luettavasti osallistujatyypin, ruokarajoitteen ja buffet-valinnan kanssa
+- Varmista, ettei osallistujien 3-10 tyhjiä kenttiä näytetä tilausvahvistuksessa, sähköpostissa tai adminissa

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
@@ -966,6 +966,167 @@ function rytkoset_theme_get_tampere_2026_order_participant_quantity( $order ) {
 }
 
 /**
+ * Returns the Tampere 2026 participant field IDs for a participant index.
+ *
+ * @param int $index Participant index.
+ * @return array<int, string>
+ */
+function rytkoset_theme_get_tampere_2026_participant_field_ids( $index ) {
+	$index = absint( $index );
+
+	return array(
+		sprintf( 'rytkoset/participant_%d_name', $index ),
+		sprintf( 'rytkoset/participant_%d_diet', $index ),
+		sprintf( 'rytkoset/participant_%d_friday_buffet', $index ),
+	);
+}
+
+/**
+ * Removes WooCommerce's order meta prefix from an additional checkout field ID.
+ *
+ * @param string $field_id Field ID or order meta key.
+ * @return string
+ */
+function rytkoset_theme_normalize_tampere_2026_participant_field_id( $field_id ) {
+	$field_id = (string) $field_id;
+	$prefix   = '_wc_other/';
+
+	if ( 0 === strpos( $field_id, $prefix ) ) {
+		return substr( $field_id, strlen( $prefix ) );
+	}
+
+	return $field_id;
+}
+
+/**
+ * Parses a Tampere 2026 participant index from an additional checkout field ID.
+ *
+ * @param string $field_id Field ID or order meta key.
+ * @return int Participant index, or 0 when the field is not a Tampere 2026 participant field.
+ */
+function rytkoset_theme_get_tampere_2026_participant_index_from_field_id( $field_id ) {
+	$field_id = rytkoset_theme_normalize_tampere_2026_participant_field_id( $field_id );
+
+	if ( ! preg_match( '/^rytkoset\/participant_(\d+)_(?:name|diet|friday_buffet)$/', $field_id, $matches ) ) {
+		return 0;
+	}
+
+	return absint( $matches[1] );
+}
+
+/**
+ * Resolves the original checkout field ID from WooCommerce order confirmation field data.
+ *
+ * @param array<string, mixed> $field Field data.
+ * @param array<string, mixed> $fields All fields in the current confirmation context.
+ * @return string
+ */
+function rytkoset_theme_get_order_confirmation_checkout_field_id( $field, $fields ) {
+	if ( isset( $field['id'] ) && is_string( $field['id'] ) ) {
+		return $field['id'];
+	}
+
+	foreach ( $fields as $field_id => $candidate_field ) {
+		if ( $candidate_field === $field ) {
+			return (string) $field_id;
+		}
+	}
+
+	return '';
+}
+
+/**
+ * Hides extra Tampere 2026 participant fields from order confirmation views and emails.
+ *
+ * WooCommerce Blocks stores unchecked hidden checkboxes as false, which would otherwise
+ * render as "Ei" for participants that were not actually purchased.
+ *
+ * @param bool                 $show Whether WooCommerce would show the field.
+ * @param array<string, mixed> $field Field data.
+ * @param array<string, mixed> $fields All fields in the current confirmation context.
+ * @param array<string, mixed> $context Confirmation context.
+ * @return bool
+ */
+function rytkoset_theme_filter_tampere_2026_order_confirmation_fields( $show, $field, $fields, $context ) {
+	$field_id = rytkoset_theme_get_order_confirmation_checkout_field_id( $field, $fields );
+	$index    = rytkoset_theme_get_tampere_2026_participant_index_from_field_id( $field_id );
+
+	if ( $index < 1 ) {
+		return $show;
+	}
+
+	$order = isset( $context['order'] ) && $context['order'] instanceof WC_Order ? $context['order'] : null;
+
+	if ( ! $order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+		return $show;
+	}
+
+	return $show && $index <= rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+}
+add_filter( 'woocommerce_filter_fields_for_order_confirmation', 'rytkoset_theme_filter_tampere_2026_order_confirmation_fields', 10, 4 );
+
+/**
+ * Removes extra Tampere 2026 participant fields from WooCommerce admin order fields.
+ *
+ * @param array<string, mixed> $fields Admin field definitions.
+ * @param WC_Order|null        $order Order object.
+ * @return array<string, mixed>
+ */
+function rytkoset_theme_filter_tampere_2026_admin_order_fields( $fields, $order = null ) {
+	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+		return $fields;
+	}
+
+	$participant_quantity = rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+
+	foreach ( $fields as $field_key => $field ) {
+		$field_id = is_array( $field ) && isset( $field['id'] ) ? (string) $field['id'] : (string) $field_key;
+		$index    = rytkoset_theme_get_tampere_2026_participant_index_from_field_id( $field_id );
+
+		if ( $index > $participant_quantity ) {
+			unset( $fields[ $field_key ] );
+		}
+	}
+
+	return $fields;
+}
+add_filter( 'woocommerce_admin_shipping_fields', 'rytkoset_theme_filter_tampere_2026_admin_order_fields', 20, 2 );
+
+/**
+ * Deletes hidden extra Tampere 2026 participant meta from new Store API orders.
+ *
+ * @param WC_Order $order WooCommerce order object.
+ * @return void
+ */
+function rytkoset_theme_cleanup_tampere_2026_extra_participant_order_meta( $order ) {
+	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+		return;
+	}
+
+	$participant_quantity = rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+	$max_participants     = rytkoset_theme_get_tampere_2026_max_participants();
+	$deleted_meta         = false;
+
+	for ( $index = $participant_quantity + 1; $index <= $max_participants; $index++ ) {
+		foreach ( rytkoset_theme_get_tampere_2026_participant_field_ids( $index ) as $field_id ) {
+			$meta_key = '_wc_other/' . $field_id;
+
+			if ( ! $order->meta_exists( $meta_key ) ) {
+				continue;
+			}
+
+			$order->delete_meta_data( $meta_key );
+			$deleted_meta = true;
+		}
+	}
+
+	if ( $deleted_meta ) {
+		$order->save();
+	}
+}
+add_action( 'woocommerce_store_api_checkout_order_processed', 'rytkoset_theme_cleanup_tampere_2026_extra_participant_order_meta', 20 );
+
+/**
  * Registers the Tampere 2026 participants metabox for order admin screens.
  *
  * Uses a dedicated metabox so the participant list is visible in both legacy


### PR DESCRIPTION
## Summary

- Korjaa Tampere 2026 -tilausten ylimääräisten osallistujakenttien näkymisen tilausvahvistuksessa, sähköposteissa ja WooCommerce-adminissa
- Rajaa WooCommerce Blocks -lisäkentät tilauksen todelliseen Tampere 2026 -osallistujamäärään
- Siivoaa uusilta Store API -tilauksilta ylimääräisten osallistujien lisäkenttämetat

## Changes

- Lisää parserin `rytkoset/participant_{n}_...`-kenttä-ID:lle
- Lisää `woocommerce_filter_fields_for_order_confirmation` -suodatuksen tilausvahvistukseen ja sähköposteihin
- Lisää `woocommerce_admin_shipping_fields` -suodatuksen adminin tilauskenttiin
- Lisää `woocommerce_store_api_checkout_order_processed` -siivouksen ylimääräisille `_wc_other/rytkoset/participant_{n}_...`-metoille
- Päivittää Tampere 2026 checkout-kenttien dokumentaation
- Lisää #271-korjauksen changelogiin

## Testing

- [x] `docker compose exec wordpress php -l /var/www/html/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php`
- [x] WordPress-smoke-testi Dockerissa:
  - 1 osallistuja: vain osallistuja 1 näkyy
  - 2 osallistujaa: osallistujat 1-2 näkyvät, 3+ piilotetaan
  - admin-kenttäsuodatus toimii
  - order confirmation -kenttäsuodatus toimii
  - ylimääräiset `_wc_other/rytkoset/...` metat poistuvat
  - osallistuja 1:n nimi, ruokarajoite ja buffet-valinta säilyvät