### PR TITLE
fix(a11y): yhtenäistä main-maamerkki ja korjaa ohituslinkki (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.
 
 ### Fixed
+- Navigaation saavutettavuus: `<main id="primary">`-maamerkki yhtenäistettiin kaikkiin sisältöpohjiin (mm. `page.php`, tapahtuma- ja albumiarkistot, `index.php`, `bbpress.php`), jotta "Siirry sisältöön" -ohituslinkillä on aina kohde; mainille lisättiin `tabindex="-1"`, jolloin näppäimistöfokus siirtyy sisältöön, ja mobiilivalikon alavalikon avauspainike sai näkyvän fokusrenkaan (#83)
 - Tampere 2026 -tilausten ylimääräiset osallistujien 2-10 buffet-kentät piilotetaan tilausvahvistuksesta, sähköposteista ja administa sekä siivotaan uusilta Store API -tilauksilta (#271)
 - Tietosuojaselosteen pitkät linkit, sähköpostiosoitteet ja koodimaiset tekstipätkät rivittyvät mobiilileveydellä ilman vaakasuuntaista overflow’ta (#267)
 - Maksuttoman tapahtuman julkinen ilmoittautumislomake hylkää honeypot-kentän täyttävät bottimaiset lähetykset ilman ilmoittautumisen tallennusta.

--- a/wp-content/themes/rytkoset-theme/404.php
+++ b/wp-content/themes/rytkoset-theme/404.php
@@ -32,7 +32,7 @@ $rytkoset_404_quick_links = array(
 );
 ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 
 	<section class="nf" aria-labelledby="nf-title">
 		<div class="container nf__inner">

--- a/wp-content/themes/rytkoset-theme/archive-digital_magazine.php
+++ b/wp-content/themes/rytkoset-theme/archive-digital_magazine.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 get_header();
 ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 	<section class="section">
 		<div class="container section__wide">
 			<header class="section__header">

--- a/wp-content/themes/rytkoset-theme/archive-gallery_album.php
+++ b/wp-content/themes/rytkoset-theme/archive-gallery_album.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 get_header();
 ?>
 
+<main id="primary" class="site-main" tabindex="-1">
 <section class="section">
         <div class="container section__wide">
                 <header class="section__header">
@@ -60,6 +61,7 @@ get_header();
                 <?php endif; ?>
         </div>
 </section>
+</main>
 
 <?php
 get_footer();

--- a/wp-content/themes/rytkoset-theme/archive-rytkoset_event.php
+++ b/wp-content/themes/rytkoset-theme/archive-rytkoset_event.php
@@ -143,6 +143,7 @@ $render_event_list = static function ( WP_Query $event_query ) {
 };
 ?>
 
+<main id="primary" class="site-main" tabindex="-1">
 <section class="section">
 	<div class="container">
 		<header class="section__header">
@@ -178,6 +179,7 @@ $render_event_list = static function ( WP_Query $event_query ) {
 		<?php endif; ?>
 	</div>
 </section>
+</main>
 
 <?php
 get_footer();

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
@@ -427,3 +427,9 @@
   border-radius: var(--radius-nav);
   text-decoration: none;
 }
+
+/* Skip-linkin kohde saa fokuksen vain ohjelmallisesti, joten suuren
+   container-ääriviivan piilotus on tarkoituksellista. */
+#primary:focus {
+  outline: none;
+}

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.mobile.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.mobile.css
@@ -298,6 +298,11 @@
   outline-offset: 2px;
 }
 
+.mobile-submenu-toggle:focus-visible {
+  outline: var(--nav-focus-outline);
+  outline-offset: 2px;
+}
+
 .mobile-submenu-toggle__icon {
   display: inline-flex;
   align-items: center;

--- a/wp-content/themes/rytkoset-theme/bbpress.php
+++ b/wp-content/themes/rytkoset-theme/bbpress.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 get_header();
 ?>
-<main id="main-content">
+<main id="primary" class="site-main" tabindex="-1">
 <?php
 if ( function_exists( 'bbp_is_single_topic' ) && bbp_is_single_topic() ) {
 	bbp_get_template_part( 'content', 'single-topic' );

--- a/wp-content/themes/rytkoset-theme/front-page.php
+++ b/wp-content/themes/rytkoset-theme/front-page.php
@@ -2,7 +2,7 @@
 
 <?php $rytkoset_home_img = get_template_directory_uri() . '/assets/images/home'; ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 
   <!-- HERO (tumma) -->
   <section class="hero">

--- a/wp-content/themes/rytkoset-theme/index.php
+++ b/wp-content/themes/rytkoset-theme/index.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<main>
+<main id="primary" class="site-main" tabindex="-1">
     <h1>Tervetuloa Rytkösten sukuseuran uusitulle sivustolle</h1>
     <p>Tämä on Rytkösten sukuseuran virallinen WordPress-teema.</p>
 </main>

--- a/wp-content/themes/rytkoset-theme/page-blogi.php
+++ b/wp-content/themes/rytkoset-theme/page-blogi.php
@@ -21,7 +21,7 @@ $blog_query = new WP_Query(
 );
 ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 	<section class="section">
 		<div class="container">
 			<nav class="breadcrumb" aria-label="<?php esc_attr_e( 'Murupolku', 'rytkoset-theme' ); ?>">

--- a/wp-content/themes/rytkoset-theme/page.php
+++ b/wp-content/themes/rytkoset-theme/page.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 get_header();
 ?>
 
+<main id="primary" class="site-main" tabindex="-1">
 <section class="section">
         <div class="container section__narrow">
                 <?php
@@ -40,6 +41,7 @@ get_header();
                 ?>
         </div>
 </section>
+</main>
 
 <?php
 get_footer();

--- a/wp-content/themes/rytkoset-theme/single-digital_magazine.php
+++ b/wp-content/themes/rytkoset-theme/single-digital_magazine.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 get_header();
 ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 <?php
 if ( have_posts() ) :
 	while ( have_posts() ) :

--- a/wp-content/themes/rytkoset-theme/single-gallery_album.php
+++ b/wp-content/themes/rytkoset-theme/single-gallery_album.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 get_header();
 
 ?>
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 <?php
 
 if ( have_posts() ) :

--- a/wp-content/themes/rytkoset-theme/single-post.php
+++ b/wp-content/themes/rytkoset-theme/single-post.php
@@ -17,7 +17,7 @@ if ( have_posts() ) :
 		$blog_page = get_page_by_path( 'blogi' );
 		$blog_url  = $blog_page instanceof WP_Post ? get_permalink( $blog_page ) : home_url( '/blogi/' );
 		?>
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 
 	<header class="blog-post-hero<?php echo has_post_thumbnail() ? '' : ' blog-post-hero--no-image'; ?>">
 		<?php if ( has_post_thumbnail() ) : ?>

--- a/wp-content/themes/rytkoset-theme/single-rytkoset_event.php
+++ b/wp-content/themes/rytkoset-theme/single-rytkoset_event.php
@@ -12,7 +12,7 @@ global $post;
 get_header();
 ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 <?php
 if ( have_posts() ) :
 	while ( have_posts() ) :

--- a/wp-content/themes/rytkoset-theme/single.php
+++ b/wp-content/themes/rytkoset-theme/single.php
@@ -12,7 +12,7 @@ global $post;
 get_header();
 ?>
 
-<main id="primary" class="site-main">
+<main id="primary" class="site-main" tabindex="-1">
 	<section class="section">
 		<div class="container section__narrow">
 			<?php


### PR DESCRIPTION
## Yhteenveto

- Yhtenäistetään `<main id="primary" class="site-main" tabindex="-1">` kaikkiin sisältöpohjiin — "Siirry sisältöön" -ohituslinkki toimii nyt kaikilla sivuilla
- Lisätään `<main id="primary">` pohjiin joista se puuttui kokonaan: `page.php`, `archive-rytkoset_event.php`, `archive-gallery_album.php`
- Yhtenäistetään poikkeavat maanerkit: `index.php` (oli `<main>` ilman id:tä), `bbpress.php` (oli `id="main-content"`)
- Lisätään `tabindex="-1"` kaikkiin main-elementteihin → näppäimistöfokus siirtyy oikeasti sisältöön pelkän vierittämisen sijaan
- Korjataan mobiilivalikon alavalikkopainikkeen puuttuva fokusrengas (`nav.mobile.css`)
- Lisätään `#primary:focus { outline: none }` estämään visuaalinen ääriviiva ohjelmalliselta fokusoinnilta

## Testaussuunnitelma

- [ ] Paina Tab etusivulla → ohituslinkki "Siirry sisältöön" tulee näkyviin → Enter → fokus siirtyy `<main>`-elementtiin (vieritys + fokus, ei vain vieritys)
- [ ] Toista samoilla sivuilla: staattinen sivu (esim. `/tietosuoja/`), `/tapahtumat/`, `/albumit/`
- [ ] Avaa mobiilivalikko → navigoi alavalikon avausnappiin → Tab/fokus näkyy
- [ ] `aria-current="page"` löytyy renderöidystä HTML:stä (F12 > Elements)
- [ ] PHP-lint läpäissyt CI:ssä

Closes #83
