### PR TITLE
Fix contrast and color WCAG AA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Tietosuojaselosteen pohjaan täydennetty rekisteröidyn oikeudet, automaattisen päätöksenteon maininta, YouTube/Google-upotusten tietojen käsittely ja sisäisten käyttöoikeuksien kuvaus.
 
 ### Fixed
+- Saavutettavuus: vaalean teeman päävalikon ja hero-gradientin kontrasti nostettu WCAG 2.1 AA -tasolle; `--header-primary-bg` käyttää nyt `var(--color-primary)` (`#0f4c81`) aiemman kirkkaan `#3b82f6`:n sijaan, jolloin valkoinen valikkoteksti saa ~8,9:1 (oli 3,68:1) ja hero-otsikon alaotsikko ~5,4:1 (oli ~3,0:1); pre-footer (uutiskirjekaista, large ja compact) yhtenäistettiin käyttämään samaa `--header-primary-bg`/`--header-utility-bg`-gradienttia, jolloin tumman teeman valkoinen body-teksti pre-footerissa nousi ~3,0:1 → ~6,1:1 (#84)
 - Navigaation saavutettavuus: `<main id="primary">`-maamerkki yhtenäistettiin kaikkiin sisältöpohjiin (mm. `page.php`, tapahtuma- ja albumiarkistot, `index.php`, `bbpress.php`), jotta "Siirry sisältöön" -ohituslinkillä on aina kohde; mainille lisättiin `tabindex="-1"`, jolloin näppäimistöfokus siirtyy sisältöön, ja mobiilivalikon alavalikon avauspainike sai näkyvän fokusrenkaan (#83)
 - Tampere 2026 -tilausten ylimääräiset osallistujien 2-10 buffet-kentät piilotetaan tilausvahvistuksesta, sähköposteista ja administa sekä siivotaan uusilta Store API -tilauksilta (#271)
 - Tietosuojaselosteen pitkät linkit, sähköpostiosoitteet ja koodimaiset tekstipätkät rivittyvät mobiilileveydellä ilman vaakasuuntaista overflow’ta (#267)

--- a/docs/saavutettavuus-analyysi.md
+++ b/docs/saavutettavuus-analyysi.md
@@ -31,14 +31,15 @@ fokustyylit sekä esimerkillisesti merkitty tapahtumailmoittautumislomake.
 **Kriittisiä esteitä ei löytynyt.** Korjattavat kohdat ovat rajattuja ja
 toteutettavissa pieninä osina jatkotiketeissä:
 
-| Prioriteetti | Löydös | Tiketti |
-| --- | --- | --- |
-| **Korkea** | Vaalean teeman päävalikon linkkitekstin kontrasti alle AA:n (3,68:1) | #84 |
-| **Keski** | Galleriavideon `<iframe>` ilman saavutettavaa nimeä (`title`) | #86 |
-| **Keski** | Galleriakuvien alt-tekstien laatu riippuu syötetystä datasta | #86 |
-| **Matala** | Pari fokustilaa ilmaistaan vain tausta-/värimuutoksella, ei fokusrenkaalla | #83 |
-| **Matala** | `aria-current` aktiivisesta valikkokohdasta — varmistettava renderöidystä HTML:stä | #83 |
-| **Matala** | WooCommerce-kassan ja uutiskirjeen kenttien labelit — varmistettava | #85 / #88 |
+| Prioriteetti | Löydös | Tiketti | Tila |
+| --- | --- | --- | --- |
+| **Korkea** | Vaalean teeman päävalikon linkkitekstin kontrasti alle AA:n (3,68:1) | #84 | ✅ korjattu |
+| **Keski** | Galleriavideon `<iframe>` ilman saavutettavaa nimeä (`title`) | #86 | avoinna |
+| **Keski** | Galleriakuvien alt-tekstien laatu riippuu syötetystä datasta | #86 | avoinna |
+| **Matala** | Pari fokustilaa ilmaistaan vain tausta-/värimuutoksella, ei fokusrenkaalla | #83 | ✅ korjattu |
+| **Matala** | `aria-current` aktiivisesta valikkokohdasta | #83 | ✅ varmistettu (WP-walker tuottaa automaattisesti) |
+| **Matala** | Skip-linkki rikki staattisilla sivuilla ja arkistoissa (puuttuva tai poikkeava main) | #83 | ✅ korjattu (löydetty toteutuksen aikana) |
+| **Matala** | WooCommerce-kassan ja uutiskirjeen kenttien labelit — varmistettava | #85 / #88 | avoinna |
 
 ---
 
@@ -91,25 +92,26 @@ Kontrastit on laskettu WCAG-kaavalla `(L1+0,05)/(L2+0,05)`. Rajat: normaali teks
 | Tumma etusivulohko, valkoinen | `#ffffff` / `#0b315b` | ~7,8:1 | ✅ |
 | Footer-teksti / footer | `#ffffff` / `#111827` | ~13,1:1 | ✅ |
 | Yläpalkin utility-rivi | `rgba(255,255,255,.82)` / `#1f4277` | ~7:1+ | ✅ |
-| **Päävalikon linkki (15px) / palkki** | `#ffffff` / `#3b82f6` | **~3,68:1** | ❌ |
+| Päävalikon linkki (15px) / palkki | `#ffffff` / `#0f4c81` *(oli `#3b82f6` — korjattu #84:ssä)* | ~8,9:1 | ✅ |
 
 **Tumma teema** (`:root[data-theme="dark"]`) läpäisee kauttaaltaan (laskennalliset
 suhteet 5:1–13:1), mm. päävalikon palkki tummenee arvoon `#0f4c81`, jolloin valkoinen
 teksti saa ~8,9:1.
 
-**Korjattava:**
+**Korjattu #84:ssä:**
 
-- **Vaalean teeman päävalikon linkkiteksti** — `.menu-item a` on valkoista
-  (`--color-text-inverted`) 15px:n tekstiä (`font-size: 0.9375rem`,
-  `nav.desktop.css:67`) sinisen palkin (`--header-primary-bg: #3b82f6`,
-  `nav.base.css:4`) päällä. Kontrasti **~3,68:1** alittaa normaalin tekstin AA-rajan
-  4,5:1 (riittäisi vain suurelle tekstille). **Korkein prioriteetti.** Korjausvaihtoehdot:
-  tummempi palkin sävy vaaleassa teemassa (esim. `#1f4277`, jolla valkoinen saa ~10:1)
-  tai tummempi tekstiväri. Vakavuus: korkea. → #84
-- **Ghost-/outline-napit kuvan päällä** (`components.css`, hero) — valkoinen teksti
-  läpinäkyvällä napilla kuvan päällä: kontrasti riippuu kuvan kirkkaudesta. Teemassa on
-  gradienttipeite, mutta *varmistettava todellisilla hero-kuvilla dev-ympäristössä*.
-  Vakavuus: keski. → #84
+- **Vaalean teeman päävalikon linkkiteksti** — `--header-primary-bg` muutettiin
+  `#3b82f6` → `var(--color-primary)` (`#0f4c81`, [base.css:57](../wp-content/themes/rytkoset-theme/assets/css/base.css)).
+  Vaalea ja tumma teema käyttävät nyt rakenteellisesti samaa headeria. Valkoisen
+  tekstin kontrasti nousi 3,68:1 → ~8,9:1. Korjaus heijastuu myös hero-gradientin
+  yläosaan ja `.btn--ghost`-nappeihin gradientin päällä — hero-otsikon alaotsikko
+  `hero__lead` (rgba(255,255,255,.82) 18px) nousi ~3,0:1 → ~5,4:1.
+
+**Avoinna:**
+
+- **Ghost-napit erittäin kirkkaiden kuvien päällä** (`components.css`) — kontrasti
+  hero-gradientin lisäksi kuvan luminanssista. Korjauksen jälkeen riski on huomattavasti
+  pienempi. Vakavuus: matala. Tarvittaessa lisätään tummempi gradienttipeite.
 
 ### 2.3 Lomakkeet
 

--- a/wp-content/themes/rytkoset-theme/assets/css/base.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/base.css
@@ -54,7 +54,9 @@
 
   /* Nav helperit */
   --header-utility-bg: #1f4277;
-  --header-primary-bg: #3b82f6;
+  /* Vaalean teeman päävalikon palkki: brändisininen, jotta valkoinen
+     teksti ja hero-gradientin yläosa täyttävät WCAG 2.1 AA -kontrastit. */
+  --header-primary-bg: var(--color-primary);
   --nav-bg: var(--color-primary-dark);
   --nav-border: var(--color-nav-border);
   --nav-hover-bg: var(--color-nav-hover);

--- a/wp-content/themes/rytkoset-theme/assets/css/footer.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/footer.css
@@ -13,7 +13,9 @@
   position: relative;
   overflow: hidden;
   padding: 4.5rem 0 5rem;
-  background: linear-gradient(180deg, var(--color-primary) 0%, var(--color-primary-dark) 100%);
+  /* Sama gradientti kuin headerilla ja herolla, jotta valkoinen teksti
+     säilyttää WCAG AA -kontrastin molemmissa teemoissa. */
+  background: linear-gradient(180deg, var(--header-primary-bg) 0%, var(--header-utility-bg) 100%);
 }
 
 .site-prefooter--large::before {
@@ -118,7 +120,7 @@
 /* ---- Compact (sub pages) ---- */
 .site-prefooter--compact {
   padding: 2.25rem 0;
-  background: var(--color-primary);
+  background: var(--header-primary-bg);
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 


### PR DESCRIPTION
## Yhteenveto

- `--header-primary-bg` muutettu `#3b82f6` → `var(--color-primary)` (`#0f4c81`) vaaleassa teemassa — valkoinen valikkoteksti: **3,68:1 → 8,86:1** ✅
- Hero-otsikon alaotsikko `hero__lead` gradientin yläosassa: **~3,0:1 → ~5,4:1** ✅
- Pre-footer (uutiskirjekaista, large + compact) yhtenäistetty käyttämään samaa `--header-primary-bg`/`--header-utility-bg`-gradienttia kuin header ja hero — tumman teeman body-teksti pre-footerissa: **~3,0:1 → ~6,1:1** ✅
- Kaikki muutokset CSS-muuttujien kautta (`var(--color-primary)`, `var(--header-primary-bg)`), ei raaka-hex-arvoja
- Päivitetty `docs/saavutettavuus-analyysi.md` ja CHANGELOG

## Testaussuunnitelma

- [ ] Vaalea teema: päävalikko, hero ja pre-footer (etusivu + alasivut) näyttävät järkeviltä tummemmalla sinisellä
- [ ] Tumma teema: pre-footer on nyt tumma sininen (ei enää kirkas `#3b82f6`) — tarkista visuaalinen ilme
- [ ] Tarkista, että fokusrengas (`--color-accent #fbbf24`) erottuu uudella palkilla molemmissa teemoissa
- [ ] Tumma teema ei muutu headerissa tai herossa (oli jo `#0f4c81`)

Closes #84