### PR TITLE
feat: add newsletter opt-in flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- Uutiskirjeen vapaaehtoinen AcyMailing-opt-in WordPress-rekisteröitymiseen, maksuttomaan tapahtumailmoittautumiseen ja WooCommerce Checkout Block -kassalle (#276)
 - Footerin AcyMailing-uutiskirjetilaus Customizer-shortcodella, kirjautuneen tilaajan piilotuslogiikalla sekä ylläpitodokumentaatio `docs/newsletter.md` (#266)
 - Maksullisille tapahtumille tapahtumakohtaiset järjestäjäilmoitusten vastaanottajat ja yleinen WooCommerce-tilausilmoitus (#269)
 - Maksuttoman tapahtumailmoittautumisen kuittisähköposti ilmoittautujalle sekä erillinen selvitystiketti AcyMailing-tapahtumaviestinnälle (#107, #264)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ The theme `wp-content/themes/rytkoset-theme/` is the only versioned codebase. Wo
 | `inc/attachment-iptc.php`              | IPTC headline and description sync for attachment images                                 |
 | `inc/seo-meta.php`                     | Open Graph and Twitter Card meta tags                                                    |
 | `inc/login.php`                        | Login page branding and Finnish translations                                             |
-| `inc/newsletter.php`                   | Footer newsletter signup Customizer setting and AcyMailing shortcode rendering           |
+| `inc/newsletter.php`                   | AcyMailing newsletter integration: footer signup, subscription helpers and opt-in hooks   |
 | `inc/woocommerce-mollie.php`           | Mollie Finnish translations, RF reference normalization                                  |
 | `inc/woocommerce-membership.php`       | Membership products, checkout notice, admin column and metabox                           |
 | `inc/woocommerce-tampere-2026.php`     | Tampere 2026 participation fee: product, checkout fields, admin, organizer notifications |
@@ -166,6 +166,6 @@ WordPress admin-managed menus: `primary` (main menu), `footer`, `account` (user/
 
 `docs/` contains setup and maintenance guides for WooCommerce features. Read the relevant doc before making WooCommerce changes.
 
-`docs/newsletter.md` documents the AcyMailing footer signup setup, target list and newsletter MVP boundaries.
+`docs/newsletter.md` documents the AcyMailing footer signup setup, target list, opt-in workflows and newsletter MVP boundaries.
 
 `docs/design-system.md` documents the theme's color tokens, radius/shadow/transition variables, layout, and component conventions. Read it before writing or modifying CSS.

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -8,6 +8,8 @@ Uutiskirjeen tilaus kerätään AcyMailingilla. Teema ei tallenna tilaajia omaan
 
 Ensimmäinen julkaistu tilauspaikka on sivuston footer, koska se näkyy koko sivustolla eikä vaadi erillisiä sivukohtaisia sisältömuutoksia.
 
+Jatkoslicessä `#276` samaa AcyMailing-kohdelistaa käytetään myös vapaaehtoisissa opt-in-valinnoissa rekisteröitymisen, maksuttoman tapahtumailmoittautumisen ja WooCommerce-kassan yhteydessä.
+
 ## Lista
 
 Uudet yleiset uutiskirjetilaukset ohjataan olemassa olevalle AcyMailing-listalle:
@@ -86,12 +88,27 @@ Teema:
 - näyttää kirjautuneelle käyttäjälle lomakkeen sijaan tekstin `Olet jo uutiskirjeen tilaaja.`, jos käyttäjä on jo aktiivisena tilaajana lomakkeen kohdelistalla
 - näyttää kirjautuneelle käyttäjälle pelkän tilauspainikkeen, jos käyttäjä ei vielä ole kohdelistan tilaaja; painike käyttää kirjautuneen käyttäjän sähköpostiosoitetta piilotettuna kenttänä
 - vaihtaa kirjautuneen käyttäjän tilauspainikkeen onnistuneen AcyMailing-vastauksen jälkeen heti tekstiksi `Olet jo uutiskirjeen tilaaja.`, jotta käyttäjän ei tarvitse päivittää sivua nähdäkseen tilan
+- tarjoaa yhteisen AcyMailing-helperin, jolla rekisteröityminen, maksuton tapahtumailmoittautuminen ja WooCommerce-kassa voivat tilata sähköpostiosoitteen samalle kohdelistalle
+- näyttää opt-in-checkboxin vain, jos footer-shortcode ja sen AcyMailing-kohdelista ovat käytettävissä
+- piilottaa opt-in-checkboxin kirjautuneelta käyttäjältä, joka on jo kohdelistan aktiivinen tilaaja
 - poistaa footerissa renderöidystä AcyMailing-lomakkeesta lomakkeen omat sisäiset `<style>`-tagit, jotta AcyMailingin shortcode-preview-tyylit eivät tee footeriin erillistä valkoista laatikkoa
 - muotoilee lomakkeen scoped-tyyleillä tiedostossa `assets/css/footer.css`
 
 AcyMailingin plugin-koodissa automaattiset popup/header/footer-lomakkeet tarkistetaan Enterprise-tasoa vasten, mutta shortcode rekisteröidään erikseen WordPress-shortcodena. Siksi teema ei riipu Enterprise-footer-ominaisuudesta.
 
 Kirjautuneen käyttäjän tilaustila tarkistetaan AcyMailingin tauluista `wp_acym_user` ja `wp_acym_user_has_list`. Tarkistus käyttää footer-shortcoden lomake-ID:tä ja lomakkeen listavalintoja, joten listan numeerista ID:tä ei kovakoodata teemaan.
+
+## Opt-in-paikat
+
+Uutiskirjeen vapaaehtoinen opt-in on käytössä näissä työnkuluissa:
+
+- WordPress-rekisteröityminen: checkbox `Tilaa uutiskirje`, ei oletuksena valittu. Valittu opt-in käsitellään `user_register`-hookissa.
+- Maksuton tapahtumailmoittautuminen: checkbox näkyy lomakkeella, jos käyttäjä ei ole kirjautuneena jo tilaaja. Tilaus käsitellään vasta onnistuneen ilmoittautumisen tallennuksen jälkeen.
+- WooCommerce Checkout Block: checkbox `Tilaa uutiskirje` näkyy kaikille tilauksille, paitsi kirjautuneelle jo tilaajana olevalle käyttäjälle. Tilaus käsitellään Store API -checkoutin order processed -hookissa.
+
+Kirjautumattomille käyttäjille opt-in näytetään, koska tilaustilaa ei voi päätellä luotettavasti ennen sähköpostiosoitteen syöttämistä. Jos syötetty sähköposti on jo tilaaja, integraatio käsittelee tilanteen onnistumisena eikä näytä käyttäjälle virhettä.
+
+AcyMailingin `Require confirmation` -asetus määrää, vaatiiko uusi tilaus sähköpostivahvistuksen. Teema ei ohita AcyMailingin double opt-in -asetusta.
 
 ## Testaus
 
@@ -104,6 +121,10 @@ Testaa käyttöönoton jälkeen:
 - kirjautunut käyttäjä, joka ei ole kohdelistan tilaaja, voi tilata uutiskirjeen ilman sähköpostiosoitteen uudelleenkirjoittamista
 - kirjautuneen käyttäjän tilauspainike näyttää lähetyksen aikana tilan `Tilataan...` ja onnistumisen jälkeen tekstin `Olet jo uutiskirjeen tilaaja.`
 - kirjautunut käyttäjä, joka on jo kohdelistan tilaaja, näkee tekstin `Olet jo uutiskirjeen tilaaja.` lomakkeen sijaan
+- rekisteröitymisen opt-in lisää uuden käyttäjän sähköpostin uutiskirjelistalle
+- maksuttoman tapahtumailmoittautumisen opt-in lisää ilmoittautujan sähköpostin uutiskirjelistalle eikä estä ilmoittautumista, jos AcyMailing-tilaus epäonnistuu
+- WooCommerce-kassan opt-in lisää billing email -osoitteen uutiskirjelistalle eikä estä tilausta, jos AcyMailing-tilaus epäonnistuu
+- kirjautunut jo tilaaja ei näe tapahtuma- tai kassalomakkeiden opt-in-checkboxia
 - testiosoite ilmestyy AcyMailingin tilaajiin listalle `Rytkoset.net GDPR`
 
 Jos frontendissä näkyy virhe `You are not allowed to modify this user`, testaa lomake kirjautumattomana tai käytä kirjautuneen WordPress-käyttäjän omaa sähköpostiosoitetta. AcyMailing voi estää tilanteen, jossa kirjautunut käyttäjä yrittää tilata tai muokata eri sähköpostiosoitteen tilausta.
@@ -113,9 +134,7 @@ Jos frontendissä näkyy virhe `You are not allowed to modify this user`, testaa
 Tämä MVP ei sisällä:
 
 - etusivun erillistä uutiskirjenostoa
-- tapahtumailmoittautumisen erillistä uutiskirjevalintaa
-- WooCommerce checkout -tilausvalintaa
 - AcyMailing-automaatioita tai kuittiviestejä
 - uutiskirjeen lähetyspohjaa tai SMTP-asetuksia
 
-Paikallisessa plugin-koodissa ei ole mukana erillistä AcyMailing WooCommerce -integraatiolisäosaa. Siksi checkout-opt-in rajataan jatkotiketiksi, ellei lisäosa oteta myöhemmin käyttöön.
+Paikallisessa plugin-koodissa ei ole mukana erillistä AcyMailing WooCommerce -integraatiolisäosaa. Checkout-opt-in toteutetaan siksi teeman kevyellä WooCommerce Blocks -hookilla.

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -788,6 +788,37 @@
   outline-offset: 2px;
 }
 
+.event-registration__newsletter {
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--color-border-neutral);
+  border-radius: var(--radius-small);
+  background: var(--color-surface-alt);
+}
+
+.event-registration__newsletter label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.event-registration__newsletter input[type="checkbox"] {
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+  width: 1.125rem;
+  height: 1.125rem;
+  cursor: pointer;
+}
+
+.event-registration__newsletter input[type="checkbox"]:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 @media (min-width: 64rem) {
   .article--event {
     gap: 2.5rem;

--- a/wp-content/themes/rytkoset-theme/assets/css/login.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/login.css
@@ -205,6 +205,31 @@ body.login .forgetmenot input[type="checkbox"]:focus-visible {
     0 0 0 3px rgba(251, 191, 36, 0.65);
 }
 
+.rytkoset-login-newsletter-opt-in {
+  margin: 0.6rem 0 1rem;
+}
+
+.rytkoset-login-newsletter-opt-in label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.rytkoset-login-newsletter-opt-in input[type="checkbox"] {
+  flex-shrink: 0;
+  margin-top: 0.2rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--color-primary);
+}
+
+.rytkoset-login-newsletter-opt-in input[type="checkbox"]:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 body.login .submit {
   padding-top: 0.25rem;
 }

--- a/wp-content/themes/rytkoset-theme/inc/event-registrations.php
+++ b/wp-content/themes/rytkoset-theme/inc/event-registrations.php
@@ -718,6 +718,14 @@ function rytkoset_theme_handle_event_registration_submission() {
 
 	rytkoset_theme_send_event_registration_receipt_email( $event_id, $name, $email );
 
+	if ( ! empty( $_POST['registration_newsletter_opt_in'] ) && '1' === sanitize_text_field( wp_unslash( $_POST['registration_newsletter_opt_in'] ) ) && function_exists( 'rytkoset_theme_subscribe_email_to_newsletter' ) ) {
+		$newsletter_result = rytkoset_theme_subscribe_email_to_newsletter( $email, 'event_registration', get_current_user_id() );
+
+		if ( is_wp_error( $newsletter_result ) && function_exists( 'rytkoset_theme_log_newsletter_error' ) ) {
+			rytkoset_theme_log_newsletter_error( 'event_registration', $newsletter_result->get_error_message() );
+		}
+	}
+
 	wp_safe_redirect( rytkoset_theme_get_event_registration_redirect_url( $event_id, 'success' ) );
 	exit;
 }
@@ -905,6 +913,16 @@ function rytkoset_theme_render_free_event_registration_form( $event_id ) {
 					<span aria-hidden="true">*</span>
 				</label>
 			</div>
+
+			<?php if ( function_exists( 'rytkoset_theme_should_show_newsletter_opt_in' ) && function_exists( 'rytkoset_theme_render_newsletter_opt_in_checkbox' ) && rytkoset_theme_should_show_newsletter_opt_in() ) : ?>
+				<?php
+				rytkoset_theme_render_newsletter_opt_in_checkbox(
+					$form_id . '-newsletter',
+					'registration_newsletter_opt_in',
+					'event-registration__newsletter'
+				);
+				?>
+			<?php endif; ?>
 
 			<p class="event-registration__required-note">
 				<?php esc_html_e( '* Pakollinen kenttä', 'rytkoset-theme' ); ?>

--- a/wp-content/themes/rytkoset-theme/inc/newsletter.php
+++ b/wp-content/themes/rytkoset-theme/inc/newsletter.php
@@ -155,6 +155,71 @@ if ( ! function_exists( 'rytkoset_theme_get_newsletter_form_list_ids' ) ) {
 	}
 }
 
+if ( ! function_exists( 'rytkoset_theme_get_newsletter_list_ids' ) ) {
+	/**
+	 * Returns the newsletter target list IDs from the configured footer form.
+	 *
+	 * @return int[]
+	 */
+	function rytkoset_theme_get_newsletter_list_ids() {
+		$shortcode = rytkoset_theme_get_newsletter_shortcode();
+
+		if ( '' === $shortcode || ! shortcode_exists( 'acymailing_form_shortcode' ) ) {
+			return array();
+		}
+
+		$form_id = rytkoset_theme_get_newsletter_form_id( $shortcode );
+
+		return rytkoset_theme_get_newsletter_form_list_ids( $form_id );
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_email_has_newsletter_subscription' ) ) {
+	/**
+	 * Checks whether an email address is already actively subscribed to the newsletter list.
+	 *
+	 * @param string $email    Email address.
+	 * @param int[]  $list_ids Optional AcyMailing list IDs. Defaults to the configured newsletter lists.
+	 * @return bool
+	 */
+	function rytkoset_theme_email_has_newsletter_subscription( $email, $list_ids = array() ) {
+		$email = sanitize_email( $email );
+
+		if ( '' === $email || ! is_email( $email ) ) {
+			return false;
+		}
+
+		if ( empty( $list_ids ) ) {
+			$list_ids = rytkoset_theme_get_newsletter_list_ids();
+		}
+
+		$list_ids = array_values( array_unique( array_filter( array_map( 'absint', $list_ids ) ) ) );
+
+		if ( empty( $list_ids ) ) {
+			return false;
+		}
+
+		global $wpdb;
+
+		$user_table   = $wpdb->prefix . 'acym_user';
+		$list_table   = $wpdb->prefix . 'acym_user_has_list';
+		$placeholders = implode( ',', array_fill( 0, count( $list_ids ), '%d' ) );
+		$query_args   = array_merge( array( $email ), $list_ids );
+		$query        = $wpdb->prepare(
+			"SELECT COUNT(*)
+			 FROM {$user_table} AS acym_user
+			 INNER JOIN {$list_table} AS acym_list
+				ON acym_list.user_id = acym_user.id
+			 WHERE acym_user.email = %s
+				AND acym_list.status = 1
+				AND acym_list.list_id IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names and placeholders are generated internally.
+			$query_args
+		);
+
+		return (int) $wpdb->get_var( $query ) > 0;
+	}
+}
+
 if ( ! function_exists( 'rytkoset_theme_current_user_has_newsletter_subscription' ) ) {
 	/**
 	 * Checks whether the current logged-in user is already subscribed to the form target list.
@@ -200,6 +265,337 @@ if ( ! function_exists( 'rytkoset_theme_current_user_has_newsletter_subscription
 		return (int) $wpdb->get_var( $query ) > 0;
 	}
 }
+
+if ( ! function_exists( 'rytkoset_theme_user_has_newsletter_subscription' ) ) {
+	/**
+	 * Checks whether a WordPress user is already subscribed to the newsletter list.
+	 *
+	 * @param int   $user_id  WordPress user ID.
+	 * @param int[] $list_ids Optional AcyMailing list IDs. Defaults to the configured newsletter lists.
+	 * @return bool
+	 */
+	function rytkoset_theme_user_has_newsletter_subscription( $user_id, $list_ids = array() ) {
+		$user_id = absint( $user_id );
+
+		if ( 0 === $user_id ) {
+			return false;
+		}
+
+		if ( empty( $list_ids ) ) {
+			$list_ids = rytkoset_theme_get_newsletter_list_ids();
+		}
+
+		$list_ids = array_values( array_unique( array_filter( array_map( 'absint', $list_ids ) ) ) );
+
+		if ( empty( $list_ids ) ) {
+			return false;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		if ( ! $user instanceof WP_User || ! is_email( $user->user_email ) ) {
+			return false;
+		}
+
+		global $wpdb;
+
+		$user_table   = $wpdb->prefix . 'acym_user';
+		$list_table   = $wpdb->prefix . 'acym_user_has_list';
+		$placeholders = implode( ',', array_fill( 0, count( $list_ids ), '%d' ) );
+		$query_args   = array_merge( array( $user_id, sanitize_email( $user->user_email ) ), $list_ids );
+		$query        = $wpdb->prepare(
+			"SELECT COUNT(*)
+			 FROM {$user_table} AS acym_user
+			 INNER JOIN {$list_table} AS acym_list
+				ON acym_list.user_id = acym_user.id
+			 WHERE (acym_user.cms_id = %d OR acym_user.email = %s)
+				AND acym_list.status = 1
+				AND acym_list.list_id IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names and placeholders are generated internally.
+			$query_args
+		);
+
+		return (int) $wpdb->get_var( $query ) > 0;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_log_newsletter_error' ) ) {
+	/**
+	 * Logs newsletter integration errors without personal data.
+	 *
+	 * @param string $source Source workflow.
+	 * @param string $message Error message.
+	 * @return void
+	 */
+	function rytkoset_theme_log_newsletter_error( $source, $message ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$message = (string) preg_replace(
+				'/[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}/i',
+				'[email redacted]',
+				(string) $message
+			);
+
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				sprintf(
+					'[rytkoset-newsletter] source=%s message=%s',
+					sanitize_key( $source ),
+					sanitize_text_field( $message )
+				)
+			);
+		}
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_get_newsletter_error_message' ) ) {
+	/**
+	 * Builds a safe AcyMailing error message for return values and logging.
+	 *
+	 * @param mixed  $errors   AcyMailing error data.
+	 * @param string $fallback Fallback message.
+	 * @return string
+	 */
+	function rytkoset_theme_get_newsletter_error_message( $errors, $fallback ) {
+		if ( empty( $errors ) ) {
+			return $fallback;
+		}
+
+		$message = implode( '; ', array_map( 'wp_strip_all_tags', (array) $errors ) );
+
+		return (string) preg_replace(
+			'/[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}/i',
+			'[email redacted]',
+			$message
+		);
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_subscribe_email_to_newsletter' ) ) {
+	/**
+	 * Subscribes an email address to the configured AcyMailing newsletter list.
+	 *
+	 * @param string $email       Email address.
+	 * @param string $source      Source workflow.
+	 * @param int    $cms_user_id Optional WordPress user ID.
+	 * @return true|WP_Error
+	 */
+	function rytkoset_theme_subscribe_email_to_newsletter( $email, $source, $cms_user_id = 0 ) {
+		$email       = sanitize_email( $email );
+		$source      = sanitize_key( $source );
+		$cms_user_id = absint( $cms_user_id );
+		$list_ids    = rytkoset_theme_get_newsletter_list_ids();
+
+		if ( '' === $email || ! is_email( $email ) ) {
+			return new WP_Error( 'invalid_email', __( 'Uutiskirjeen tilausta ei voitu tehdä virheellisen sähköpostiosoitteen takia.', 'rytkoset-theme' ) );
+		}
+
+		if ( empty( $list_ids ) ) {
+			return new WP_Error( 'missing_newsletter_list', __( 'Uutiskirjeen kohdelistaa ei ole määritetty.', 'rytkoset-theme' ) );
+		}
+
+		if ( rytkoset_theme_email_has_newsletter_subscription( $email, $list_ids ) ) {
+			return true;
+		}
+
+		if ( ! class_exists( '\AcyMailing\Classes\UserClass' ) ) {
+			return new WP_Error( 'acymailing_missing', __( 'AcyMailing ei ole käytettävissä.', 'rytkoset-theme' ) );
+		}
+
+		$user_class = new \AcyMailing\Classes\UserClass();
+		$user_class->checkVisitor = false;
+
+		if ( function_exists( 'acym_setVar' ) ) {
+			acym_setVar( 'acy_source', $source );
+		}
+
+		$subscriber = $user_class->getOneByEmail( $email );
+
+		if ( empty( $subscriber ) ) {
+			$subscriber = new stdClass();
+			$subscriber->email = $email;
+			$subscriber->source = $source;
+
+			if ( $cms_user_id > 0 ) {
+				$subscriber->cms_id = $cms_user_id;
+			}
+
+			$subscriber_id = $user_class->save( $subscriber );
+
+			if ( empty( $subscriber_id ) ) {
+				$message = rytkoset_theme_get_newsletter_error_message( $user_class->errors, __( 'Tilaajan tallennus epäonnistui.', 'rytkoset-theme' ) );
+				rytkoset_theme_log_newsletter_error( $source, $message );
+
+				return new WP_Error( 'acymailing_save_failed', $message );
+			}
+		} else {
+			$subscriber_id = absint( $subscriber->id );
+		}
+
+		if ( $cms_user_id > 0 && ! empty( $subscriber_id ) && empty( $subscriber->cms_id ) ) {
+			global $wpdb;
+
+			$wpdb->update(
+				$wpdb->prefix . 'acym_user',
+				array( 'cms_id' => $cms_user_id ),
+				array( 'id' => $subscriber_id ),
+				array( '%d' ),
+				array( '%d' )
+			);
+		}
+
+		$subscribed = $user_class->subscribe( array( $subscriber_id ), $list_ids );
+
+		if ( ! $subscribed && ! rytkoset_theme_email_has_newsletter_subscription( $email, $list_ids ) ) {
+			$message = rytkoset_theme_get_newsletter_error_message( $user_class->errors, __( 'Listalle lisääminen epäonnistui.', 'rytkoset-theme' ) );
+			rytkoset_theme_log_newsletter_error( $source, $message );
+
+			return new WP_Error( 'acymailing_subscribe_failed', $message );
+		}
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_should_show_newsletter_opt_in' ) ) {
+	/**
+	 * Returns whether a generic newsletter opt-in should be shown.
+	 *
+	 * @return bool
+	 */
+	function rytkoset_theme_should_show_newsletter_opt_in() {
+		$list_ids = rytkoset_theme_get_newsletter_list_ids();
+
+		if ( empty( $list_ids ) ) {
+			return false;
+		}
+
+		if ( is_user_logged_in() && rytkoset_theme_current_user_has_newsletter_subscription( $list_ids ) ) {
+			return false;
+		}
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_render_newsletter_opt_in_checkbox' ) ) {
+	/**
+	 * Renders a reusable newsletter opt-in checkbox.
+	 *
+	 * @param string $field_id Field ID.
+	 * @param string $field_name Field name.
+	 * @param string $class_name Wrapper class.
+	 * @return void
+	 */
+	function rytkoset_theme_render_newsletter_opt_in_checkbox( $field_id, $field_name, $class_name ) {
+		?>
+		<div class="<?php echo esc_attr( $class_name ); ?>">
+			<label for="<?php echo esc_attr( $field_id ); ?>">
+				<input id="<?php echo esc_attr( $field_id ); ?>" type="checkbox" name="<?php echo esc_attr( $field_name ); ?>" value="1" />
+				<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
+			</label>
+		</div>
+		<?php
+	}
+}
+
+if ( ! function_exists( 'rytkoset_theme_render_registration_newsletter_opt_in' ) ) {
+	/**
+	 * Renders newsletter opt-in on the WordPress registration form.
+	 *
+	 * @return void
+	 */
+	function rytkoset_theme_render_registration_newsletter_opt_in() {
+		if ( empty( rytkoset_theme_get_newsletter_list_ids() ) ) {
+			return;
+		}
+
+		rytkoset_theme_render_newsletter_opt_in_checkbox(
+			'rytkoset-newsletter-opt-in',
+			'rytkoset_newsletter_opt_in',
+			'rytkoset-login-newsletter-opt-in'
+		);
+	}
+}
+add_action( 'register_form', 'rytkoset_theme_render_registration_newsletter_opt_in' );
+
+if ( ! function_exists( 'rytkoset_theme_handle_registration_newsletter_opt_in' ) ) {
+	/**
+	 * Subscribes a newly registered user when they selected the opt-in checkbox.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return void
+	 */
+	function rytkoset_theme_handle_registration_newsletter_opt_in( $user_id ) {
+		if ( empty( $_POST['rytkoset_newsletter_opt_in'] ) || '1' !== sanitize_text_field( wp_unslash( $_POST['rytkoset_newsletter_opt_in'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Handled by WordPress registration flow.
+			return;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+
+		if ( ! $user instanceof WP_User ) {
+			return;
+		}
+
+		$result = rytkoset_theme_subscribe_email_to_newsletter( $user->user_email, 'registration', $user_id );
+
+		if ( is_wp_error( $result ) ) {
+			rytkoset_theme_log_newsletter_error( 'registration', $result->get_error_message() );
+		}
+	}
+}
+add_action( 'user_register', 'rytkoset_theme_handle_registration_newsletter_opt_in' );
+
+if ( ! function_exists( 'rytkoset_theme_register_checkout_newsletter_opt_in' ) ) {
+	/**
+	 * Registers newsletter opt-in for WooCommerce Checkout Block.
+	 *
+	 * @return void
+	 */
+	function rytkoset_theme_register_checkout_newsletter_opt_in() {
+		if ( ! function_exists( 'woocommerce_register_additional_checkout_field' ) || ! rytkoset_theme_should_show_newsletter_opt_in() ) {
+			return;
+		}
+
+		woocommerce_register_additional_checkout_field(
+			array(
+				'id'                => 'rytkoset/newsletter_opt_in',
+				'label'             => __( 'Tilaa uutiskirje', 'rytkoset-theme' ),
+				'location'          => 'order',
+				'type'              => 'checkbox',
+				'required'          => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			)
+		);
+	}
+}
+add_action( 'woocommerce_init', 'rytkoset_theme_register_checkout_newsletter_opt_in' );
+
+if ( ! function_exists( 'rytkoset_theme_handle_checkout_newsletter_opt_in' ) ) {
+	/**
+	 * Handles WooCommerce Checkout Block newsletter opt-in after order processing.
+	 *
+	 * @param WC_Order $order WooCommerce order object.
+	 * @return void
+	 */
+	function rytkoset_theme_handle_checkout_newsletter_opt_in( $order ) {
+		if ( ! $order instanceof WC_Order || ! function_exists( 'rytkoset_theme_get_order_additional_checkout_field_bool' ) ) {
+			return;
+		}
+
+		if ( ! rytkoset_theme_get_order_additional_checkout_field_bool( $order, 'rytkoset/newsletter_opt_in' ) ) {
+			return;
+		}
+
+		$result = rytkoset_theme_subscribe_email_to_newsletter(
+			$order->get_billing_email(),
+			'woocommerce_checkout',
+			$order->get_user_id()
+		);
+
+		if ( is_wp_error( $result ) ) {
+			rytkoset_theme_log_newsletter_error( 'woocommerce_checkout', $result->get_error_message() );
+		}
+	}
+}
+add_action( 'woocommerce_store_api_checkout_order_processed', 'rytkoset_theme_handle_checkout_newsletter_opt_in', 30 );
 
 if ( ! function_exists( 'rytkoset_theme_get_logged_in_newsletter_button_markup' ) ) {
 	/**


### PR DESCRIPTION
## Summary
Adds optional AcyMailing newsletter opt-ins to WordPress registration, free event registration, and WooCommerce Checkout Block.

## Changes
- Adds shared newsletter helpers for target list lookup, subscription checks, and email subscription.
- Hides opt-in for logged-in users who are already subscribed to the configured newsletter list.
- Adds unchecked newsletter opt-in to WordPress registration.
- Adds unchecked newsletter opt-in to free event registration after successful registration save.
- Adds unchecked newsletter opt-in to WooCommerce Checkout Block using the additional checkout field API.
- Documents the opt-in workflows and updates changelog/agent notes.

## Testing
- PHP syntax check for all theme PHP files.
- Verified local AcyMailing list lookup and subscription helper.
- Verified guest registration page shows the opt-in.
- Verified guest free event form shows the opt-in.
- Verified WooCommerce additional checkout field API is available and registration runs.