### PR TITLE
feat(footer): uudista footer pre-footer- ja slim-footer-rakenteeksi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- Footerin uudistus (Footer C): näyttävä pre-footer-uutiskirjekaista etusivulla, kompakti kaista alasivuilla ja kevyt slim footer kaikilla sivuilla; uudet `template-parts/pre-footer-large.php` ja `template-parts/pre-footer-compact.php` (#278)
 - Uutiskirjeen vapaaehtoinen AcyMailing-opt-in WordPress-rekisteröitymiseen, maksuttomaan tapahtumailmoittautumiseen ja WooCommerce Checkout Block -kassalle (#276)
 - Footerin AcyMailing-uutiskirjetilaus Customizer-shortcodella, kirjautuneen tilaajan piilotuslogiikalla sekä ylläpitodokumentaatio `docs/newsletter.md` (#266)
 - Maksullisille tapahtumille tapahtumakohtaiset järjestäjäilmoitusten vastaanottajat ja yleinen WooCommerce-tilausilmoitus (#269)
@@ -25,6 +26,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerce-kaupan brändin mukaiset alasvetovalikko- ja painiketyylit.
 
 ### Changed
+- Footerin uutiskirjetilaus siirtyi pre-footer-kaistaan; aktiiviselle tilaajalle koko kaista piilotetaan aiemman tekstihuomautuksen sijaan ja `assets/css/footer.css` kirjoitettiin uusiksi (#278)
 - Tampere 2026 -järjestäjäilmoitusten vastaanottajat siirretty globaalista asetuksesta tapahtuman omaan `Järjestäjäilmoitukset`-kenttään (#269)
 - Päivitetty `CLAUDE.md`:n `inc/`-moduulitaulukko ja WooCommerce-arkkitehtuurihuomio vastaamaan nykyistä `functions.php`-include-listaa.
 - Tapahtuman yhteenvetokortti piilottaa ilmoittautumisen määräpäivän menneiltä tapahtumilta ja käyttää mennyttä aikamuotoa määräpäivän jälkeen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,9 @@ The theme `wp-content/themes/rytkoset-theme/` is the only versioned codebase. Wo
 | `single-gallery_album.php`   | Single album                  |
 | `archive-rytkoset_event.php` | Event archive (`/tapahtumat`) |
 | `archive-gallery_album.php`  | Album archive (`/albumit`)    |
-| `header.php` / `footer.php`  | Site header and footer        |
+| `header.php` / `footer.php`  | Site header; footer = pre-footer band + slim footer |
+
+Footer (Footer C, #278): `footer.php` renders a pre-footer newsletter band above the slim footer on every page — `template-parts/pre-footer-large.php` on the front page (`is_front_page()`), `template-parts/pre-footer-compact.php` elsewhere. Each partial calls `rytkoset_theme_get_footer_newsletter_form()` and renders nothing when there is no form to show (active subscriber, or newsletter shortcode not configured). The slim footer (`<footer class="site-footer">`) holds brand, footer nav, contact email and social links, and shows on all pages.
 
 ### functions.php and inc/ modules
 

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -6,7 +6,7 @@ Tämä dokumentti kuvaa uutiskirjeen tilauspaikkojen MVP-toteutuksen tiketille `
 
 Uutiskirjeen tilaus kerätään AcyMailingilla. Teema ei tallenna tilaajia omaan tietokantaan eikä käsittele lomakkeen lähetystä itse.
 
-Ensimmäinen julkaistu tilauspaikka on sivuston footer, koska se näkyy koko sivustolla eikä vaadi erillisiä sivukohtaisia sisältömuutoksia.
+Ensimmäinen julkaistu tilauspaikka on sivuston footerin yläpuolinen pre-footer-kaista, joka näkyy koko sivustolla eikä vaadi erillisiä sivukohtaisia sisältömuutoksia. Tiketissä `#278` footer jaettiin pre-footeriin (uutiskirjekaista) ja slim footeriin (brändi, navigaatio, yhteystiedot, some). Etusivulla pre-footer on näyttävä iso lohko (`template-parts/pre-footer-large.php`), muilla sivuilla yksirivinen kompakti kaista (`template-parts/pre-footer-compact.php`). Molemmat käyttävät samaa AcyMailing-lomaketta.
 
 Jatkoslicessä `#276` samaa AcyMailing-kohdelistaa käytetään myös vapaaehtoisissa opt-in-valinnoissa rekisteröitymisen, maksuttoman tapahtumailmoittautumisen ja WooCommerce-kassan yhteydessä.
 
@@ -85,7 +85,7 @@ Teema:
 - lisää Customizer-asetuksen `rytkoset_theme_newsletter_shortcode`
 - hyväksyy footerissa vain AcyMailingin `acymailing_form_shortcode`-shortcoden
 - renderöi lomakkeen footerissa vain, kun AcyMailing-shortcode on käytettävissä
-- näyttää kirjautuneelle käyttäjälle lomakkeen sijaan tekstin `Olet jo uutiskirjeen tilaaja.`, jos käyttäjä on jo aktiivisena tilaajana lomakkeen kohdelistalla
+- piilottaa koko pre-footer-kaistan kirjautuneelta käyttäjältä, joka on jo aktiivisena tilaajana lomakkeen kohdelistalla (`rytkoset_theme_get_footer_newsletter_form()` palauttaa tyhjän merkkijonon, jolloin partial ei renderöi mitään)
 - näyttää kirjautuneelle käyttäjälle pelkän tilauspainikkeen, jos käyttäjä ei vielä ole kohdelistan tilaaja; painike käyttää kirjautuneen käyttäjän sähköpostiosoitetta piilotettuna kenttänä
 - vaihtaa kirjautuneen käyttäjän tilauspainikkeen onnistuneen AcyMailing-vastauksen jälkeen heti tekstiksi `Olet jo uutiskirjeen tilaaja.`, jotta käyttäjän ei tarvitse päivittää sivua nähdäkseen tilan
 - tarjoaa yhteisen AcyMailing-helperin, jolla rekisteröityminen, maksuton tapahtumailmoittautuminen ja WooCommerce-kassa voivat tilata sähköpostiosoitteen samalle kohdelistalle
@@ -114,13 +114,14 @@ AcyMailingin `Require confirmation` -asetus määrää, vaatiiko uusi tilaus sä
 
 Testaa käyttöönoton jälkeen:
 
-- footer näyttää lomakkeen desktopissa ja mobiilissa
+- etusivun iso pre-footer ja alasivujen kompakti kaista näyttävät lomakkeen desktopissa ja mobiilissa
+- slim footer (brändi, navigaatio, yhteystiedot, some) näkyy kaikilla sivuilla
 - lomake toimii näppäimistöllä ja focus-tila näkyy
 - tumma teema näyttää kentät ja painikkeet luettavasti
 - kirjautumaton käyttäjä voi tilata uutiskirjeen, jos AcyMailing-asetukset sallivat sen
 - kirjautunut käyttäjä, joka ei ole kohdelistan tilaaja, voi tilata uutiskirjeen ilman sähköpostiosoitteen uudelleenkirjoittamista
 - kirjautuneen käyttäjän tilauspainike näyttää lähetyksen aikana tilan `Tilataan...` ja onnistumisen jälkeen tekstin `Olet jo uutiskirjeen tilaaja.`
-- kirjautunut käyttäjä, joka on jo kohdelistan tilaaja, näkee tekstin `Olet jo uutiskirjeen tilaaja.` lomakkeen sijaan
+- kirjautunut käyttäjä, joka on jo kohdelistan tilaaja, ei näe pre-footer-kaistaa lainkaan (vain slim footer)
 - rekisteröitymisen opt-in lisää uuden käyttäjän sähköpostin uutiskirjelistalle
 - maksuttoman tapahtumailmoittautumisen opt-in lisää ilmoittautujan sähköpostin uutiskirjelistalle eikä estä ilmoittautumista, jos AcyMailing-tilaus epäonnistuu
 - WooCommerce-kassan opt-in lisää billing email -osoitteen uutiskirjelistalle eikä estä tilausta, jos AcyMailing-tilaus epäonnistuu
@@ -133,7 +134,6 @@ Jos frontendissä näkyy virhe `You are not allowed to modify this user`, testaa
 
 Tämä MVP ei sisällä:
 
-- etusivun erillistä uutiskirjenostoa
 - AcyMailing-automaatioita tai kuittiviestejä
 - uutiskirjeen lähetyspohjaa tai SMTP-asetuksia
 

--- a/wp-content/themes/rytkoset-theme/assets/css/footer.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/footer.css
@@ -1,17 +1,140 @@
+/* =================================================================
+   Pre-footer (newsletter band)
+   Large variant on the front page, compact variant on sub pages.
+   Both sit directly above the slim footer.
+   ================================================================= */
+.site-prefooter {
+  color: var(--color-text-inverted);
+  font-family: var(--font-body);
+}
+
+/* ---- Large (front page) ---- */
+.site-prefooter--large {
+  position: relative;
+  overflow: hidden;
+  padding: 4.5rem 0 5rem;
+  background: linear-gradient(180deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+}
+
+.site-prefooter--large::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 92% 18%, rgba(251, 191, 36, 0.18), transparent 45%),
+    radial-gradient(circle at 8% 92%, rgba(251, 191, 36, 0.08), transparent 45%);
+}
+
+.site-prefooter__inner {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 4rem;
+  align-items: center;
+}
+
+.site-prefooter__copy {
+  display: flex;
+  flex-direction: column;
+}
+
+.site-prefooter__eyebrow {
+  margin: 0 0 0.875rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-accent);
+}
+
+.site-prefooter__title {
+  margin: 0 0 1.125rem;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  color: var(--color-text-inverted);
+  text-wrap: balance;
+}
+
+.site-prefooter__title--sm {
+  font-size: clamp(1.5rem, 3vw, 1.75rem);
+  margin-bottom: 0.375rem;
+}
+
+.site-prefooter__desc {
+  margin: 0 0 1.375rem;
+  max-width: 34rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.site-prefooter__desc--sm {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.site-prefooter__bullets {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.site-prefooter__bullets li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+}
+
+.site-prefooter__bullets li::before {
+  content: "\2713";
+  color: var(--color-accent);
+  font-weight: 800;
+}
+
+.site-prefooter__card {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-l);
+  padding: 2rem;
+  backdrop-filter: blur(6px);
+}
+
+/* ---- Compact (sub pages) ---- */
+.site-prefooter--compact {
+  padding: 2.25rem 0;
+  background: var(--color-primary);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-prefooter__row {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.site-prefooter--compact .site-footer__newsletter-form {
+  max-width: 30rem;
+}
+
+/* =================================================================
+   Slim footer (all pages)
+   Three-part grid: brand · navigation · contact + social.
+   ================================================================= */
 .site-footer {
   background: var(--footer-bg);
   color: var(--color-text-light);
-  padding: 2.25rem 0;
+  padding: 1.75rem 0 1.25rem;
   margin-top: 0;
-}
-
-.site-footer__inner {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1.5rem;
-  font-size: 0.95rem;
-  flex-wrap: wrap;
 }
 
 .site-footer a {
@@ -24,11 +147,17 @@
   text-decoration: underline;
 }
 
+.site-footer__inner {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 4rem;
+}
+
 .site-footer__brand {
   display: flex;
   align-items: center;
   gap: 0.9rem;
-  font-size: 1rem;
 }
 
 .site-footer__brand .site-logo {
@@ -52,33 +181,69 @@
   line-height: 1.35;
 }
 
+.site-footer__brand-text strong {
+  font-weight: 700;
+  color: var(--color-text-inverted);
+}
+
+.site-footer__brand-text span {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
 .site-logo__link--footer {
   color: var(--color-text-light);
 }
 
 .site-footer__nav {
-  margin-left: auto;
+  display: flex;
+  justify-content: center;
 }
 
 .site-footer__menu {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.25rem;
+  justify-content: center;
+  gap: 0.5rem 1.375rem;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
 .site-footer__menu a {
-  font-weight: 700;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.site-footer__menu a:hover {
+  color: var(--color-text-inverted);
 }
 
 .site-footer__meta {
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-left: 0;
-  align-items: flex-start;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.site-footer__contact {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.site-footer__contact-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.site-footer__contact:hover .site-footer__contact-icon {
+  opacity: 1;
 }
 
 .site-footer__social-list {
@@ -114,8 +279,8 @@
 .site-footer__social-link img,
 .site-footer__social-link svg {
   display: block;
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   object-fit: contain;
 }
 
@@ -132,23 +297,20 @@
   transform: scale(0.94);
 }
 
-.site-footer__newsletter {
-  flex: 1 1 260px;
-  max-width: 360px;
-  min-width: 0;
+.site-footer__legal {
+  margin-top: 1.125rem;
+  padding-top: 0.875rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: center;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
 }
 
-.site-footer__newsletter-title {
-  margin: 0 0 0.45rem;
-  color: var(--color-text-inverted);
-  font-size: 1.1rem;
-}
-
-.site-footer__newsletter-text {
-  margin: 0 0 0.85rem;
-  color: var(--color-text-light);
-}
-
+/* =================================================================
+   Newsletter form (AcyMailing) — shared by both pre-footer variants.
+   Styles the AcyMailing-rendered fields, the logged-in button form and
+   the status message on the dark/blue pre-footer background.
+   ================================================================= */
 .site-footer__newsletter-form {
   min-width: 0;
 }
@@ -288,6 +450,51 @@
 
 .site-footer__newsletter-form .acym__subscription__form__termscond a {
   display: inline !important;
-  color: var(--color-text-light) !important;
+  color: var(--color-text-inverted) !important;
   text-decoration: underline;
+}
+
+/* =================================================================
+   Responsive
+   ================================================================= */
+@media (max-width: 64rem) {
+  .site-prefooter__inner {
+    grid-template-columns: 1fr;
+    gap: 2.25rem;
+  }
+}
+
+@media (max-width: 48rem) {
+  .site-prefooter--large {
+    padding: 3rem 0 3.5rem;
+  }
+
+  .site-prefooter__card {
+    padding: 1.375rem;
+  }
+
+  .site-prefooter__row {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  .site-prefooter--compact .site-footer__newsletter-form {
+    max-width: none;
+  }
+
+  .site-footer__inner {
+    grid-template-columns: 1fr;
+    gap: 1.75rem;
+    text-align: center;
+    justify-items: center;
+  }
+
+  .site-footer__nav {
+    justify-content: center;
+  }
+
+  .site-footer__meta {
+    flex-direction: column;
+    gap: 1rem;
+  }
 }

--- a/wp-content/themes/rytkoset-theme/footer.php
+++ b/wp-content/themes/rytkoset-theme/footer.php
@@ -1,70 +1,88 @@
+<?php
+/**
+ * Footer: pre-footer newsletter band + slim footer.
+ *
+ * The pre-footer is rendered here for every page (large on the front page,
+ * compact elsewhere) so it cannot be forgotten on an individual template.
+ * Each partial hides itself when there is no newsletter form to show.
+ */
+
+if ( is_front_page() ) {
+	get_template_part( 'template-parts/pre-footer', 'large' );
+} else {
+	get_template_part( 'template-parts/pre-footer', 'compact' );
+}
+?>
+
 <footer class="site-footer" role="contentinfo">
-  <div class="container site-footer__inner">
-    <div class="site-footer__brand">
-      <?php
-      rytkoset_theme_the_logo(
-        array(
-          'class'      => 'site-logo site-logo--footer',
-          'link_class' => 'site-logo__link site-logo__link--footer',
-        )
-      );
-      ?>
-      <div class="site-footer__brand-text">
-        <strong>Rytkösten sukuseura ry.</strong>
-        <span>Kotipaikka: Iisalmi</span>
+  <div class="container">
+    <div class="site-footer__inner">
+      <div class="site-footer__brand">
+        <?php
+        rytkoset_theme_the_logo(
+          array(
+            'class'      => 'site-logo site-logo--footer',
+            'link_class' => 'site-logo__link site-logo__link--footer',
+          )
+        );
+        ?>
+        <div class="site-footer__brand-text">
+          <strong>Rytkösten sukuseura ry.</strong>
+          <span>Kotipaikka: Iisalmi</span>
+        </div>
+      </div>
+
+      <nav class="site-footer__nav" aria-label="Alavalikko">
+        <?php
+        wp_nav_menu(
+          array(
+            'theme_location' => 'footer',
+            'container'      => false,
+            'menu_class'     => 'site-footer__menu',
+            'fallback_cb'    => false,
+            'depth'          => 1,
+          )
+        );
+        ?>
+      </nav>
+
+      <div class="site-footer__meta">
+        <?php $contact_email = rytkoset_theme_get_contact_email(); ?>
+        <a class="site-footer__contact" href="mailto:<?php echo esc_attr( $contact_email ); ?>">
+          <svg class="site-footer__contact-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <rect x="3" y="5" width="18" height="14" rx="2"></rect>
+            <path d="m3 7 9 6 9-6"></path>
+          </svg>
+          <span><?php echo esc_html( $contact_email ); ?></span>
+        </a>
+
+        <?php
+        $social_links = rytkoset_theme_get_social_links();
+
+        if ( ! empty( $social_links ) ) :
+        ?>
+          <ul class="site-footer__social-list" aria-label="Sosiaalisen median linkit">
+            <?php foreach ( $social_links as $social_link ) : ?>
+              <?php
+              if ( empty( $social_link['icon_src'] ) ) {
+                continue;
+              }
+              ?>
+                <li class="site-footer__social-item">
+                  <a class="site-footer__social-link" href="<?php echo esc_url( $social_link['url'] ); ?>">
+                    <span class="screen-reader-text"><?php echo esc_html( $social_link['label'] ); ?></span>
+                    <img src="<?php echo esc_url( $social_link['icon_src'] ); ?>" alt="" aria-hidden="true" />
+                  </a>
+                </li>
+            <?php endforeach; ?>
+          </ul>
+        <?php endif; ?>
       </div>
     </div>
 
-    <nav class="site-footer__nav" aria-label="Alavalikko">
-      <?php
-      wp_nav_menu(
-        array(
-          'theme_location' => 'footer',
-          'container'      => false,
-          'menu_class'     => 'site-footer__menu',
-          'fallback_cb'    => false,
-          'depth'          => 1,
-        )
-      );
-      ?>
-    </nav>
-
-    <div class="site-footer__meta">
-      <?php $contact_email = rytkoset_theme_get_contact_email(); ?>
-      <span>Yhteydenotot: <a href="mailto:<?php echo esc_attr( $contact_email ); ?>"><?php echo esc_html( $contact_email ); ?></a></span>
-
-      <?php
-      $social_links = rytkoset_theme_get_social_links();
-
-      if ( ! empty( $social_links ) ) :
-      ?>
-        <ul class="site-footer__social-list" aria-label="Sosiaalisen median linkit">
-          <?php foreach ( $social_links as $social_link ) : ?>
-            <?php
-            if ( empty( $social_link['icon_src'] ) ) {
-              continue;
-            }
-            ?>
-              <li class="site-footer__social-item">
-                <a class="site-footer__social-link" href="<?php echo esc_url( $social_link['url'] ); ?>">
-                  <span class="screen-reader-text"><?php echo esc_html( $social_link['label'] ); ?></span>
-                  <img src="<?php echo esc_url( $social_link['icon_src'] ); ?>" alt="" aria-hidden="true" />
-                </a>
-              </li>
-          <?php endforeach; ?>
-        </ul>
-      <?php endif; ?>
+    <div class="site-footer__legal">
+      <span>&copy; Rytkösten sukuseura ry. &middot; Kotipaikka: Iisalmi</span>
     </div>
-
-    <?php
-    $newsletter_markup = function_exists( 'rytkoset_theme_get_footer_newsletter_markup' )
-      ? rytkoset_theme_get_footer_newsletter_markup()
-      : '';
-
-    if ( '' !== $newsletter_markup ) {
-      echo $newsletter_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is built by the theme and AcyMailing form renderer.
-    }
-    ?>
   </div>
 </footer>
 

--- a/wp-content/themes/rytkoset-theme/inc/newsletter.php
+++ b/wp-content/themes/rytkoset-theme/inc/newsletter.php
@@ -727,13 +727,19 @@ if ( ! function_exists( 'rytkoset_theme_get_logged_in_newsletter_button_markup' 
 	}
 }
 
-if ( ! function_exists( 'rytkoset_theme_get_footer_newsletter_markup' ) ) {
+if ( ! function_exists( 'rytkoset_theme_get_footer_newsletter_form' ) ) {
 	/**
-	 * Builds the footer newsletter signup markup.
+	 * Builds the inner newsletter form markup for the pre-footer.
+	 *
+	 * Returns only the form element (no wrapping section/heading), so the
+	 * pre-footer partials can place it inside the large card or the compact row.
+	 * Returns an empty string when there is nothing to show — newsletter not
+	 * configured, or the current logged-in user is already an active subscriber
+	 * (the pre-footer band is hidden entirely in that case).
 	 *
 	 * @return string
 	 */
-	function rytkoset_theme_get_footer_newsletter_markup() {
+	function rytkoset_theme_get_footer_newsletter_form() {
 		$shortcode = rytkoset_theme_get_newsletter_shortcode();
 
 		if ( '' === $shortcode || ! shortcode_exists( 'acymailing_form_shortcode' ) ) {
@@ -743,43 +749,19 @@ if ( ! function_exists( 'rytkoset_theme_get_footer_newsletter_markup' ) ) {
 		$form_id  = rytkoset_theme_get_newsletter_form_id( $shortcode );
 		$list_ids = rytkoset_theme_get_newsletter_form_list_ids( $form_id );
 
+		// Active subscriber: no form, so the pre-footer band is omitted.
 		if ( rytkoset_theme_current_user_has_newsletter_subscription( $list_ids ) ) {
-			ob_start();
-			?>
-			<section class="site-footer__newsletter" aria-labelledby="site-footer-newsletter-title">
-				<h2 id="site-footer-newsletter-title" class="site-footer__newsletter-title">
-					<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
-				</h2>
-				<p class="site-footer__newsletter-text">
-					<?php esc_html_e( 'Olet jo uutiskirjeen tilaaja.', 'rytkoset-theme' ); ?>
-				</p>
-			</section>
-			<?php
-
-			return trim( ob_get_clean() );
+			return '';
 		}
 
+		// Logged-in non-subscriber: single subscribe button.
 		$logged_in_button_markup = rytkoset_theme_get_logged_in_newsletter_button_markup( $form_id, $list_ids );
 
 		if ( '' !== $logged_in_button_markup ) {
-			ob_start();
-			?>
-			<section class="site-footer__newsletter" aria-labelledby="site-footer-newsletter-title">
-				<h2 id="site-footer-newsletter-title" class="site-footer__newsletter-title">
-					<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
-				</h2>
-				<p class="site-footer__newsletter-text">
-					<?php esc_html_e( 'Saat ajankohtaiset tiedot sukuseuran uutisista ja tapahtumista sähköpostiisi.', 'rytkoset-theme' ); ?>
-				</p>
-				<div class="site-footer__newsletter-form">
-					<?php echo $logged_in_button_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is generated and escaped above. ?>
-				</div>
-			</section>
-			<?php
-
-			return trim( ob_get_clean() );
+			return $logged_in_button_markup;
 		}
 
+		// Guest: full AcyMailing subscription form (email + consent + button).
 		$form_markup = trim( do_shortcode( $shortcode ) );
 
 		if ( '' === $form_markup || $form_markup === $shortcode ) {
@@ -789,25 +771,6 @@ if ( ! function_exists( 'rytkoset_theme_get_footer_newsletter_markup' ) ) {
 		$form_markup = preg_replace( '#<style\b[^>]*>.*?</style>#is', '', $form_markup );
 		$form_markup = is_string( $form_markup ) ? trim( $form_markup ) : '';
 
-		if ( '' === $form_markup ) {
-			return '';
-		}
-
-		ob_start();
-		?>
-		<section class="site-footer__newsletter" aria-labelledby="site-footer-newsletter-title">
-			<h2 id="site-footer-newsletter-title" class="site-footer__newsletter-title">
-				<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
-			</h2>
-			<p class="site-footer__newsletter-text">
-				<?php esc_html_e( 'Saat ajankohtaiset tiedot sukuseuran uutisista ja tapahtumista sähköpostiisi.', 'rytkoset-theme' ); ?>
-			</p>
-			<div class="site-footer__newsletter-form">
-				<?php echo $form_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- AcyMailing renders the subscription form markup. ?>
-			</div>
-		</section>
-		<?php
-
-		return trim( ob_get_clean() );
+		return $form_markup;
 	}
 }

--- a/wp-content/themes/rytkoset-theme/template-parts/pre-footer-compact.php
+++ b/wp-content/themes/rytkoset-theme/template-parts/pre-footer-compact.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Pre-footer — compact variant (sub pages).
+ *
+ * Single-row newsletter reminder: short copy on the left, inline AcyMailing
+ * form on the right. Hidden entirely when there is no form to show
+ * (active subscriber or newsletter not configured).
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$newsletter_form = function_exists( 'rytkoset_theme_get_footer_newsletter_form' )
+	? rytkoset_theme_get_footer_newsletter_form()
+	: '';
+
+if ( '' === $newsletter_form ) {
+	return;
+}
+?>
+<section class="site-prefooter site-prefooter--compact" aria-labelledby="site-prefooter-title">
+	<div class="container site-prefooter__row">
+		<div class="site-prefooter__copy">
+			<h2 id="site-prefooter-title" class="site-prefooter__title site-prefooter__title--sm">
+				<?php esc_html_e( 'Tilaa uutiskirje', 'rytkoset-theme' ); ?>
+			</h2>
+			<p class="site-prefooter__desc site-prefooter__desc--sm">
+				<?php esc_html_e( 'Sukuseuran ajankohtaiset uutiset ja tapahtumat sähköpostiisi.', 'rytkoset-theme' ); ?>
+			</p>
+		</div>
+		<div class="site-prefooter__form-wrap">
+			<div class="site-footer__newsletter-form site-footer__newsletter-form--inline">
+				<?php echo $newsletter_form; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is built by the theme and AcyMailing form renderer. ?>
+			</div>
+		</div>
+	</div>
+</section>

--- a/wp-content/themes/rytkoset-theme/template-parts/pre-footer-large.php
+++ b/wp-content/themes/rytkoset-theme/template-parts/pre-footer-large.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Pre-footer — large variant (front page).
+ *
+ * Storytelling newsletter signup block: copy + benefits on the left,
+ * AcyMailing form in a card on the right. Hidden entirely when there is
+ * no form to show (active subscriber or newsletter not configured).
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$newsletter_form = function_exists( 'rytkoset_theme_get_footer_newsletter_form' )
+	? rytkoset_theme_get_footer_newsletter_form()
+	: '';
+
+if ( '' === $newsletter_form ) {
+	return;
+}
+?>
+<section class="site-prefooter site-prefooter--large" aria-labelledby="site-prefooter-title">
+	<div class="container site-prefooter__inner">
+		<div class="site-prefooter__copy">
+			<p class="site-prefooter__eyebrow"><?php esc_html_e( 'Pysy mukana', 'rytkoset-theme' ); ?></p>
+			<h2 id="site-prefooter-title" class="site-prefooter__title">
+				<?php esc_html_e( 'Tilaa Rytkösten uutiskirje', 'rytkoset-theme' ); ?>
+			</h2>
+			<p class="site-prefooter__desc">
+				<?php esc_html_e( 'Tapahtumat, sukukokoukset, uudet albumit ja sukututkimuksen löydöt — kerran kuussa ajankohtaiset tiedot suoraan sähköpostiisi. Vain sukuseuran omat uutiset, ei mainoksia. Voit perua tilauksen milloin vain.', 'rytkoset-theme' ); ?>
+			</p>
+			<ul class="site-prefooter__bullets">
+				<li><?php esc_html_e( 'Sukukokousten ohjelmat ja ilmoittautumislinkit', 'rytkoset-theme' ); ?></li>
+				<li><?php esc_html_e( 'Uudet kuvagalleriat ja sukututkimusartikkelit', 'rytkoset-theme' ); ?></li>
+				<li><?php esc_html_e( 'Kaupan uutuudet ja jäsenetuhinnat', 'rytkoset-theme' ); ?></li>
+			</ul>
+		</div>
+		<div class="site-prefooter__form-wrap">
+			<div class="site-prefooter__card">
+				<div class="site-footer__newsletter-form">
+					<?php echo $newsletter_form; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is built by the theme and AcyMailing form renderer. ?>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>


### PR DESCRIPTION
## Yhteenveto

Footerin yksitasoinen flex-asettelu korvattu kahdella komponentilla:
pre-footer-uutiskirjekaista ja slim footer. Pre-footer injektoidaan
keskitetysti `footer.php`:sta `is_front_page()`-ehdolla — ei voi unohtua
uusista templatesista.

Sulkee #278.

## Muutokset

- **`footer.php`** — pre-footer-kutsu + slim footer (brändi · nav · sähköposti + some · copyright)
- **`template-parts/pre-footer-large.php`** (uusi) — etusivun iso gradient-lohko: eyebrow, otsikko, kuvaus, ✓-edut, AcyMailing-lomake kortissa
- **`template-parts/pre-footer-compact.php`** (uusi) — alasivujen yksirivinen kaista
- **`assets/css/footer.css`** — kirjoitettu uusiksi; vain teeman CSS-tokeneita, mobiili-breakpointit 64 rem / 48 rem
- **`inc/newsletter.php`** — uusi `rytkoset_theme_get_footer_newsletter_form()` palauttaa pelkän lomake-HTMLn tai tyhjän (tilaaja / ei konfiguraatiota); partial piilottaa itsensä

## Testausohje

- [ ] **Etusivu** — iso pre-footer näkyy (gradient, otsikko, edut, lomake kortissa)
- [ ] **Alasivu** (esim. /sukuseura) — kompakti kaista näkyy
- [ ] **Kirjautumaton** — sähköpostikenttä + suostumus + nappi molemmissa
- [ ] **Kirjautunut, ei tilaaja** — vain "Tilaa uutiskirje" -nappi
- [ ] **Kirjautunut, aktiivinen tilaaja** — pre-footer ei näy lainkaan, slim footer näkyy
- [ ] **Slim footer** — näkyy kaikilla sivuilla (logo, footer-nav, sähköposti, some)
- [ ] **Mobiili** (alle 48 rem) — kaikki osat pinoutuvat yhteen sarakkeeseen
- [ ] **CI** — `php -l` läpäisee
