### PR TITLE
feat(404): add branded 404 page "kadonnut oksa sukupuussa" (#293)

### DIFF
--- a/wp-content/themes/rytkoset-theme/404.php
+++ b/wp-content/themes/rytkoset-theme/404.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * 404-malli (Sivua ei löytynyt).
+ *
+ * "Kadonnut oksa sukupuussa": tumma navy-osio kuten etusivun hero,
+ * geometrinen sukupuukaavio jossa yksi oksa on merkitty puuttuvaksi,
+ * sekä paluulinkit suosituimpiin osioihin.
+ *
+ * @package Rytkoset_Theme
+ */
+
+get_header();
+
+$rytkoset_404_contact     = rytkoset_theme_get_contact_email();
+$rytkoset_404_quick_links = array(
+	array(
+		'label' => __( 'Albumit', 'rytkoset-theme' ),
+		'url'   => home_url( '/albumit' ),
+	),
+	array(
+		'label' => __( 'Tapahtumat', 'rytkoset-theme' ),
+		'url'   => home_url( '/tapahtumat' ),
+	),
+	array(
+		'label' => __( 'Kauppa', 'rytkoset-theme' ),
+		'url'   => home_url( '/kauppa' ),
+	),
+	array(
+		'label' => __( 'Foorumi', 'rytkoset-theme' ),
+		'url'   => home_url( '/foorumi/' ),
+	),
+);
+?>
+
+<main id="primary" class="site-main">
+
+	<section class="nf" aria-labelledby="nf-title">
+		<div class="container nf__inner">
+
+			<div class="nf__copy">
+				<p class="nf__code">
+					404 <small><?php esc_html_e( 'Virhe', 'rytkoset-theme' ); ?></small>
+				</p>
+
+				<h1 id="nf-title" class="nf__title">
+					<?php esc_html_e( 'Tätä haaraa ei löytynyt sukupuusta', 'rytkoset-theme' ); ?>
+				</h1>
+
+				<p class="nf__lede">
+					<?php esc_html_e( 'Etsimääsi sivua ei ole olemassa tai se on ehtinyt siirtyä. Eksyneetkin oksat löytävät aina takaisin juurille — tästä pääset eteenpäin.', 'rytkoset-theme' ); ?>
+				</p>
+
+				<div class="nf__actions">
+					<a class="btn btn--primary" href="<?php echo esc_url( home_url( '/' ) ); ?>">
+						<?php esc_html_e( 'Palaa etusivulle', 'rytkoset-theme' ); ?>
+					</a>
+					<a class="btn btn--ghost" href="mailto:<?php echo esc_attr( $rytkoset_404_contact ); ?>">
+						<?php esc_html_e( 'Ota yhteyttä', 'rytkoset-theme' ); ?>
+					</a>
+				</div>
+
+				<div class="nf__quick">
+					<p class="nf__quick-label"><?php esc_html_e( 'Suosituimmat sivut', 'rytkoset-theme' ); ?></p>
+					<ul class="nf__chips">
+						<?php foreach ( $rytkoset_404_quick_links as $rytkoset_404_link ) : ?>
+							<li>
+								<a class="nf__chip" href="<?php echo esc_url( $rytkoset_404_link['url'] ); ?>">
+									<?php echo esc_html( $rytkoset_404_link['label'] ); ?>
+									<span aria-hidden="true">&rarr;</span>
+								</a>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
+			</div>
+
+			<div class="nf__media">
+				<figure class="nf__card">
+					<svg class="nf-tree" viewBox="0 0 520 430" role="img" aria-label="<?php esc_attr_e( 'Sukupuukaavio, josta yksi oksa puuttuu', 'rytkoset-theme' ); ?>">
+						<!-- yhdysviivat -->
+						<g class="nf-tree__line">
+							<path d="M260 112 V142" />
+							<path d="M130 142 H390" />
+							<path d="M130 142 V176" />
+							<path d="M260 142 V176" />
+							<path d="M390 142 V176" />
+							<path d="M260 272 V300" />
+							<path d="M212 300 H308" />
+							<path d="M212 300 V322" />
+							<path d="M308 300 V322" />
+						</g>
+
+						<!-- latvuston lehtiä -->
+						<g>
+							<ellipse class="nf-tree__leaf" cx="196" cy="70" rx="11" ry="6" transform="rotate(-32 196 70)" />
+							<ellipse class="nf-tree__leaf--alt" cx="324" cy="66" rx="11" ry="6" transform="rotate(30 324 66)" />
+							<ellipse class="nf-tree__leaf" cx="232" cy="44" rx="10" ry="5.5" transform="rotate(-14 232 44)" />
+							<ellipse class="nf-tree__leaf--alt" cx="292" cy="46" rx="10" ry="5.5" transform="rotate(16 292 46)" />
+							<ellipse class="nf-tree__leaf" cx="120" cy="118" rx="10" ry="5.5" transform="rotate(36 120 118)" />
+							<ellipse class="nf-tree__leaf--alt" cx="404" cy="120" rx="10" ry="5.5" transform="rotate(-34 404 120)" />
+						</g>
+
+						<!-- sukupolvi 1 — pariskunnan ovaalit -->
+						<ellipse class="nf-tree__frame" cx="234" cy="78" rx="26" ry="33" />
+						<ellipse class="nf-tree__frame" cx="288" cy="78" rx="26" ry="33" />
+
+						<!-- sukupolvi 2 — kolme kehystä, oikeanpuoleinen puuttuu -->
+						<rect class="nf-tree__frame" x="93" y="176" width="74" height="92" rx="6" />
+						<rect class="nf-tree__frame" x="223" y="176" width="74" height="92" rx="6" />
+						<!-- puuttuva oksa -->
+						<rect class="nf-tree__miss" x="353" y="176" width="74" height="92" rx="6" />
+						<text class="nf-tree__miss-text" x="390" y="231" font-size="30" text-anchor="middle">?</text>
+
+						<!-- sukupolvi 3 — kaksi pientä kehystä keskilinjan alla -->
+						<rect class="nf-tree__frame" x="187" y="322" width="50" height="62" rx="5" />
+						<rect class="nf-tree__frame" x="283" y="322" width="50" height="62" rx="5" />
+
+						<!-- oliivinoksat juurella -->
+						<g class="nf-tree__line" stroke-width="2.4">
+							<path d="M150 404 q34 -10 70 4" />
+							<path d="M370 404 q-34 -10 -70 4" />
+						</g>
+						<g>
+							<ellipse class="nf-tree__leaf" cx="166" cy="398" rx="9" ry="4.6" transform="rotate(-24 166 398)" />
+							<ellipse class="nf-tree__leaf--alt" cx="192" cy="404" rx="9" ry="4.6" transform="rotate(-10 192 404)" />
+							<ellipse class="nf-tree__leaf" cx="354" cy="398" rx="9" ry="4.6" transform="rotate(24 354 398)" />
+							<ellipse class="nf-tree__leaf--alt" cx="328" cy="404" rx="9" ry="4.6" transform="rotate(10 328 404)" />
+						</g>
+					</svg>
+					<figcaption class="nf__card-caption">
+						<?php esc_html_e( 'Sukupuusta puuttuu oksa', 'rytkoset-theme' ); ?>
+					</figcaption>
+				</figure>
+			</div>
+
+		</div>
+	</section>
+
+</main>
+
+<?php
+get_footer();

--- a/wp-content/themes/rytkoset-theme/assets/css/404.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/404.css
@@ -1,0 +1,223 @@
+/* =====================================================
+   404 — "kadonnut oksa sukupuussa"
+   Tumma navy-osio kuten etusivun hero. Kermakortti ja
+   sukupuukaavio ovat itsenäinen vaalea kuvitus, joten
+   niiden paletti on kiinteä (--nf-*) eikä seuraa teemaa.
+   ===================================================== */
+.nf {
+  /* Sama gradientti kuin etusivun herossa (assets/css/hero.css) */
+  background: linear-gradient(180deg, var(--header-primary-bg) 0%, var(--header-utility-bg) 100%);
+  color: var(--color-text-inverted);
+
+  /* Kuvituksen kiinteä paletti */
+  --nf-cream: #efe7d6;
+  --nf-caption: rgba(21, 64, 110, 0.72);
+}
+
+.nf__inner {
+  display: grid;
+  grid-template-columns: 1.04fr 0.96fr;
+  gap: 60px;
+  align-items: center;
+  padding-top: clamp(4rem, 8vw, 5.25rem);
+  padding-bottom: clamp(4.75rem, 9vw, 6rem);
+  min-height: min(72vh, 760px);
+}
+
+/* ---- Tekstipalsta ---- */
+.nf__code {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 14px;
+  font-family: var(--font-heading);
+  font-weight: 500;
+  font-size: clamp(64px, 9vw, 120px);
+  line-height: 0.9;
+  letter-spacing: -0.03em;
+  color: var(--color-accent);
+  margin: 0 0 6px;
+}
+
+.nf__code small {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+  transform: translateY(-0.7em);
+}
+
+.nf__title {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: clamp(32px, 4.4vw, 52px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 18px;
+  text-wrap: balance;
+}
+
+.nf__lede {
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.82);
+  max-width: 480px;
+  margin: 0 0 30px;
+  text-wrap: pretty;
+}
+
+.nf__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 38px;
+}
+
+.nf__quick {
+  border-top: 1px solid var(--color-nav-border);
+  padding-top: 22px;
+}
+
+.nf__quick-label {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0 0 12px;
+}
+
+.nf__chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.nf__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border-radius: var(--radius-pill);
+  background: var(--color-nav-surface);
+  border: 1px solid var(--color-nav-border);
+  color: var(--color-text-inverted);
+  font-size: 14.5px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color var(--transition-fast),
+              border-color var(--transition-fast),
+              transform var(--transition-fast);
+}
+
+.nf__chip:hover {
+  background: var(--color-nav-hover);
+  border-color: rgba(255, 255, 255, 0.32);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
+.nf__chip span {
+  transition: transform var(--transition-fast);
+}
+
+.nf__chip:hover span {
+  transform: translateX(2px);
+}
+
+/* ---- Kuvituskortti ---- */
+.nf__media {
+  position: relative;
+}
+
+.nf__card {
+  margin: 0;
+  background: var(--nf-cream);
+  border-radius: 22px;
+  padding: 34px 34px 26px;
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.34);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.nf__card svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.nf__card-caption {
+  margin: 18px 0 0;
+  text-align: center;
+  font-size: 13.5px;
+  font-style: italic;
+  color: var(--nf-caption);
+}
+
+/* SVG-paletti (sukupuukuva) */
+.nf-tree {
+  --line: #15406e;
+  --frame: #c79a3a;
+  --paper: #efe7d6;
+  --leaf: #8a9a63;
+  --leaf-2: #6f8050;
+}
+
+.nf-tree__line {
+  stroke: var(--line);
+  stroke-width: 3;
+  fill: none;
+  stroke-linecap: round;
+}
+
+.nf-tree__frame {
+  fill: var(--paper);
+  stroke: var(--frame);
+  stroke-width: 3;
+}
+
+.nf-tree__leaf {
+  fill: var(--leaf);
+}
+
+.nf-tree__leaf--alt {
+  fill: var(--leaf-2);
+}
+
+.nf-tree__miss {
+  fill: rgba(199, 154, 58, 0.1);
+  stroke: var(--frame);
+  stroke-width: 3;
+  stroke-dasharray: 8 7;
+}
+
+.nf-tree__miss-text {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  fill: var(--line);
+}
+
+@media (max-width: 920px) {
+  .nf__inner {
+    grid-template-columns: 1fr;
+    gap: 44px;
+    padding-top: clamp(3rem, 8vw, 4rem);
+    padding-bottom: clamp(3.5rem, 9vw, 4.5rem);
+    min-height: 0;
+  }
+
+  /* Kuvitus tekstin yläpuolelle mobiilissa */
+  .nf__media {
+    order: -1;
+    max-width: 460px;
+  }
+}
+
+@media (max-width: 540px) {
+  .nf__card {
+    padding: 24px 22px 20px;
+  }
+}

--- a/wp-content/themes/rytkoset-theme/style.css
+++ b/wp-content/themes/rytkoset-theme/style.css
@@ -20,6 +20,9 @@ Text Domain: rytkoset-theme
 /* Etusivun sisältölohkot (vaalea/tumma-vuorottelu) */
 @import url("assets/css/home.css");
 
+/* 404-sivu (kadonnut oksa sukupuussa) */
+@import url("assets/css/404.css");
+
 /* Komponentit: napit, kortit jne. */
 @import url("assets/css/components.css");
 


### PR DESCRIPTION
## Mitä tässä on tehty

Lisätty brändätty 404-sivu teemaan. Aiemmin WordPress palautti 404-osoitteissa etusivun sisällön tummalla päällystä, jolloin hero-otsikko jäi lukukelvottomaksi eikä käyttäjä saanut minkäänlaista ohjausta.

## Muutokset

- **`404.php`** (uusi) — WordPress-malli, joka käyttää teeman headeria ja footeria. Tumma navy-osio kuten etusivun hero: keltainen "404 Virhe" -otsikko (Newsreader), otsikko *"Tätä haaraa ei löytynyt sukupuusta"*, selittävä teksti, kaksi toimintopainiketta (Palaa etusivulle / Ota yhteyttä) ja pikalinkit neljään pääosioon. Geometrinen sukupuukaavio inline-SVG:nä kermanvärisellä kortilla — yksi oksa katkoviivakehyksellä `?`-merkillä.
- **`assets/css/404.css`** (uusi) — `.nf-*`-tyylit. Kaikki värit `base.css`-tokeneista, SVG-paletti kiinteä (`--nf-*`). Mobiilissa (≤ 920 px) kuvituskortti siirtyy tekstin yläpuolelle.
- **`style.css`** — lisätty `@import "assets/css/404.css"`.

## Testattu

- HTTP-statuskoodi on 404 (ei 200)
- Etusivun hero (`Rytkösiä sukupolvesta toiseen`) ei enää vuoda 404-sivulle
- Desktop 1280 px, mobiili 390 px ja `data-theme="dark"` kaikki renderöivät oikein

Sulkee #293.
