### PR TITLE
feat: add footer newsletter signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- Footerin AcyMailing-uutiskirjetilaus Customizer-shortcodella, kirjautuneen tilaajan piilotuslogiikalla sekä ylläpitodokumentaatio `docs/newsletter.md` (#266)
 - Maksullisille tapahtumille tapahtumakohtaiset järjestäjäilmoitusten vastaanottajat ja yleinen WooCommerce-tilausilmoitus (#269)
 - Maksuttoman tapahtumailmoittautumisen kuittisähköposti ilmoittautujalle sekä erillinen selvitystiketti AcyMailing-tapahtumaviestinnälle (#107, #264)
 - GitHub PR -kuvauspohja yhtenäiselle muutosten, testien ja lisähuomioiden kuvaukselle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ The theme `wp-content/themes/rytkoset-theme/` is the only versioned codebase. Wo
 | `inc/attachment-iptc.php`              | IPTC headline and description sync for attachment images                                   |
 | `inc/seo-meta.php`                     | Open Graph and Twitter Card meta tags                                                      |
 | `inc/login.php`                        | Login page branding and Finnish translations                                               |
+| `inc/newsletter.php`                   | Footer newsletter signup Customizer setting and AcyMailing shortcode rendering             |
 | `inc/woocommerce-mollie.php`           | Mollie Finnish translations, RF reference normalization                                    |
 | `inc/woocommerce-membership.php`       | Membership products, checkout notice, admin column and metabox                             |
 | `inc/woocommerce-tampere-2026.php`     | Tampere 2026 participation fee: product, checkout fields, admin, organizer notifications   |
@@ -164,5 +165,7 @@ WordPress admin-managed menus: `primary` (main menu), `footer`, `account` (user/
 ## Documentation
 
 `docs/` contains setup and maintenance guides for WooCommerce features. Read the relevant doc before making WooCommerce changes.
+
+`docs/newsletter.md` documents the AcyMailing footer signup setup, target list and newsletter MVP boundaries.
 
 `docs/design-system.md` documents the theme's color tokens, radius/shadow/transition variables, layout, and component conventions. Read it before writing or modifying CSS.

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -1,0 +1,121 @@
+# Uutiskirjeet ja AcyMailing
+
+Tämä dokumentti kuvaa uutiskirjeen tilauspaikkojen MVP-toteutuksen tiketille `#266`.
+
+## Käyttötarkoitus
+
+Uutiskirjeen tilaus kerätään AcyMailingilla. Teema ei tallenna tilaajia omaan tietokantaan eikä käsittele lomakkeen lähetystä itse.
+
+Ensimmäinen julkaistu tilauspaikka on sivuston footer, koska se näkyy koko sivustolla eikä vaadi erillisiä sivukohtaisia sisältömuutoksia.
+
+## Lista
+
+Uudet yleiset uutiskirjetilaukset ohjataan olemassa olevalle AcyMailing-listalle:
+
+- `Rytkoset.net GDPR`
+
+Uutta listaa ei luoda tätä MVP:tä varten. AcyMailingissa voi näkyä myös muita listoja, kuten hallituksen lista tai oletuksena syntynyt `Newsletters`, mutta niitä ei käytetä footerin yleiseen uutiskirjetilaukseen.
+
+## Footer-lomakkeen käyttöönotto
+
+1. Avaa WordPress-adminissa `AcyMailing > Subscription forms`.
+2. Luo tai tarkista `Shortcode`-tyyppinen lomake.
+3. Aseta lomakkeen listaksi `Rytkoset.net GDPR`.
+4. Pidä lomake lyhyenä:
+   - sähköpostiosoite
+   - tilauspainike
+   - tietosuojalinkki tai suostumusteksti AcyMailingin lomakeasetuksista
+5. Jos AcyMailing-lomakkeessa on source-asetus, käytä arvoa `footer`.
+6. Kopioi lomakkeen shortcode muodossa `[acymailing_form_shortcode id="..."]`.
+7. Avaa `Ulkoasu > Mukauta > Uutiskirje`.
+8. Liitä shortcode kenttään `AcyMailing-lomakkeen shortcode`.
+9. Tallenna ja testaa footer.
+
+Älä valitse AcyMailingin omaa `Footer`-lomaketyyppiä tässä MVP:ssä. Se on AcyMailingin automaattinen footer-display ja paikallisen plugin-koodin perusteella Enterprise-ominaisuus. Teeman toteutus käyttää sen sijaan Essentialissa käytettävissä olevaa shortcode-lomaketta ja sijoittaa sen itse sivuston footeriin.
+
+Footer ei näytä uutiskirjeblokkia, jos shortcode on tyhjä, AcyMailing ei ole aktiivinen tai shortcode ei renderöi lomaketta.
+
+## Suositellut AcyMailing-asetukset
+
+Footerin uutiskirjelomake on tarkoitettu myös kävijöille, joilla ei ole WordPress-käyttäjätunnusta. AcyMailing luo tai päivittää AcyMailing-tilaajan, mutta ei luo WordPress-käyttäjää.
+
+Suositeltu asetuspolku on `AcyMailing > Configuration > Subscription`:
+
+- `Allow non-logged in users`: päällä
+- `Auto-generate User's name`: päällä, jos lomakkeella kysytään vain sähköpostiosoite
+- `Require confirmation`: projektin päätös
+- `Allow subscriber data modifications without authentication`: `Only their subscription`
+
+Jos `Require confirmation` on päällä, tilaaja saa vahvistusviestin ennen kuin tilaus vahvistuu. Jos se on pois päältä, sähköpostiosoite voidaan lisätä listalle heti lomakkeen lähetyksestä. Vahvistuksen poistaminen tekee tilauksesta helpomman, mutta lisää väärien tai toisen henkilön sähköpostiosoitteiden tilaamisen riskiä.
+
+Tietosuostumus tai tietosuojalinkki kannattaa pitää lomakkeella erillään sähköpostivahvistuksesta. Se ei ole tekninen kaksoisvahvistus, vaan kertoo mihin tilaaja antaa suostumuksen.
+
+## Lomakkeen kieli
+
+Footerissa näkyvät AcyMailing-lomakkeen omat tekstit, kuten `Email`, `I agree with the Privacy policy` ja `Privacy policy`, tulevat AcyMailingin käännösavaimista eivätkä teemasta.
+
+Suomenkielinen lomake otetaan käyttöön AcyMailingin asetuksista:
+
+1. Varmista WordPressissä, että `Asetukset > Yleinen > Sivuston kieli` on `Suomi`.
+2. Avaa `AcyMailing > Configuration > Languages`.
+3. Lisää tai avaa `Suomi` / `fi-FI`.
+4. Jos AcyMailing ehdottaa uusimman kielitiedoston lataamista, lataa se ja tallenna kieli.
+5. Päivitä footer ja testaa lomake kirjautumattomana.
+
+Jos tekstit jäävät englanniksi, tarkista AcyMailingin `fi-FI`-kielestä ainakin nämä avaimet:
+
+```ini
+ACYM_EMAIL="Sähköposti"
+ACYM_PRIVACY_POLICY="tietosuojaselosteen"
+ACYM_I_AGREE_PRIVACY="Hyväksyn %s"
+```
+
+Lomakkeen `Display only for those languages: Suomi` rajaa lomakkeen näkymistä kielen perusteella, mutta se ei yksin käännä lomakkeen tekstejä.
+
+Englannin kieltä ei kannata poistaa AcyMailingista, vaikka sivusto on vain suomeksi. AcyMailingin plugin-koodissa `en-US` on oletus- ja fallback-kieli, jota käytetään, jos nykyisen kielen käännöstä ei löydy. Suomenkielisyys kannattaa tehdä `fi-FI`-käännöksillä tai `fi-FI` custom translations -kentällä.
+
+## Toteutus teemassa
+
+Toteutus on tiedostossa `wp-content/themes/rytkoset-theme/inc/newsletter.php`.
+
+Teema:
+
+- lisää Customizer-asetuksen `rytkoset_theme_newsletter_shortcode`
+- hyväksyy footerissa vain AcyMailingin `acymailing_form_shortcode`-shortcoden
+- renderöi lomakkeen footerissa vain, kun AcyMailing-shortcode on käytettävissä
+- näyttää kirjautuneelle käyttäjälle lomakkeen sijaan tekstin `Olet jo uutiskirjeen tilaaja.`, jos käyttäjä on jo aktiivisena tilaajana lomakkeen kohdelistalla
+- näyttää kirjautuneelle käyttäjälle pelkän tilauspainikkeen, jos käyttäjä ei vielä ole kohdelistan tilaaja; painike käyttää kirjautuneen käyttäjän sähköpostiosoitetta piilotettuna kenttänä
+- vaihtaa kirjautuneen käyttäjän tilauspainikkeen onnistuneen AcyMailing-vastauksen jälkeen heti tekstiksi `Olet jo uutiskirjeen tilaaja.`, jotta käyttäjän ei tarvitse päivittää sivua nähdäkseen tilan
+- poistaa footerissa renderöidystä AcyMailing-lomakkeesta lomakkeen omat sisäiset `<style>`-tagit, jotta AcyMailingin shortcode-preview-tyylit eivät tee footeriin erillistä valkoista laatikkoa
+- muotoilee lomakkeen scoped-tyyleillä tiedostossa `assets/css/footer.css`
+
+AcyMailingin plugin-koodissa automaattiset popup/header/footer-lomakkeet tarkistetaan Enterprise-tasoa vasten, mutta shortcode rekisteröidään erikseen WordPress-shortcodena. Siksi teema ei riipu Enterprise-footer-ominaisuudesta.
+
+Kirjautuneen käyttäjän tilaustila tarkistetaan AcyMailingin tauluista `wp_acym_user` ja `wp_acym_user_has_list`. Tarkistus käyttää footer-shortcoden lomake-ID:tä ja lomakkeen listavalintoja, joten listan numeerista ID:tä ei kovakoodata teemaan.
+
+## Testaus
+
+Testaa käyttöönoton jälkeen:
+
+- footer näyttää lomakkeen desktopissa ja mobiilissa
+- lomake toimii näppäimistöllä ja focus-tila näkyy
+- tumma teema näyttää kentät ja painikkeet luettavasti
+- kirjautumaton käyttäjä voi tilata uutiskirjeen, jos AcyMailing-asetukset sallivat sen
+- kirjautunut käyttäjä, joka ei ole kohdelistan tilaaja, voi tilata uutiskirjeen ilman sähköpostiosoitteen uudelleenkirjoittamista
+- kirjautuneen käyttäjän tilauspainike näyttää lähetyksen aikana tilan `Tilataan...` ja onnistumisen jälkeen tekstin `Olet jo uutiskirjeen tilaaja.`
+- kirjautunut käyttäjä, joka on jo kohdelistan tilaaja, näkee tekstin `Olet jo uutiskirjeen tilaaja.` lomakkeen sijaan
+- testiosoite ilmestyy AcyMailingin tilaajiin listalle `Rytkoset.net GDPR`
+
+Jos frontendissä näkyy virhe `You are not allowed to modify this user`, testaa lomake kirjautumattomana tai käytä kirjautuneen WordPress-käyttäjän omaa sähköpostiosoitetta. AcyMailing voi estää tilanteen, jossa kirjautunut käyttäjä yrittää tilata tai muokata eri sähköpostiosoitteen tilausta.
+
+## Rajaukset
+
+Tämä MVP ei sisällä:
+
+- etusivun erillistä uutiskirjenostoa
+- tapahtumailmoittautumisen erillistä uutiskirjevalintaa
+- WooCommerce checkout -tilausvalintaa
+- AcyMailing-automaatioita tai kuittiviestejä
+- uutiskirjeen lähetyspohjaa tai SMTP-asetuksia
+
+Paikallisessa plugin-koodissa ei ole mukana erillistä AcyMailing WooCommerce -integraatiolisäosaa. Siksi checkout-opt-in rajataan jatkotiketiksi, ellei lisäosa oteta myöhemmin käyttöön.

--- a/wp-content/themes/rytkoset-theme/assets/css/footer.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/footer.css
@@ -131,3 +131,163 @@
 .site-footer__social-link img[src*="X.svg"] {
   transform: scale(0.94);
 }
+
+.site-footer__newsletter {
+  flex: 1 1 260px;
+  max-width: 360px;
+  min-width: 0;
+}
+
+.site-footer__newsletter-title {
+  margin: 0 0 0.45rem;
+  color: var(--color-text-inverted);
+  font-size: 1.1rem;
+}
+
+.site-footer__newsletter-text {
+  margin: 0 0 0.85rem;
+  color: var(--color-text-light);
+}
+
+.site-footer__newsletter-form {
+  min-width: 0;
+}
+
+.site-footer__newsletter-form [id^="acym_fulldiv_"] {
+  display: block !important;
+  width: 100% !important;
+  height: auto !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+  color: var(--color-text-light) !important;
+}
+
+.site-footer__newsletter-form form,
+.site-footer__newsletter-form .acym_module_form,
+.site-footer__newsletter-form .acym_form {
+  display: grid;
+  gap: 0.7rem;
+  width: 100% !important;
+  margin: 0 !important;
+}
+
+.site-footer__newsletter-action {
+  justify-items: start;
+}
+
+.site-footer__newsletter-status {
+  min-height: 1.4em;
+  margin: 0;
+  color: var(--color-text-light);
+}
+
+.site-footer__newsletter-form .acym__subscription__form__fields {
+  display: grid !important;
+  gap: 0.7rem !important;
+  width: 100% !important;
+  margin: 0 !important;
+}
+
+.site-footer__newsletter-form .onefield,
+.site-footer__newsletter-form .acym__subscription__form__termscond,
+.site-footer__newsletter-form .acym__subscription__form__button {
+  width: 100% !important;
+  margin: 0 !important;
+}
+
+.site-footer__newsletter-form input[type="email"],
+.site-footer__newsletter-form input[type="text"] {
+  width: 100% !important;
+  min-height: 48px;
+  box-sizing: border-box;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: var(--radius-medium);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text-inverted);
+  padding: 0.65rem 0.8rem;
+}
+
+.site-footer__newsletter-form .onefield input:not([type="radio"]):not([type="checkbox"]):not([type="hidden"]) {
+  width: 100% !important;
+  margin: 0 !important;
+}
+
+.site-footer__newsletter-form input[type="email"]::placeholder,
+.site-footer__newsletter-form input[type="text"]::placeholder {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.site-footer__newsletter-form input[type="email"]:focus-visible,
+.site-footer__newsletter-form input[type="text"]:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.site-footer__newsletter-form button,
+.site-footer__newsletter-form input[type="submit"],
+.site-footer__newsletter-form .acym_button,
+.site-footer__newsletter-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border: 2px solid var(--color-accent) !important;
+  border-radius: var(--radius-pill) !important;
+  background: var(--color-accent) !important;
+  color: var(--color-primary-deeper) !important;
+  padding: 0.45rem 1rem;
+  font-weight: 800;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color var(--transition-normal), border-color var(--transition-normal), color var(--transition-normal);
+}
+
+.site-footer__newsletter-form button:hover,
+.site-footer__newsletter-form button:focus-visible,
+.site-footer__newsletter-form button:disabled,
+.site-footer__newsletter-form input[type="submit"]:hover,
+.site-footer__newsletter-form input[type="submit"]:focus-visible,
+.site-footer__newsletter-form input[type="submit"]:disabled,
+.site-footer__newsletter-form .acym_button:hover,
+.site-footer__newsletter-form .acym_button:focus-visible,
+.site-footer__newsletter-button:hover,
+.site-footer__newsletter-button:focus-visible,
+.site-footer__newsletter-button:disabled {
+  background: var(--color-accent-hover) !important;
+  border-color: var(--color-accent-hover) !important;
+  color: var(--color-primary-deeper) !important;
+  text-decoration: none;
+}
+
+.site-footer__newsletter-form button:disabled,
+.site-footer__newsletter-form input[type="submit"]:disabled,
+.site-footer__newsletter-button:disabled {
+  cursor: wait;
+  opacity: 0.9;
+}
+
+.site-footer__newsletter-form label,
+.site-footer__newsletter-form .acym__users__creation__fields__title,
+.site-footer__newsletter-form .acym__field__error {
+  color: var(--color-text-light) !important;
+}
+
+.site-footer__newsletter-form .acym__subscription__form__termscond label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  line-height: 1.4;
+}
+
+.site-footer__newsletter-form .acym__subscription__form__termscond input[type="checkbox"] {
+  flex: 0 0 auto;
+  margin-top: 0.2rem !important;
+}
+
+.site-footer__newsletter-form .acym__subscription__form__termscond a {
+  display: inline !important;
+  color: var(--color-text-light) !important;
+  text-decoration: underline;
+}

--- a/wp-content/themes/rytkoset-theme/assets/css/responsive.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/responsive.css
@@ -151,6 +151,11 @@
     text-align: center;
   }
 
+  .site-footer__newsletter {
+    width: min(100%, 360px);
+    max-width: 100%;
+  }
+
 }
 
 @media (max-width: 480px) {

--- a/wp-content/themes/rytkoset-theme/footer.php
+++ b/wp-content/themes/rytkoset-theme/footer.php
@@ -55,6 +55,16 @@
         </ul>
       <?php endif; ?>
     </div>
+
+    <?php
+    $newsletter_markup = function_exists( 'rytkoset_theme_get_footer_newsletter_markup' )
+      ? rytkoset_theme_get_footer_newsletter_markup()
+      : '';
+
+    if ( '' !== $newsletter_markup ) {
+      echo $newsletter_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is built by the theme and AcyMailing form renderer.
+    }
+    ?>
   </div>
 </footer>
 

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -21,6 +21,7 @@ require_once get_template_directory() . '/inc/digital-magazines.php';
 require_once get_template_directory() . '/inc/attachment-iptc.php';
 require_once get_template_directory() . '/inc/seo-meta.php';
 require_once get_template_directory() . '/inc/login.php';
+require_once get_template_directory() . '/inc/newsletter.php';
 require_once get_template_directory() . '/inc/woocommerce-mollie.php';
 require_once get_template_directory() . '/inc/woocommerce-membership.php';
 require_once get_template_directory() . '/inc/woocommerce-tampere-2026.php';

--- a/wp-content/themes/rytkoset-theme/inc/newsletter.php
+++ b/wp-content/themes/rytkoset-theme/inc/newsletter.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Newsletter signup helpers.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_newsletter_shortcode' ) ) {
+	/**
+	 * Returns the Customizer-defined AcyMailing newsletter shortcode.
+	 *
+	 * @return string
+	 */
+	function rytkoset_theme_get_newsletter_shortcode() {
+		$shortcode = get_theme_mod( 'rytkoset_theme_newsletter_shortcode', '' );
+
+		return is_string( $shortcode ) ? trim( $shortcode ) : '';
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_sanitize_newsletter_shortcode' ) ) {
+	/**
+	 * Sanitizes the newsletter shortcode Customizer value.
+	 *
+	 * Only the AcyMailing subscription form shortcode is accepted for the footer.
+	 *
+	 * @param string $value Customizer value.
+	 * @return string
+	 */
+	function rytkoset_theme_sanitize_newsletter_shortcode( $value ) {
+		$value = is_string( $value ) ? trim( $value ) : '';
+
+		if ( '' === $value ) {
+			return '';
+		}
+
+		$value = sanitize_text_field( $value );
+
+		if ( ! has_shortcode( $value, 'acymailing_form_shortcode' ) ) {
+			return '';
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_register_newsletter_customizer' ) ) {
+	/**
+	 * Registers the newsletter Customizer settings.
+	 *
+	 * @param WP_Customize_Manager $wp_customize Customizer manager.
+	 * @return void
+	 */
+	function rytkoset_theme_register_newsletter_customizer( $wp_customize ) {
+		$wp_customize->add_section(
+			'rytkoset_theme_newsletter',
+			array(
+				'title'       => __( 'Uutiskirje', 'rytkoset-theme' ),
+				'description' => __( 'Footerin uutiskirjelomake käyttää AcyMailingin subscription form -shortcodea.', 'rytkoset-theme' ),
+				'priority'    => 85,
+			)
+		);
+
+		$wp_customize->add_setting(
+			'rytkoset_theme_newsletter_shortcode',
+			array(
+				'default'           => '',
+				'sanitize_callback' => 'rytkoset_theme_sanitize_newsletter_shortcode',
+				'transport'         => 'refresh',
+			)
+		);
+
+		$wp_customize->add_control(
+			'rytkoset_theme_newsletter_shortcode',
+			array(
+				'label'       => __( 'AcyMailing-lomakkeen shortcode', 'rytkoset-theme' ),
+				'description' => __( 'Esimerkiksi [acymailing_form_shortcode id="1"]. Lomake näytetään footerissa vain, jos AcyMailing on aktiivinen ja shortcode renderöityy.', 'rytkoset-theme' ),
+				'section'     => 'rytkoset_theme_newsletter',
+				'type'        => 'text',
+			)
+		);
+	}
+}
+add_action( 'customize_register', 'rytkoset_theme_register_newsletter_customizer' );
+
+if ( ! function_exists( 'rytkoset_theme_get_newsletter_form_id' ) ) {
+	/**
+	 * Extracts the AcyMailing form ID from the configured shortcode.
+	 *
+	 * @param string $shortcode Newsletter shortcode.
+	 * @return int
+	 */
+	function rytkoset_theme_get_newsletter_form_id( $shortcode ) {
+		if ( ! is_string( $shortcode ) || '' === trim( $shortcode ) ) {
+			return 0;
+		}
+
+		if ( ! preg_match( '/\[acymailing_form_shortcode\b([^\]]*)\]/', $shortcode, $matches ) ) {
+			return 0;
+		}
+
+		$atts = shortcode_parse_atts( $matches[1] );
+
+		return isset( $atts['id'] ) ? absint( $atts['id'] ) : 0;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_newsletter_form_list_ids' ) ) {
+	/**
+	 * Returns the target list IDs from an AcyMailing form.
+	 *
+	 * @param int $form_id AcyMailing form ID.
+	 * @return int[]
+	 */
+	function rytkoset_theme_get_newsletter_form_list_ids( $form_id ) {
+		$form_id = absint( $form_id );
+
+		if ( 0 === $form_id ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$form_table = $wpdb->prefix . 'acym_form';
+		$settings   = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT settings FROM {$form_table} WHERE id = %d AND active = 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is built from the WordPress DB prefix.
+				$form_id
+			)
+		);
+
+		if ( ! is_string( $settings ) || '' === $settings ) {
+			return array();
+		}
+
+		$settings = json_decode( $settings, true );
+
+		if ( ! is_array( $settings ) || empty( $settings['lists'] ) || ! is_array( $settings['lists'] ) ) {
+			return array();
+		}
+
+		$list_ids = array();
+
+		foreach ( array( 'automatic_subscribe', 'checked', 'displayed' ) as $key ) {
+			if ( empty( $settings['lists'][ $key ] ) || ! is_array( $settings['lists'][ $key ] ) ) {
+				continue;
+			}
+
+			$list_ids = array_merge( $list_ids, array_map( 'absint', $settings['lists'][ $key ] ) );
+		}
+
+		return array_values( array_unique( array_filter( $list_ids ) ) );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_current_user_has_newsletter_subscription' ) ) {
+	/**
+	 * Checks whether the current logged-in user is already subscribed to the form target list.
+	 *
+	 * @param int[] $list_ids AcyMailing list IDs.
+	 * @return bool
+	 */
+	function rytkoset_theme_current_user_has_newsletter_subscription( $list_ids ) {
+		if ( ! is_user_logged_in() || empty( $list_ids ) ) {
+			return false;
+		}
+
+		$list_ids = array_values( array_unique( array_filter( array_map( 'absint', $list_ids ) ) ) );
+
+		if ( empty( $list_ids ) ) {
+			return false;
+		}
+
+		global $wpdb;
+
+		$user_table = $wpdb->prefix . 'acym_user';
+		$list_table = $wpdb->prefix . 'acym_user_has_list';
+		$cms_user   = wp_get_current_user();
+		$email      = is_a( $cms_user, 'WP_User' ) ? sanitize_email( $cms_user->user_email ) : '';
+
+		if ( '' === $email ) {
+			return false;
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $list_ids ), '%d' ) );
+		$query_args   = array_merge( array( get_current_user_id(), $email ), $list_ids );
+		$query        = $wpdb->prepare(
+			"SELECT COUNT(*)
+			 FROM {$user_table} AS acym_user
+			 INNER JOIN {$list_table} AS acym_list
+				ON acym_list.user_id = acym_user.id
+			 WHERE (acym_user.cms_id = %d OR acym_user.email = %s)
+				AND acym_list.status = 1
+				AND acym_list.list_id IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names and placeholders are generated internally.
+			$query_args
+		);
+
+		return (int) $wpdb->get_var( $query ) > 0;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_logged_in_newsletter_button_markup' ) ) {
+	/**
+	 * Builds a compact AcyMailing subscribe form for logged-in users.
+	 *
+	 * @param int   $form_id  AcyMailing form ID.
+	 * @param int[] $list_ids AcyMailing list IDs.
+	 * @return string
+	 */
+	function rytkoset_theme_get_logged_in_newsletter_button_markup( $form_id, $list_ids ) {
+		if ( ! is_user_logged_in() || empty( $list_ids ) || ! function_exists( 'acym_frontendLink' ) ) {
+			return '';
+		}
+
+		$user = wp_get_current_user();
+
+		if ( ! is_a( $user, 'WP_User' ) || '' === sanitize_email( $user->user_email ) ) {
+			return '';
+		}
+
+		$form_id        = absint( $form_id );
+		$list_ids       = array_values( array_unique( array_filter( array_map( 'absint', $list_ids ) ) ) );
+		$form_name      = 'formAcymFooterLoggedIn' . $form_id;
+		$frontend_link  = htmlspecialchars_decode( acym_frontendLink( 'frontusers' ) );
+		$component_name = defined( 'ACYM_COMPONENT' ) ? ACYM_COMPONENT : 'acymailing';
+
+		if ( function_exists( 'acym_initModule' ) ) {
+			acym_initModule( null, array( 'loadJsInModule' => true ) );
+		}
+
+		ob_start();
+		?>
+		<form
+			action="<?php echo esc_url( $frontend_link ); ?>"
+			id="<?php echo esc_attr( $form_name ); ?>"
+			name="<?php echo esc_attr( $form_name ); ?>"
+			class="site-footer__newsletter-action"
+			method="post"
+			data-success-message="<?php esc_attr_e( 'Olet jo uutiskirjeen tilaaja.', 'rytkoset-theme' ); ?>"
+			data-loading-message="<?php esc_attr_e( 'Tilataan...', 'rytkoset-theme' ); ?>"
+			data-error-message="<?php esc_attr_e( 'Tilaus ei onnistunut. Yritä hetken päästä uudelleen.', 'rytkoset-theme' ); ?>"
+			onsubmit="return rytkosetThemeSubmitNewsletterButton(this)"
+		>
+			<input type="hidden" name="user[email]" value="<?php echo esc_attr( sanitize_email( $user->user_email ) ); ?>">
+			<input type="hidden" name="hiddenlists" value="<?php echo esc_attr( implode( ',', $list_ids ) ); ?>">
+			<input type="hidden" name="ctrl" value="frontusers">
+			<input type="hidden" name="task" value="notask">
+			<input type="hidden" name="page" value="acymailing_front">
+			<input type="hidden" name="option" value="<?php echo esc_attr( $component_name ); ?>">
+			<input type="hidden" name="acy_source" value="<?php echo esc_attr( 'Footer form ID ' . $form_id ); ?>">
+			<input type="hidden" name="acyformname" value="<?php echo esc_attr( $form_name ); ?>">
+			<input type="hidden" name="acymformtype" value="shortcode">
+			<input type="hidden" name="acysubmode" value="form_acym">
+			<input type="hidden" name="redirect" value="">
+			<input type="hidden" name="ajax" value="1">
+			<input type="hidden" name="confirmation_message" value="">
+			<button type="submit" class="site-footer__newsletter-button">
+				<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
+			</button>
+			<p class="site-footer__newsletter-status" role="status" aria-live="polite"></p>
+		</form>
+		<script>
+			window.rytkosetThemeSubmitNewsletterButton = window.rytkosetThemeSubmitNewsletterButton || function(form) {
+				if (!window.fetch || !window.FormData) {
+					return true;
+				}
+
+				var button = form.querySelector('button[type="submit"]');
+				var status = form.querySelector('.site-footer__newsletter-status');
+				var successMessage = form.getAttribute('data-success-message') || 'Olet jo uutiskirjeen tilaaja.';
+				var loadingMessage = form.getAttribute('data-loading-message') || 'Tilataan...';
+				var errorMessage = form.getAttribute('data-error-message') || 'Tilaus ei onnistunut. Yritä hetken päästä uudelleen.';
+
+				if (button) {
+					button.disabled = true;
+					button.textContent = loadingMessage;
+				}
+
+				if (status) {
+					status.textContent = loadingMessage;
+				}
+
+				var formData = new FormData(form);
+				formData.set('task', 'subscribe');
+
+				fetch(form.action, {
+					method: 'POST',
+					body: formData,
+					credentials: 'same-origin'
+				})
+					.then(function(response) {
+						return response.text();
+					})
+					.then(function(text) {
+						var data = {};
+
+						try {
+							data = JSON.parse(text);
+						} catch (error) {
+							throw new Error('Invalid AcyMailing response');
+						}
+
+						if (data.type === 'error') {
+							throw new Error(data.message || errorMessage);
+						}
+
+						var message = document.createElement('p');
+						message.className = 'site-footer__newsletter-text';
+						message.textContent = successMessage;
+						form.replaceWith(message);
+					})
+					.catch(function(error) {
+						if (button) {
+							button.disabled = false;
+							button.textContent = 'Tilaa uutiskirje';
+						}
+
+						if (status) {
+							status.textContent = error && error.message ? error.message : errorMessage;
+						}
+					});
+
+				return false;
+			};
+		</script>
+		<?php
+
+		return trim( ob_get_clean() );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_footer_newsletter_markup' ) ) {
+	/**
+	 * Builds the footer newsletter signup markup.
+	 *
+	 * @return string
+	 */
+	function rytkoset_theme_get_footer_newsletter_markup() {
+		$shortcode = rytkoset_theme_get_newsletter_shortcode();
+
+		if ( '' === $shortcode || ! shortcode_exists( 'acymailing_form_shortcode' ) ) {
+			return '';
+		}
+
+		$form_id  = rytkoset_theme_get_newsletter_form_id( $shortcode );
+		$list_ids = rytkoset_theme_get_newsletter_form_list_ids( $form_id );
+
+		if ( rytkoset_theme_current_user_has_newsletter_subscription( $list_ids ) ) {
+			ob_start();
+			?>
+			<section class="site-footer__newsletter" aria-labelledby="site-footer-newsletter-title">
+				<h2 id="site-footer-newsletter-title" class="site-footer__newsletter-title">
+					<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
+				</h2>
+				<p class="site-footer__newsletter-text">
+					<?php esc_html_e( 'Olet jo uutiskirjeen tilaaja.', 'rytkoset-theme' ); ?>
+				</p>
+			</section>
+			<?php
+
+			return trim( ob_get_clean() );
+		}
+
+		$logged_in_button_markup = rytkoset_theme_get_logged_in_newsletter_button_markup( $form_id, $list_ids );
+
+		if ( '' !== $logged_in_button_markup ) {
+			ob_start();
+			?>
+			<section class="site-footer__newsletter" aria-labelledby="site-footer-newsletter-title">
+				<h2 id="site-footer-newsletter-title" class="site-footer__newsletter-title">
+					<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
+				</h2>
+				<p class="site-footer__newsletter-text">
+					<?php esc_html_e( 'Saat ajankohtaiset tiedot sukuseuran uutisista ja tapahtumista sähköpostiisi.', 'rytkoset-theme' ); ?>
+				</p>
+				<div class="site-footer__newsletter-form">
+					<?php echo $logged_in_button_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is generated and escaped above. ?>
+				</div>
+			</section>
+			<?php
+
+			return trim( ob_get_clean() );
+		}
+
+		$form_markup = trim( do_shortcode( $shortcode ) );
+
+		if ( '' === $form_markup || $form_markup === $shortcode ) {
+			return '';
+		}
+
+		$form_markup = preg_replace( '#<style\b[^>]*>.*?</style>#is', '', $form_markup );
+		$form_markup = is_string( $form_markup ) ? trim( $form_markup ) : '';
+
+		if ( '' === $form_markup ) {
+			return '';
+		}
+
+		ob_start();
+		?>
+		<section class="site-footer__newsletter" aria-labelledby="site-footer-newsletter-title">
+			<h2 id="site-footer-newsletter-title" class="site-footer__newsletter-title">
+				<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
+			</h2>
+			<p class="site-footer__newsletter-text">
+				<?php esc_html_e( 'Saat ajankohtaiset tiedot sukuseuran uutisista ja tapahtumista sähköpostiisi.', 'rytkoset-theme' ); ?>
+			</p>
+			<div class="site-footer__newsletter-form">
+				<?php echo $form_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- AcyMailing renders the subscription form markup. ?>
+			</div>
+		</section>
+		<?php
+
+		return trim( ob_get_clean() );
+	}
+}

--- a/wp-content/themes/rytkoset-theme/style.css
+++ b/wp-content/themes/rytkoset-theme/style.css
@@ -4,7 +4,7 @@ Theme URI: https://rytkoset.net
 Author: Ilkka Rytkönen
 Author URI: https://ilkkarytkonen.fi
 Description: Rytkösten sukuseura ry:n uusi WordPress-teema.
-Version: 0.1.0
+Version: 0.1.1
 Text Domain: rytkoset-theme
 */
 
@@ -27,7 +27,7 @@ Text Domain: rytkoset-theme
 @import url("assets/css/nav.mobile.css");
 
 /* Footer */
-@import url("assets/css/footer.css");
+@import url("assets/css/footer.css?v=266-3");
 
 
 /* Media queryt */


### PR DESCRIPTION
## Summary

- Add footer newsletter signup via AcyMailing shortcode configured in Customizer
- Add logged-in user handling: show subscribe button only when not subscribed, and show “Olet jo uutiskirjeen tilaaja.” when already subscribed
- Style the footer newsletter form and document AcyMailing setup, language settings, and test flow

## Testing

- Ran PHP syntax checks for theme PHP files
- Tested AcyMailing footer form rendering locally
- Tested logged-in subscription state helpers locally
- Verified subscribed users see the already-subscribed state instead of the form

## Notes

- Uses existing AcyMailing list from the configured form; no list ID is hardcoded in the theme
- AcyMailing Enterprise footer form type is not used; this uses the Essential-compatible shortcode form
- WooCommerce checkout newsletter opt-in remains out of scope for this slice