### PR TITLE
ci: add manual production theme deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,51 @@
+name: Deploy theme to production
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Git ref to deploy
+        required: true
+        default: main
+      server_dir:
+        description: Production theme directory
+        required: true
+        default: /wp-content/themes/rytkoset-theme/
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: none
+
+      - name: Lint PHP files in theme
+        run: |
+          find wp-content/themes/rytkoset-theme -name "*.php" -print0 | xargs -0 -n1 php -l
+
+      - name: Deploy via FTPS
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
+        with:
+          server: ${{ secrets.PROD_FTP_HOST }}
+          username: ${{ secrets.PROD_FTP_USERNAME }}
+          password: ${{ secrets.PROD_FTP_PASSWORD }}
+          port: ${{ secrets.PROD_FTP_PORT }}
+          protocol: ftps
+          local-dir: wp-content/themes/rytkoset-theme/
+          server-dir: ${{ inputs.server_dir }}
+          log-level: standard
+          dangerous-clean-slate: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 
 ## [Unreleased]
 
+### Added
+- Manual GitHub Actions production theme deploy workflow for `rytkoset.net`.
+
 ---
 
 ## [1.0.0] - 2026-05-30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ GitHub Actions runs this automatically for every PR and `main` push (`.github/wo
 
 - `dev` branch → automatic FTPS deploy → `dev.rytkoset.net` (when changes in `wp-content/themes/rytkoset-theme/**`)
 - `main` branch → no automatic deploy
-- Production (`rytkoset.net`) deploy is always manual
+- Production (`rytkoset.net`) deploy is manual via `.github/workflows/deploy-production.yml`, defaulting to `main` and requiring production FTPS secrets (`PROD_FTP_HOST`, `PROD_FTP_USERNAME`, `PROD_FTP_PASSWORD`, `PROD_FTP_PORT`)
 
 ## Commit messages
 


### PR DESCRIPTION
## Summary

- Adds a manually triggered GitHub Actions workflow for deploying the production theme to `rytkoset.net`.

## Changes

- Add `.github/workflows/deploy-production.yml`.
- Deploys `wp-content/themes/rytkoset-theme/` via FTPS using production-specific secrets.
- Defaults deployment source to `main`.
- Adds `source_ref` and `server_dir` workflow inputs for controlled manual deploys.
- Runs PHP lint before deploying the theme.
- Updates `CLAUDE.md` with the production deploy workflow details.
- Updates `CHANGELOG.md`.

## Testing

- Not run locally.
- Workflow syntax and changed files reviewed.
- PHP lint will run inside the production deploy workflow before FTPS upload.

## Notes

- Required repository or environment secrets:
  - `PROD_FTP_HOST`
  - `PROD_FTP_USERNAME`
  - `PROD_FTP_PASSWORD`
  - `PROD_FTP_PORT`
- The workflow deploys only the custom theme, not WordPress core, plugins, uploads, database content, or site settings.
- Production PHP should be updated to PHP 8.3 before relying on the new theme in production.