### PR TITLE
chore(release): v1.0.0 — first production release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 
 ## [Unreleased]
 
+---
+
+## [1.0.0] - 2026-05-30
+
+Ensimmäinen tuotantojulkaisu: uusi WordPress-teema rytkoset.net-sivustolla. Sisältää tapahtumakokonaisuuden (CPT, maksuttomat ilmoittautumiset, viestintä, GDPR), WooCommerce-jäsenmaksut ja Tampere 2026 -osallistumismaksun Mollie-maksuilla, AcyMailing-uutiskirjeen, Claude Designin mukaisesti uusitut etusivun, footerin ja kirjautumissivut, branded 404-sivun sekä WCAG 2.1 AA -tason saavutettavuusparannukset.
+
 ### Added
 - Saavutettavuuden perustason analyysi (WCAG 2.1 AA): keskeisten näkymien läpikäynti, todennetut kontrastilaskelmat, priorisoidut löydökset ja ehdotetut jatkotikettien sisällöt (#83–#89); dokumentti `docs/saavutettavuus-analyysi.md` (#82)
 - Tapahtumaviestinnän WP-Cron-lähetysjono, joka säilyttää `Tapahtumat > Viestintä` -näkymän ensisijaisena työkaluna ja rajoittaa massaviestit 18 `wp_mail()`-yritykseen rullaavan tunnin aikana (#264)

--- a/wp-content/themes/rytkoset-theme/style.css
+++ b/wp-content/themes/rytkoset-theme/style.css
@@ -4,7 +4,7 @@ Theme URI: https://rytkoset.net
 Author: Ilkka Rytkönen
 Author URI: https://ilkkarytkonen.fi
 Description: Rytkösten sukuseura ry:n uusi WordPress-teema.
-Version: 0.1.1
+Version: 1.0.0
 Text Domain: rytkoset-theme
 */
 


### PR DESCRIPTION
## Summary
- Lisätään `## [1.0.0] - 2026-05-30`-osio CHANGELOG.md:hen yhden kappaleen julkaisuyhteenvedolla
- Bumpataan teeman versio `style.css`:ssä `0.1.1 → 1.0.0`

Tämä on ensimmäinen tuotantojulkaisu — sisältää tapahtumakokonaisuuden, WooCommerce-jäsenmaksut + Tampere 2026, AcyMailing-uutiskirjeen, uusitut etusivun/footerin/kirjautumissivut, 404-sivun ja WCAG 2.1 AA -saavutettavuusparannukset, jotka jo merkittiin pääsisältönä #305:ssä.

## Konteksti
PR #305 squash-mergetty mainiin 5 min ennen kuin v1.0.0-commit ehdittiin tehdä — siksi versiobumpit jäivät ulos. Tässä PR:ssä cherry-pick puhtaalle release-haaralle suoraan mainin päälle, mikä antaa minimi-diffin ilman dev↔main historiakonfliktia (squash-merge irrotti dev:n historian).

## Test plan
- [ ] PR näkyy konfliktittomana ja sisältää vain CHANGELOG.md + style.css muutokset
- [ ] PHP-lint (GitHub Actions) menee läpi
- [ ] Mergen jälkeen tagataan `v1.0.0` mainin uudelle kärkeen ja luodaan GitHub release CHANGELOG-yhteenvedon pohjalta