### PR TITLE
feat(login): uudista kirjautumis-, rekisteröitymissivut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerce-kaupan brändin mukaiset alasvetovalikko- ja painiketyylit.
 
 ### Changed
+- Kirjautumis-, rekisteröitymis- ja salasananunohdussivut (`wp-login.php`) uudistettu Claude Designin split-layoutiin: sininen brändipaneeli + lomakekortti, näkymäkohtaiset välilehdet/otsikot, uutiskirjeen opt-in -kortti ja sivuston teemavalintaa seuraava tumma/vaalea teema; toteutus `inc/login.php` + `assets/css/login.css` (#285)
 - Footerin uutiskirjetilaus siirtyi pre-footer-kaistaan; aktiiviselle tilaajalle koko kaista piilotetaan aiemman tekstihuomautuksen sijaan ja `assets/css/footer.css` kirjoitettiin uusiksi (#278)
 - Tampere 2026 -järjestäjäilmoitusten vastaanottajat siirretty globaalista asetuksesta tapahtuman omaan `Järjestäjäilmoitukset`-kenttään (#269)
 - Päivitetty `CLAUDE.md`:n `inc/`-moduulitaulukko ja WooCommerce-arkkitehtuurihuomio vastaamaan nykyistä `functions.php`-include-listaa.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Footer (Footer C, #278): `footer.php` renders a pre-footer newsletter band above
 | `inc/social-links.php`                 | Social media links in header/footer; icons inlined via `rytkoset_theme_inline_icon`      |
 | `inc/attachment-iptc.php`              | IPTC headline and description sync for attachment images                                 |
 | `inc/seo-meta.php`                     | Open Graph and Twitter Card meta tags                                                    |
-| `inc/login.php`                        | Login page branding and Finnish translations                                             |
+| `inc/login.php`                        | `wp-login.php` redesign: JS builds a split-layout brand panel + form card around `#login`, per-view copy/tabs, theme-following dark mode, Finnish translations |
 | `inc/newsletter.php`                   | AcyMailing newsletter integration: footer signup, subscription helpers and opt-in hooks   |
 | `inc/woocommerce-mollie.php`           | Mollie Finnish translations, RF reference normalization                                  |
 | `inc/woocommerce-membership.php`       | Membership products, checkout notice, admin column and metabox                           |

--- a/wp-content/themes/rytkoset-theme/assets/css/login.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/login.css
@@ -1,360 +1,703 @@
-:root {
-  /* Colors live in base.css; only login-specific tokens stay here. */
-  --shadow-card: 0 18px 48px rgba(15, 23, 42, 0.18);
-  --radius-medium: 14px;
-}
+/* =================================================================
+   Rytköset — Kirjautumis-, rekisteröitymis- ja salasananunohdussivut
+   (wp-login.php). Editoriaalinen split-layout: sininen brändipaneeli +
+   vaalea lomakekortti. Värit base.css:n tokeneista; login-spesifit
+   pintatokenit alla. Tumma teema seuraa sivuston valintaa
+   (:root[data-theme="dark"]).
+   ================================================================= */
 
-/* Piilotetaan WordPressin oletuslogin-logo, kun käytetään omaa brändiblokkia */
-body.login .wp-login-logo {
-  display: none;
-}
-
-
-/* Nollaa WordPressin oletuslogin-logotyylit */
-body.login h1 a {
-  background: none;
-  background-image: none;
-  text-indent: 0;
-  width: auto;
-  height: auto;
-  box-shadow: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
+/* -------------------------------------------------------------
+   Login-spesifit pintatokenit (vaalea). Brändivärit (--color-primary,
+   --color-accent jne.) tulevat base.css:stä.
+   ------------------------------------------------------------- */
 body.login {
+  --form-bg: #ffffff;
+  --form-bg-soft: #f7f8fa;
+  --auth-text: #1b2430;
+  --auth-text-mute: #5b6577;
+  --auth-text-faint: #8a93a3;
+  --auth-field-bg: #ffffff;
+  --auth-field-border: #d3d9e2;
+  --auth-field-border-hover: #b6bfcc;
+  --auth-divider: #e8ebf0;
+  --auth-card-shadow: 0 18px 50px rgba(8, 37, 74, 0.10);
+
+  --radius-auth-m: 10px;
+  --radius-auth-l: 16px;
+  --radius-auth-xl: 22px;
+
   font-family: var(--font-body);
-  background:
-    radial-gradient(circle at 14% 20%, rgba(59, 118, 168, 0.32), transparent 32%),
-    radial-gradient(circle at 78% 0%, rgba(251, 191, 36, 0.18), transparent 26%),
-    linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-primary) 45%, var(--color-primary-dark) 100%);
-  color: var(--color-text-inverted);
+  color: var(--auth-text);
   min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1rem;
-}
-
-body.login::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(15, 76, 129, 0.35) 0%, rgba(15, 76, 129, 0.5) 45%, rgba(11, 49, 91, 0.8) 100%);
-  mix-blend-mode: soft-light;
-  pointer-events: none;
-  z-index: 0;
-}
-
-body.login #login {
-  width: min(460px, 100%);
   margin: 0;
   padding: 0;
-  z-index: 1;
-  font-size: 1.05rem;
+  background: var(--color-primary-deeper);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.55;
 }
 
-.login-branding {
-  display: inline-flex;
-  align-items: center;
-  gap: 1rem;
-  margin: 0 0 1.25rem;
-  padding: 0.4rem 0.65rem 0.4rem 0.4rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 2px solid transparent;
-  border-radius: 18px;
-  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
-  text-decoration: none;
-  color: var(--color-text-inverted);
-  text-indent: 0;
-  transition: transform var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-normal), background var(--transition-fast);
+/* Tumma teema — lomakepuoli muuttuu syvänsiniseksi (designin mukaan). */
+:root[data-theme="dark"] body.login {
+  --form-bg: #0c2e57;
+  --form-bg-soft: #0a294e;
+  --auth-text: #eaf1f9;
+  --auth-text-mute: #aebfd4;
+  --auth-text-faint: #7e93b3;
+  --auth-field-bg: rgba(255, 255, 255, 0.05);
+  --auth-field-border: rgba(255, 255, 255, 0.18);
+  --auth-field-border-hover: rgba(255, 255, 255, 0.34);
+  --auth-divider: rgba(255, 255, 255, 0.12);
+  --auth-card-shadow: 0 24px 60px rgba(0, 0, 0, 0.40);
 }
 
-.login-branding:hover {
-  border-color: var(--color-nav-border);
-  transform: translateY(-2px);
-  box-shadow:
-    0 22px 50px rgba(0, 0, 0, 0.22),
-    0 0 0 3px rgba(0, 0, 0, 0.12);
-  outline: none;
-}
+body.login a { color: inherit; }
+body.login img { display: block; max-width: 100%; }
+body.login button { font-family: inherit; }
 
-.login-branding:focus-visible {
-  border-color: var(--color-nav-border);
-  transform: translateY(-2px);
-  box-shadow:
-    0 22px 50px rgba(0, 0, 0, 0.22),
-    0 0 0 3px rgba(251, 191, 36, 0.85);
-  outline: none;
-}
+/* Piilotetaan WP:n oletuslogo-otsikko — brändi on vasemmassa paneelissa. */
+body.login h1 { display: none; }
 
-.login-branding__logo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 0.85rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 16px;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
-  text-indent: -9999px;
-  overflow: hidden;
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  width: 120px;
-  height: 120px;
-  flex-shrink: 0;
-}
-
-.login-branding__text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  color: var(--color-text-inverted);
-  text-align: left;
-  text-indent: 0;
-}
-
-.login-branding__title {
-  font-size: 1.65rem;
-  font-weight: 800;
-  letter-spacing: 0.01em;
-  line-height: 1.15;
-}
-
-.login-branding__tagline {
-  font-size: 1rem;
-  opacity: 0.9;
-  line-height: 1.3;
-}
-
-body.login h1 {
-  margin: 0;
-  text-align: center;
-}
-
-body.login form {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border-neutral);
-  border-radius: var(--radius-medium);
-  padding: 1.6rem 1.6rem 1.3rem;
-  box-shadow: var(--shadow-card);
-  color: var(--color-text);
-  font-size: 1.05rem;
-}
-
-body.login form .input,
-body.login input[type="text"],
-body.login input[type="password"],
-body.login input[type="email"],
-body.login input[type="number"] {
-  width: 100%;
-  border: 1px solid var(--color-border-neutral);
-  border-radius: 10px;
-  padding: 0.65rem 0.75rem;
-  background: var(--color-surface-alt);
-  color: var(--color-text);
-  font-size: 1.05rem;
-  transition: border-color var(--transition-normal), box-shadow var(--transition-normal), background-color var(--transition-normal), outline-color var(--transition-normal);
-}
-
-body.login form .input:focus,
-body.login input[type="text"]:focus,
-body.login input[type="password"]:focus,
-body.login input[type="email"]:focus,
-body.login input[type="number"]:focus {
-  border-color: var(--color-primary);
-  background: var(--color-surface);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.7);
-}
-
-body.login label {
-  font-weight: 600;
-  color: var(--color-text);
-  font-size: 1.05rem;
-}
-
-body.login .forgetmenot {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  margin: 0.5rem 0 0.75rem;
-}
-
-body.login .forgetmenot label {
-  font-size: 1rem;
-  font-weight: 500;
-  color: #334155;
-}
-
-body.login .forgetmenot input[type="checkbox"] {
-  width: 1.1rem;
-  height: 1.1rem;
-  border-radius: 4px;
-  border: 1px solid var(--color-border-neutral);
-  accent-color: var(--color-primary);
-}
-
-body.login .forgetmenot input[type="checkbox"]:focus-visible {
-  outline: none;
-  box-shadow:
-    0 0 0 3px rgba(0, 0, 0, 0.12),
-    0 0 0 3px rgba(251, 191, 36, 0.65);
-}
-
-.rytkoset-login-newsletter-opt-in {
-  margin: 0.6rem 0 1rem;
-}
-
-.rytkoset-login-newsletter-opt-in label {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.rytkoset-login-newsletter-opt-in input[type="checkbox"] {
-  flex-shrink: 0;
-  margin-top: 0.2rem;
-  width: 1.1rem;
-  height: 1.1rem;
-  accent-color: var(--color-primary);
-}
-
-.rytkoset-login-newsletter-opt-in input[type="checkbox"]:focus-visible {
-  outline: 3px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-body.login .submit {
-  padding-top: 0.25rem;
-}
-
-body.login .submit .button-primary {
-  width: 100%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: var(--color-text-inverted);
-  border-radius: 10px;
-  font-weight: 700;
-  font-size: 1.05rem;
-  text-shadow: none;
-  box-shadow: 0 16px 32px rgba(15, 76, 129, 0.25);
-  transition: background-color var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-normal), transform var(--transition-fast);
-}
-
-body.login .submit .button-primary:hover,
-body.login .submit .button-primary:focus {
-  background: var(--color-primary-dark);
-  border-color: var(--color-primary-dark);
-  box-shadow:
-    0 16px 32px rgba(15, 76, 129, 0.35),
-    0 0 0 3px rgba(0, 0, 0, 0.12);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-body.login .submit .button-primary:focus-visible {
-  outline: none;
-  box-shadow:
-    0 16px 32px rgba(15, 76, 129, 0.35),
-    0 0 0 3px rgba(0, 0, 0, 0.12),
-    0 0 0 3px rgba(251, 191, 36, 0.65);
-}
-
-body.login .submit .button-primary:active {
-  transform: translateY(0);
-  box-shadow: 0 10px 22px rgba(15, 76, 129, 0.32);
-}
-
-body.login .wp-hide-pw:focus,
-body.login .wp-hide-pw:focus-visible {
-  outline: none !important;
-  border-color: var(--color-primary) !important;
-  background: var(--color-surface) !important;
-  color: var(--color-primary-dark) !important;
-  box-shadow:
-    0 0 0 3px rgba(0, 0, 0, 0.12),
-    0 0 0 3px rgba(251, 191, 36, 0.65) !important;
-  border-radius: 8px !important;
-}
-
-body.login .message,
-body.login #login_error {
-  border-left: 4px solid var(--color-accent);
-  padding: 0.95rem 1rem;
-  border-radius: 10px;
-  background: var(--color-surface-alt);
-  color: var(--color-text);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.05);
-}
-
-body.login .message a,
-body.login #login_error a {
-  color: var(--color-primary);
-  font-weight: 600;
-}
-
-body.login #nav,
-body.login #backtoblog {
-  text-align: center;
-  margin: 1.1rem 0 0;
-  font-size: 1.05rem;
-  line-height: 1.45;
-}
-
-body.login #nav a,
-body.login #backtoblog a {
-  color: var(--color-text-inverted);
-  font-weight: 600;
-  font-size: 1.05rem;
-}
-
-body.login #nav a:hover,
-body.login #backtoblog a:hover {
-  color: var(--color-accent);
-}
-
-body.login #nav a:focus-visible,
-body.login #backtoblog a:focus-visible {
-  color: var(--color-text-inverted);
-  outline: 3px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-body.login form .forgetmenot + .submit {
-  margin-top: 0.6rem;
-}
-
-body.login .privacy-policy-link {
-  color: var(--color-text-inverted);
-}
-
-body.login .privacy-policy-link:hover {
-  color: var(--color-accent);
-}
-
-/* Pidetään #login keskitettynä vaikka plugin/WordPress injektoisi body-lapsia */
-body.login > *:not(#login) {
+/* Piilotetaan kaikki muu kuin split-kehys / #login (suoja plugin-tulosteille).
+   Ennen JS-injektiota #login on suora lapsi; sen jälkeen .auth-split on. */
+body.login > *:not(.auth-split):not(#login):not(script):not(style):not(noscript) {
   position: absolute;
   left: -9999px;
   visibility: hidden;
 }
 
-@media (max-width: 480px) {
-  body.login {
-    padding: 1.5rem 1rem;
-  }
+/* =================================================================
+   SPLIT-LAYOUT (JS rakentaa: .auth-split > .auth-brand + .auth-stage)
+   ================================================================= */
+.auth-split {
+  display: grid;
+  grid-template-columns: minmax(420px, 5fr) 7fr;
+  min-height: 100vh;
+}
 
-  body.login form {
-    padding: 1.25rem 1.2rem 1rem;
+/* -------- Brändipaneeli (aina sininen) -------- */
+.auth-brand {
+  position: relative;
+  overflow: hidden;
+  color: #fff;
+  padding: 56px 56px 40px;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(120% 90% at 18% 0%, rgba(59, 118, 168, 0.55) 0%, rgba(15, 76, 129, 0) 55%),
+    linear-gradient(158deg, #105087 0%, #0c3d6e 46%, #08254a 100%);
+}
+.auth-brand::after {
+  content: "";
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  width: 4px;
+  background: linear-gradient(180deg, var(--color-accent), rgba(251, 191, 36, 0));
+}
+
+/* Logo-vesileima */
+.brand-motif {
+  position: absolute;
+  right: -120px;
+  bottom: -90px;
+  width: 560px;
+  opacity: 0.06;
+  filter: grayscale(1) brightness(2);
+  pointer-events: none;
+  transform: rotate(-8deg);
+}
+
+.brand-top {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+.brand-badge {
+  flex-shrink: 0;
+  width: 72px;
+  height: 72px;
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.10);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 18px;
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+}
+.brand-badge img { width: 46px; height: auto; }
+.brand-titles { display: flex; flex-direction: column; line-height: 1.12; }
+.brand-name {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 25px;
+  letter-spacing: -0.01em;
+}
+.brand-tag {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.72);
+  margin-top: 4px;
+}
+
+.brand-body {
+  position: relative;
+  z-index: 1;
+  margin-top: auto;
+  margin-bottom: auto;
+  padding: 48px 0;
+  max-width: 460px;
+}
+.brand-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-accent);
+  margin: 0 0 18px;
+}
+.brand-headline {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: clamp(30px, 3vw, 42px);
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  margin: 0;
+  text-wrap: balance;
+}
+.brand-lede {
+  font-size: 16.5px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.80);
+  margin: 20px 0 0;
+  max-width: 420px;
+}
+
+.brand-foot {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  font-size: 13.5px;
+  color: rgba(255, 255, 255, 0.66);
+}
+.brand-foot a {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 2px;
+  border-radius: 6px;
+  transition: color 140ms ease;
+}
+.brand-foot a:hover { color: #fff; }
+.brand-foot a:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 3px; color: #fff; }
+.brand-foot a svg { width: 16px; height: 16px; }
+.brand-foot .dot { width: 3px; height: 3px; border-radius: 50%; background: rgba(255, 255, 255, 0.4); }
+
+/* =================================================================
+   LOMAKEPUOLI — #login toimii korttina .auth-stagen sisällä
+   ================================================================= */
+.auth-stage {
+  background: var(--form-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 56px 40px;
+}
+body.login #login {
+  width: 100%;
+  max-width: 426px;
+  margin: 0;
+  padding: 0;
+  font-size: 15px;
+}
+
+/* =================================================================
+   VÄLILEHDET (Kirjaudu / Rekisteröidy) — JS rakentaa
+   ================================================================= */
+.auth-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 4px;
+  background: var(--form-bg-soft);
+  border: 1px solid var(--auth-divider);
+  border-radius: var(--radius-pill);
+  margin-bottom: 30px;
+}
+.auth-tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--auth-text-mute);
+  font-size: 14.5px;
+  font-weight: 600;
+  padding: 10px 14px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  min-height: 42px;
+  transition: background-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+}
+.auth-tab.is-active {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(15, 76, 129, 0.28);
+}
+.auth-tab:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 2px; }
+:root[data-theme="dark"] .auth-tab.is-active { background: var(--color-accent); color: var(--color-primary-deeper); }
+
+/* =================================================================
+   NÄKYMÄN OTSIKKO + sisääntuloanimaatio
+   ================================================================= */
+.auth-view-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--color-primary-light);
+  margin: 0 0 10px;
+}
+:root[data-theme="dark"] .auth-view-eyebrow { color: var(--color-accent); }
+.auth-view-title {
+  display: block;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 30px;
+  line-height: 1.12;
+  letter-spacing: -0.015em;
+  margin: 0 0 8px;
+  color: var(--auth-text);
+}
+.auth-view-sub {
+  font-size: 15px;
+  color: var(--auth-text-mute);
+  margin: 0 0 26px;
+  max-width: 40ch;
+}
+
+.auth-view-head { animation: authViewIn 320ms cubic-bezier(0.22, 1, 0.36, 1); }
+@keyframes authViewIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .auth-view-head { animation: none; }
+}
+
+/* =================================================================
+   KENTÄT — tyylitellään WP:n natiivi lomakemerkintä
+   (form > p > label + input.input ; .user-pass-wrap > .wp-pwd)
+   ================================================================= */
+body.login form {
+  background: transparent;
+  border: none;
+  padding: 0;
+  box-shadow: none;
+  color: var(--auth-text);
+  margin: 0;
+}
+body.login form p { margin: 0 0 18px; }
+
+body.login form label {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--auth-text);
+  margin-bottom: 7px;
+}
+
+body.login form .input,
+body.login input[type="text"],
+body.login input[type="password"],
+body.login input[type="email"] {
+  width: 100%;
+  font-family: inherit;
+  font-size: 15px;
+  color: var(--auth-text);
+  background: var(--auth-field-bg);
+  border: 1.5px solid var(--auth-field-border);
+  border-radius: var(--radius-auth-m);
+  padding: 13px 15px;
+  min-height: 50px;
+  box-shadow: none;
+  transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+}
+body.login form .input::placeholder { color: var(--auth-text-faint); }
+body.login form .input:hover { border-color: var(--auth-field-border-hover); }
+body.login form .input:focus,
+body.login input[type="text"]:focus,
+body.login input[type="password"]:focus,
+body.login input[type="email"]:focus {
+  outline: none;
+  border-color: var(--color-primary-light);
+  box-shadow: 0 0 0 4px rgba(59, 118, 168, 0.18);
+}
+:root[data-theme="dark"] body.login form .input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.20);
+}
+
+/* Salasanan näytä/piilota — WP:n natiivi .wp-pwd + .wp-hide-pw */
+body.login .user-pass-wrap .wp-pwd { position: relative; }
+body.login .wp-pwd .input { padding-right: 50px; }
+body.login .wp-hide-pw {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--auth-text-faint);
+  cursor: pointer;
+  transition: color 140ms ease, background-color 140ms ease;
+}
+body.login .wp-hide-pw:hover { color: var(--auth-text); background: var(--form-bg-soft); }
+body.login .wp-hide-pw .dashicons { width: 20px; height: 20px; font-size: 20px; }
+body.login .wp-hide-pw:focus,
+body.login .wp-hide-pw:focus-visible {
+  outline: none;
+  color: var(--color-primary);
+  background: var(--form-bg-soft);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.7);
+}
+
+/* Rivi: "Muista minut" + "Unohditko salasanasi?" (linkki siirretään tähän JS:llä) */
+body.login .forgetmenot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 6px 0 22px;
+}
+body.login .forgetmenot label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--auth-text-mute);
+  cursor: pointer;
+}
+body.login .forgetmenot input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  border-radius: 6px;
+  border: 1.5px solid var(--auth-field-border);
+  background: var(--auth-field-bg);
+  accent-color: var(--color-primary);
+}
+body.login .forgetmenot input[type="checkbox"]:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+/* Hillitty "Unohditko salasanasi?" -linkki */
+.auth-inline-link {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+:root[data-theme="dark"] .auth-inline-link { color: var(--color-accent); }
+.auth-inline-link:hover { text-decoration: underline; }
+.auth-inline-link:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 2px; border-radius: 4px; }
+
+/* =================================================================
+   UUTISKIRJEKORTTI (rekisteröityminen) — vapaaehtoinen opt-in
+   Markup: inc/newsletter.php. On-tila :has(:checked) kautta.
+   ================================================================= */
+.rytkoset-login-newsletter-opt-in { margin: 22px 0 8px; }
+.rytkoset-login-newsletter-opt-in .newsletter {
+  display: flex;
+  gap: 13px;
+  align-items: flex-start;
+  padding: 16px 16px 16px 15px;
+  border: 1.5px solid var(--auth-field-border);
+  border-radius: var(--radius-auth-l);
+  background: var(--form-bg-soft);
+  cursor: pointer;
+  margin: 0;
+  font-weight: 400;
+  transition: border-color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+}
+.rytkoset-login-newsletter-opt-in .newsletter:hover { border-color: var(--auth-field-border-hover); }
+.rytkoset-login-newsletter-opt-in .newsletter:has(input:checked) {
+  border-color: var(--color-primary-light);
+  background: rgba(59, 118, 168, 0.06);
+  box-shadow: 0 0 0 3px rgba(59, 118, 168, 0.10);
+}
+:root[data-theme="dark"] .rytkoset-login-newsletter-opt-in .newsletter:has(input:checked) {
+  border-color: var(--color-accent);
+  background: rgba(251, 191, 36, 0.08);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.12);
+}
+.rytkoset-login-newsletter-opt-in .newsletter:has(input:focus-visible) {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.rytkoset-login-newsletter-opt-in .newsletter input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.newsletter__icon {
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  display: grid;
+  place-items: center;
+  background: var(--color-primary);
+  color: #fff;
+  transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.newsletter:has(input:checked) .newsletter__icon { transform: scale(1.04) rotate(-3deg); }
+:root[data-theme="dark"] .newsletter__icon { background: var(--color-accent); color: var(--color-primary-deeper); }
+.newsletter__icon svg { width: 22px; height: 22px; }
+.newsletter__text { flex: 1; min-width: 0; }
+.newsletter__head { display: flex; align-items: center; gap: 9px; margin-bottom: 3px; }
+.newsletter__title { font-size: 14.5px; font-weight: 700; color: var(--auth-text); }
+.newsletter__opt {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--auth-text-faint);
+  border: 1px solid var(--auth-divider);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+.newsletter__desc { font-size: 13px; color: var(--auth-text-mute); line-height: 1.5; }
+.newsletter__check {
+  flex-shrink: 0;
+  align-self: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 1.5px solid var(--auth-field-border);
+  display: grid;
+  place-items: center;
+  transition: background-color 160ms ease, border-color 160ms ease;
+}
+.newsletter__check svg {
+  width: 14px;
+  height: 14px;
+  color: #fff;
+  opacity: 0;
+  transform: scale(0.5);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+.newsletter:has(input:checked) .newsletter__check { background: var(--color-primary); border-color: var(--color-primary); }
+.newsletter:has(input:checked) .newsletter__check svg { opacity: 1; transform: scale(1); }
+:root[data-theme="dark"] .newsletter:has(input:checked) .newsletter__check { background: var(--color-accent); border-color: var(--color-accent); }
+:root[data-theme="dark"] .newsletter:has(input:checked) .newsletter__check svg { color: var(--color-primary-deeper); }
+
+/* =================================================================
+   HUOMAUTUSLAATIKKO (rekisteröitymisen vahvistusteksti)
+   ================================================================= */
+.auth-note,
+body.login #reg_passmail {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: var(--auth-text-mute);
+  background: var(--form-bg-soft);
+  border: 1px solid var(--auth-divider);
+  border-radius: var(--radius-auth-m);
+  padding: 12px 14px;
+  margin: 8px 0 0;
+}
+.auth-note svg { width: 18px; height: 18px; flex-shrink: 0; color: var(--color-primary-light); }
+:root[data-theme="dark"] .auth-note svg { color: var(--color-accent); }
+
+/* =================================================================
+   LÄHETYSPAINIKE — lukittu keltainen aksentti
+   ================================================================= */
+body.login .submit { margin: 0; padding: 0; }
+body.login .submit .button-primary,
+body.login #wp-submit {
+  width: 100%;
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 15.5px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  padding: 15px 22px;
+  min-height: 54px;
+  border-radius: var(--radius-auth-m);
+  margin-top: 18px;
+  text-shadow: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  background: var(--color-accent);
+  color: var(--color-primary-deeper);
+  box-shadow: 0 10px 24px rgba(251, 191, 36, 0.34);
+  transition: transform 140ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+body.login .submit .button-primary:hover,
+body.login .submit .button-primary:focus,
+body.login #wp-submit:hover,
+body.login #wp-submit:focus {
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(251, 191, 36, 0.42);
+}
+body.login .submit .button-primary:focus-visible,
+body.login #wp-submit:focus-visible {
+  outline: none;
+  box-shadow: 0 14px 30px rgba(251, 191, 36, 0.42), 0 0 0 3px rgba(8, 37, 74, 0.55);
+}
+body.login .submit .button-primary:active,
+body.login #wp-submit:active { transform: translateY(0); }
+
+/* =================================================================
+   VIESTIT JA VIRHEET — luettavat suomeksi
+   ================================================================= */
+body.login .message,
+body.login .success,
+body.login #login_error {
+  border-left: 4px solid var(--color-accent);
+  padding: 0.95rem 1rem;
+  border-radius: var(--radius-auth-m);
+  background: var(--form-bg-soft);
+  color: var(--auth-text);
+  box-shadow: none;
+  border-top: 1px solid var(--auth-divider);
+  border-right: 1px solid var(--auth-divider);
+  border-bottom: 1px solid var(--auth-divider);
+  margin-bottom: 20px;
+  font-size: 14px;
+}
+body.login #login_error { border-left-color: #d23f3f; }
+body.login .message a,
+body.login #login_error a {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+:root[data-theme="dark"] body.login .message a,
+:root[data-theme="dark"] body.login #login_error a { color: var(--color-accent); }
+
+/* =================================================================
+   ALAVIIVALINKKI (#nav restyle) + back-linkki + footer
+   ================================================================= */
+body.login #nav,
+.auth-switch {
+  margin-top: 26px;
+  padding-top: 22px;
+  border-top: 1px solid var(--auth-divider);
+  font-size: 14px;
+  color: var(--auth-text-mute);
+  text-align: center;
+  line-height: 1.5;
+}
+body.login #nav a,
+.auth-switch a {
+  font-weight: 700;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+:root[data-theme="dark"] body.login #nav a,
+:root[data-theme="dark"] .auth-switch a { color: var(--color-accent); }
+body.login #nav a:hover,
+.auth-switch a:hover { text-decoration: underline; }
+body.login #nav a:focus-visible,
+.auth-switch a:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 2px; border-radius: 4px; }
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--auth-text-mute);
+  text-decoration: none;
+  margin-bottom: 26px;
+  transition: color 140ms ease, gap 140ms ease;
+}
+.back-link:hover { color: var(--auth-text); gap: 11px; }
+.back-link:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 2px; border-radius: 4px; }
+.back-link svg { width: 16px; height: 16px; }
+
+/* "Palaa pääsivulle" -linkki kortin alla. Työpöydällä brändipaneelin footer
+   hoitaa saman linkin, joten enhanced-tilassa (body.login.js) #backtoblog
+   piilotetaan ja näytetään vain keskitetyssä mobiililayoutissa. Ilman JS:ää
+   linkki jää näkyviin fallbackina. */
+body.login #backtoblog {
+  text-align: center;
+  margin: 22px 0 0;
+  font-size: 13px;
+}
+body.login.js #backtoblog { display: none; }
+body.login #backtoblog a {
+  color: var(--auth-text-mute);
+  text-decoration: none;
+  font-weight: 600;
+}
+body.login #backtoblog a:hover { color: var(--auth-text); }
+body.login #backtoblog a:focus-visible { outline: 3px solid var(--color-accent); outline-offset: 2px; border-radius: 4px; }
+
+/* =================================================================
+   RESPONSIIVISUUS — ≤ 860px keskitetty layout (kelluva kortti)
+   ================================================================= */
+@media (max-width: 860px) {
+  .auth-split { grid-template-columns: 1fr; min-height: 100vh; }
+
+  .auth-brand {
+    padding: 40px 28px 30px;
+    align-items: center;
+    text-align: center;
   }
+  .auth-brand::after { display: none; }
+  .brand-top { flex-direction: column; gap: 14px; }
+  .brand-titles { align-items: center; text-align: center; }
+  .brand-body,
+  .brand-foot { display: none; }
+  .brand-motif { width: 360px; right: -90px; bottom: -70px; }
+
+  .auth-stage {
+    background: transparent;
+    padding: 0 22px 56px;
+    align-items: flex-start;
+  }
+  body.login #login {
+    background: var(--form-bg);
+    border-radius: var(--radius-auth-xl);
+    box-shadow: var(--auth-card-shadow);
+    padding: 36px 30px 32px;
+    margin-top: -8px;
+    max-width: 460px;
+  }
+  body.login.js #backtoblog { display: block; }
+  body.login #backtoblog a { color: var(--auth-text-mute); }
+}
+
+@media (max-width: 480px) {
+  .auth-brand { padding: 30px 20px 24px; }
+  .brand-badge { width: 60px; height: 60px; }
+  .brand-badge img { width: 38px; }
+  .brand-name { font-size: 22px; }
+  .auth-view-title { font-size: 26px; }
+  body.login #login { padding: 28px 22px 26px; }
 }

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/arrow-left.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/arrow-left.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19 12H5M11 6l-6 6 6 6"/></svg>

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/arrow-right.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/arrow-right.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/check.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/check.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/info.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/info.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></svg>

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/mail.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/mail.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2.5"/><path d="m3.5 7 8.5 6 8.5-6"/></svg>

--- a/wp-content/themes/rytkoset-theme/assets/icons/ui/send.svg
+++ b/wp-content/themes/rytkoset-theme/assets/icons/ui/send.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 2 11 13M22 2l-7 20-4-9-9-4 20-7Z"/></svg>

--- a/wp-content/themes/rytkoset-theme/inc/login.php
+++ b/wp-content/themes/rytkoset-theme/inc/login.php
@@ -52,54 +52,255 @@ function rytkoset_theme_get_login_logo_url() {
 }
 
 /**
- * Ajetaan lopuksi varmistava JS, joka asettaa logon taustakuvan ja piilottaa tekstin.
+ * Asetetaan teema (data-theme) heti <head>:ssä sivuston valinnan mukaan.
+ *
+ * Kirjautumissivulla ei ladata teemanvaihtonappia eikä main.js:ää, joten
+ * luetaan sama localStorage-avain ('rytkoset-theme', fallback prefers-color-scheme)
+ * ja asetetaan attribuutti ennen renderöintiä — estää teeman välähdyksen.
  */
-function rytkoset_theme_login_logo_script() {
-	$logo_url  = rytkoset_theme_get_login_logo_url();
-	$site_name = get_bloginfo( 'name' );
-	$tagline   = get_bloginfo( 'description' );
-	$home_url  = home_url( '/' );
+function rytkoset_theme_login_theme_attribute() {
+	?>
+	<script>
+		(function () {
+			try {
+				var stored = localStorage.getItem('rytkoset-theme');
+				var theme = (stored === 'dark' || stored === 'light')
+					? stored
+					: (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+				document.documentElement.setAttribute('data-theme', theme);
+			} catch (e) {}
+		})();
+	</script>
+	<?php
+}
+add_action( 'login_head', 'rytkoset_theme_login_theme_attribute' );
+
+/**
+ * Palauttaa kirjautumissivun näkymäkohtaiset tekstit ja asetukset JS:lle.
+ *
+ * @return array
+ */
+function rytkoset_theme_get_login_layout_config() {
+	$views = array(
+		'login'  => array(
+			'eyebrow'        => __( 'Jäsenten alue', 'rytkoset-theme' ),
+			'title'          => __( 'Tervetuloa takaisin', 'rytkoset-theme' ),
+			'sub'            => __( 'Kirjaudu sisään päästäksesi albumeihin, foorumille ja jäsenetuihin.', 'rytkoset-theme' ),
+			'brandEyebrow'   => __( 'Rytkösten sukuseura', 'rytkoset-theme' ),
+			'brandHeadline'  => __( 'Sukulaisten oma kohtaamispaikka.', 'rytkoset-theme' ),
+			'brandLede'      => __( 'Kirjaudu sisään ja jatka matkaa suvun tarinoiden, kuvien ja tapahtumien parissa.', 'rytkoset-theme' ),
+			'switchText'     => __( 'Ei vielä tunnusta?', 'rytkoset-theme' ),
+			'switchLinkText' => __( 'Liity sukuseuraan', 'rytkoset-theme' ),
+			'switchLinkUrl'  => wp_registration_url(),
+		),
+		'register' => array(
+			'eyebrow'        => __( 'Uusi jäsen', 'rytkoset-theme' ),
+			'title'          => __( 'Luo tunnus', 'rytkoset-theme' ),
+			'sub'            => __( 'Rekisteröidy mukaan — Rytkösiä sukupolvesta toiseen.', 'rytkoset-theme' ),
+			'brandEyebrow'   => __( 'Liity mukaan', 'rytkoset-theme' ),
+			'brandHeadline'  => __( 'Tule osaksi suvun tarinaa.', 'rytkoset-theme' ),
+			'brandLede'      => __( 'Jäsenenä pääset käsiksi albumeihin, foorumiin ja sukukokousten tietoihin.', 'rytkoset-theme' ),
+			'switchText'     => __( 'Onko sinulla jo tunnus?', 'rytkoset-theme' ),
+			'switchLinkText' => __( 'Kirjaudu sisään', 'rytkoset-theme' ),
+			'switchLinkUrl'  => wp_login_url(),
+		),
+		'forgot' => array(
+			'eyebrow'        => __( 'Salasanan palautus', 'rytkoset-theme' ),
+			'title'          => __( 'Unohtuiko salasana?', 'rytkoset-theme' ),
+			'sub'            => __( 'Kirjoita käyttäjätunnuksesi tai sähköpostiosoitteesi, niin lähetämme sinulle linkin uuden salasanan asettamiseen.', 'rytkoset-theme' ),
+			'brandEyebrow'   => __( 'Ei hätää', 'rytkoset-theme' ),
+			'brandHeadline'  => __( 'Autetaan sinut takaisin sisään.', 'rytkoset-theme' ),
+			'brandLede'      => __( 'Palautuslinkki on perillä hetkessä. Tunnukset pysyvät tallessa, suku odottaa.', 'rytkoset-theme' ),
+			'switchText'     => __( 'Muistitko sittenkin?', 'rytkoset-theme' ),
+			'switchLinkText' => __( 'Kirjaudu sisään', 'rytkoset-theme' ),
+			'switchLinkUrl'  => wp_login_url(),
+		),
+	);
+
+	return array(
+		'siteName'             => get_bloginfo( 'name' ),
+		'tagline'              => get_bloginfo( 'description' ),
+		'logoUrl'              => rytkoset_theme_get_login_logo_url(),
+		'homeUrl'              => home_url( '/' ),
+		'homeLabel'            => __( 'Palaa pääsivulle', 'rytkoset-theme' ),
+		'privacyUrl'           => get_privacy_policy_url(),
+		'privacyLabel'         => __( 'Tietosuojaseloste', 'rytkoset-theme' ),
+		'loginUrl'             => wp_login_url(),
+		'registerUrl'          => wp_registration_url(),
+		'lostpasswordUrl'      => wp_lostpassword_url(),
+		'tabLogin'             => __( 'Kirjaudu sisään', 'rytkoset-theme' ),
+		'tabRegister'          => __( 'Rekisteröidy', 'rytkoset-theme' ),
+		'lostpasswordLinkText' => __( 'Unohditko salasanasi?', 'rytkoset-theme' ),
+		'backLinkText'         => __( 'Takaisin kirjautumiseen', 'rytkoset-theme' ),
+		'icons'                => array(
+			'arrowLeft' => rytkoset_theme_inline_icon( 'arrow-left', 'ui' ),
+			'info'      => rytkoset_theme_inline_icon( 'info', 'ui' ),
+		),
+		'views'                => $views,
+	);
+}
+
+/**
+ * Rakentaa kirjautumissivun split-layoutin (brändipaneeli + lomakekortti).
+ *
+ * WordPressin lomakemerkintä säilytetään; brändipaneeli, välilehdet,
+ * näkymäotsikko ja alalinkit injektoidaan #login-elementin ympärille.
+ */
+function rytkoset_theme_login_layout_script() {
+	$config = rytkoset_theme_get_login_layout_config();
 	?>
 	<script>
 		document.addEventListener('DOMContentLoaded', function () {
-			// Poista mahdolliset vanhat brändiblokit
-			document.querySelectorAll('#login .login-branding').forEach(function (el) {
-				el.remove();
-			});
+			var CFG = <?php echo wp_json_encode( $config ); ?>;
+			var loginEl = document.getElementById('login');
+			if (!loginEl || document.querySelector('.auth-split')) return;
 
-			var heading = document.querySelector('#login h1');
-			if (!heading) return;
+			var params = new URLSearchParams(window.location.search);
+			var action = params.get('action') || 'login';
+			var view = (action === 'register') ? 'register'
+				: (action === 'lostpassword' || action === 'retrievepassword') ? 'forgot'
+				: (action === 'login' || action === '') ? 'login'
+				: 'other';
+			var v = CFG.views[view] || CFG.views.login;
 
-			// Rakennetaan yhtenäinen brändilinkki
-			var brandLink = document.createElement('a');
-			brandLink.className = 'login-branding';
-			brandLink.href = '<?php echo esc_url( $home_url ); ?>';
+			function el(tag, cls, text) {
+				var e = document.createElement(tag);
+				if (cls) e.className = cls;
+				if (text != null) e.textContent = text;
+				return e;
+			}
+			function icon(svg) {
+				var s = el('span', 'auth-ic');
+				s.setAttribute('aria-hidden', 'true');
+				s.innerHTML = svg;
+				return s;
+			}
+			function linkWithLeadIcon(href, svg, text) {
+				var a = el('a');
+				a.href = href;
+				if (svg) a.appendChild(icon(svg));
+				a.appendChild(document.createTextNode((svg ? ' ' : '') + text));
+				return a;
+			}
 
-			var logoBlock = document.createElement('span');
-			logoBlock.className = 'login-branding__logo';
-			<?php if ( ! empty( $logo_url ) ) : ?>
-			logoBlock.style.backgroundImage = 'url("<?php echo esc_url( $logo_url ); ?>")';
-			<?php endif; ?>
+			/* ---- Brändipaneeli ---- */
+			var brand = el('aside', 'auth-brand');
+			if (CFG.logoUrl) {
+				var motif = el('img', 'brand-motif');
+				motif.src = CFG.logoUrl;
+				motif.alt = '';
+				motif.setAttribute('aria-hidden', 'true');
+				brand.appendChild(motif);
+			}
+			var top = el('div', 'brand-top');
+			var badge = el('span', 'brand-badge');
+			if (CFG.logoUrl) {
+				var bi = el('img');
+				bi.src = CFG.logoUrl;
+				bi.alt = '';
+				badge.appendChild(bi);
+			}
+			var titles = el('span', 'brand-titles');
+			titles.appendChild(el('span', 'brand-name', CFG.siteName));
+			if (CFG.tagline) titles.appendChild(el('span', 'brand-tag', CFG.tagline));
+			top.appendChild(badge);
+			top.appendChild(titles);
+			brand.appendChild(top);
 
-			var text = document.createElement('span');
-			text.className = 'login-branding__text';
-			text.innerHTML =
-				'<span class="login-branding__title"><?php echo esc_js( $site_name ); ?></span>'
-				<?php if ( $tagline ) : ?> +
-				'<span class="login-branding__tagline"><?php echo esc_js( $tagline ); ?></span>'
-				<?php endif; ?>;
+			var body = el('div', 'brand-body');
+			body.appendChild(el('p', 'brand-eyebrow', v.brandEyebrow));
+			body.appendChild(el('h2', 'brand-headline', v.brandHeadline));
+			body.appendChild(el('p', 'brand-lede', v.brandLede));
+			brand.appendChild(body);
 
-			brandLink.appendChild(logoBlock);
-			brandLink.appendChild(text);
+			var foot = el('div', 'brand-foot');
+			foot.appendChild(linkWithLeadIcon(CFG.homeUrl, CFG.icons.arrowLeft, CFG.homeLabel));
+			if (CFG.privacyUrl) {
+				foot.appendChild(el('span', 'dot'));
+				var pl = el('a', null, CFG.privacyLabel);
+				pl.href = CFG.privacyUrl;
+				foot.appendChild(pl);
+			}
+			brand.appendChild(foot);
 
-			// 🔑 ÄLÄ koske h1:een, se saa olla screen-reader-text.
-			// Lisää brändikortti heti h1:n jälkeen näkyviin.
-			heading.insertAdjacentElement('afterend', brandLink);
+			/* ---- Split-kehys: siirretään #login lomakepuolelle ---- */
+			var split = el('div', 'auth-split');
+			var stage = el('div', 'auth-stage');
+			loginEl.parentNode.insertBefore(split, loginEl);
+			split.appendChild(brand);
+			split.appendChild(stage);
+			stage.appendChild(loginEl);
+
+			/* ---- Kortin yläosa: välilehdet / back-linkki + näkymäotsikko ---- */
+			var heading = loginEl.querySelector('h1');
+			var ref = heading ? heading.nextSibling : loginEl.firstChild;
+			function insertRef(node) { loginEl.insertBefore(node, ref); }
+
+			if (view === 'login' || view === 'register') {
+				var tabs = el('div', 'auth-tabs');
+				tabs.setAttribute('role', 'tablist');
+				var t1 = el('a', 'auth-tab' + (view === 'login' ? ' is-active' : ''), CFG.tabLogin);
+				t1.href = CFG.loginUrl;
+				t1.setAttribute('role', 'tab');
+				t1.setAttribute('aria-selected', view === 'login' ? 'true' : 'false');
+				var t2 = el('a', 'auth-tab' + (view === 'register' ? ' is-active' : ''), CFG.tabRegister);
+				t2.href = CFG.registerUrl;
+				t2.setAttribute('role', 'tab');
+				t2.setAttribute('aria-selected', view === 'register' ? 'true' : 'false');
+				tabs.appendChild(t1);
+				tabs.appendChild(t2);
+				insertRef(tabs);
+			} else if (view === 'forgot') {
+				insertRef(linkWithLeadIcon(CFG.loginUrl, CFG.icons.arrowLeft, CFG.backLinkText)).className = 'back-link';
+			}
+
+			if (CFG.views[view]) {
+				var head = el('div', 'auth-view-head');
+				head.appendChild(el('p', 'auth-view-eyebrow', v.eyebrow));
+				head.appendChild(el('h1', 'auth-view-title', v.title));
+				head.appendChild(el('p', 'auth-view-sub', v.sub));
+				insertRef(head);
+			}
+
+			/* ---- Register: info-ikoni vahvistustekstin (#reg_passmail) eteen ---- */
+			if (view === 'register' && CFG.icons.info) {
+				var note = loginEl.querySelector('#reg_passmail');
+				if (note && !note.querySelector('.auth-ic')) {
+					note.classList.add('auth-note');
+					note.insertBefore(icon(CFG.icons.info), note.firstChild);
+				}
+			}
+
+			/* ---- Login: "Unohditko salasanasi?" rivin oikeaan reunaan ---- */
+			if (view === 'login') {
+				var fmn = loginEl.querySelector('.forgetmenot');
+				if (fmn) {
+					var lp = el('a', 'auth-inline-link', CFG.lostpasswordLinkText);
+					lp.href = CFG.lostpasswordUrl;
+					fmn.appendChild(lp);
+				}
+			}
+
+			/* ---- Alalinkki: korvataan WP:n #nav näkymäkohtaisella switch-rivillä ---- */
+			if (CFG.views[view] && v.switchText) {
+				var sw = el('p', 'auth-switch');
+				sw.appendChild(document.createTextNode(v.switchText + ' '));
+				var swa = el('a', null, v.switchLinkText);
+				swa.href = v.switchLinkUrl;
+				sw.appendChild(swa);
+				var nav = loginEl.querySelector('#nav');
+				if (nav) {
+					nav.parentNode.insertBefore(sw, nav);
+					nav.parentNode.removeChild(nav);
+				} else {
+					loginEl.appendChild(sw);
+				}
+			}
 		});
 	</script>
 	<?php
 }
-add_action( 'login_footer', 'rytkoset_theme_login_logo_script' );
+add_action( 'login_footer', 'rytkoset_theme_login_layout_script' );
 
 
 /**

--- a/wp-content/themes/rytkoset-theme/inc/newsletter.php
+++ b/wp-content/themes/rytkoset-theme/inc/newsletter.php
@@ -507,11 +507,24 @@ if ( ! function_exists( 'rytkoset_theme_render_registration_newsletter_opt_in' )
 			return;
 		}
 
-		rytkoset_theme_render_newsletter_opt_in_checkbox(
-			'rytkoset-newsletter-opt-in',
-			'rytkoset_newsletter_opt_in',
-			'rytkoset-login-newsletter-opt-in'
-		);
+		$mail_icon  = function_exists( 'rytkoset_theme_inline_icon' ) ? rytkoset_theme_inline_icon( 'mail', 'ui' ) : '';
+		$check_icon = function_exists( 'rytkoset_theme_inline_icon' ) ? rytkoset_theme_inline_icon( 'check', 'ui' ) : '';
+		?>
+		<div class="rytkoset-login-newsletter-opt-in">
+			<label class="newsletter" for="rytkoset-newsletter-opt-in">
+				<input id="rytkoset-newsletter-opt-in" type="checkbox" name="rytkoset_newsletter_opt_in" value="1" />
+				<span class="newsletter__icon"><?php echo $mail_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted inline SVG from theme icon set. ?></span>
+				<span class="newsletter__text">
+					<span class="newsletter__head">
+						<span class="newsletter__title"><?php esc_html_e( 'Tilaa sukuseuran uutiskirje', 'rytkoset-theme' ); ?></span>
+						<span class="newsletter__opt"><?php esc_html_e( 'Vapaaehtoinen', 'rytkoset-theme' ); ?></span>
+					</span>
+					<span class="newsletter__desc"><?php esc_html_e( 'Saat ajankohtaiset uutiset, tapahtumat ja sukukokouskutsut suoraan sähköpostiisi. Voit perua tilauksen koska tahansa.', 'rytkoset-theme' ); ?></span>
+				</span>
+				<span class="newsletter__check"><?php echo $check_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted inline SVG from theme icon set. ?></span>
+			</label>
+		</div>
+		<?php
 	}
 }
 add_action( 'register_form', 'rytkoset_theme_render_registration_newsletter_opt_in' );


### PR DESCRIPTION
## Yhteenveto

- Uudistettu kirjautumis-, rekisteröitymis- ja salasananunohdussivut Claude Designin split-layoutin mukaisiksi: sininen brändipaneeli vasemmalla, lomakekortti oikealla
- JS rakentaa layoutin WP:n natiivin `#login`-elementin ympärille; WP:n autentikointilogiikkaan ei kajota
- Tumma teema seuraa sivuston valintaa (`localStorage['rytkoset-theme']`, fallback `prefers-color-scheme`); teemanvaihtoa ei ennen renderöintiä (inline-skripti `login_head`-hookissa)
- Uutiskirjeen opt-in -kortti rekisteröitymisessä uudistettu designin mukaiseksi; oletuksena valitsematta (GDPR)

## Muutokset

**`assets/css/login.css`** — kirjoitettu uusiksi Claude Designin tokenien pohjalta; tyylit sovitettu WP:n natiiviin lomakemerkintään (`.input`, `.wp-pwd`, `.forgetmenot`, `#wp-submit`). Lukittu keltainen CTA, uutiskirjekortti `:has(:checked)`-tilalla, responsiivisuus 860/480 px, WCAG-fokusrenkaat, tumma teema.

**`inc/login.php`** — lisätty kolme hookia:
- `login_head`: inline-skripti asettaa `data-theme` ennen renderöintiä
- `login_footer` (`rytkoset_theme_login_layout_script`): rakentaa `.auth-split` + `.auth-brand` -layoutin, näkymäkohtaiset välilehdet/otsikot/switch-rivit
- Poistettu vanha `.login-branding`-injektio

**`inc/newsletter.php`** — `rytkoset_theme_render_registration_newsletter_opt_in` tuottaa nyt korttimerkinnan (`.newsletter`-label), sama input-name, oletuksena valitsematta

**`assets/icons/ui/`** — lisätty 6 uutta UI-ikonia: `arrow-left`, `arrow-right`, `mail`, `info`, `send`, `check`

## Testausohje

- [ ] `docker compose up -d` → `/wp-login.php`: split-layout, brändipaneeli, välilehdet, näkymätekstit
- [ ] `?action=register`: uutiskirjekortti näkyy (kun lista konfiguroitu), oletuksena valitsematta, klikkaus toggleaa tilan
- [ ] `?action=lostpassword`: back-linkki, ei välilehtiä
- [ ] Regressio: kirjaudu sisään → onnistuu; pyydä salasanaa → sähköposti lähtee; väärä salasana → suomenkielinen virhe
- [ ] Mobiili < 860 px: brändi tiivistyy yläpalkiksi, lomake kelluu kortissa
- [ ] Tumma teema: aseta sivuston teema tummaksi → login seuraa
- [ ] CI PHP-lint läpäisee