### PR TITLE
fix(woo): hide stale Tampere participant fields from orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - `wp-content/maintenance.php`: branded maintenance page that overrides WordPress's default maintenance screen. Navy hero with gold accent, Newsreader/Manrope fonts, cream illustration card, pulsing status badge, return-time chip, and social links — matching the site's visual language. Reads `get_theme_mod()` for concept (`uudistus`/`huolto`/`talkoot`), return text, contact email, and custom logo.
 - Customizer section **Huoltotila** (in `inc/customizer-contact.php`): settings for maintenance concept and optional return-time text.
 
+### Fixed
+- Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
+
 ---
 
 ## [1.0.0] - 2026-05-30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ Free event registration forms close after the event registration deadline. Paid 
 WooCommerce-specific logic lives in `inc/woocommerce-*.php` modules, with small shared helpers still in `functions.php`. Key areas:
 
 - **Membership products** — annual and lifetime membership; checkout notice when product is in cart
-- **Paid event fees / Tampere 2026** — linked event products, Tampere-specific checkout fields, participant list in admin, CSV export, event-specific organizer email notifications
+- **Paid event fees / Tampere 2026** — linked event products, Tampere-specific checkout fields, stale participant field hiding in admin/emails, participant list in admin, CSV export, event-specific organizer email notifications
 - **Mollie payments** — Finnish language texts, output buffering on `thankyou` page for bank transfer instructions
 - **PhotoSwipe conflict** — WooCommerce registers PhotoSwipe 4 scripts; theme actively dequeues them to avoid conflicts
 

--- a/docs/woocommerce-tampere-2026-checkout-fields.md
+++ b/docs/woocommerce-tampere-2026-checkout-fields.md
@@ -41,6 +41,7 @@ Osallistujatyyppi (`Aikuinen` tai `Lapsi 3-12 vuotta`) tulee tuotteen variaatios
 - Tunnistus tehdään ensisijaisesti parent-tuotteen SKU:lla `tampere-2026-osallistumismaksu`.
 - Kentät tallentuvat tilauksen lisäkentiksiin order-metana.
 - Piilotettuja ylimääräisiä osallistujakenttiä ei näytetä tilausvahvistuksessa, sähköposteissa tai WooCommerce-adminissa.
+- Jos WooCommerce Blocks tallentaa Tampere 2026 -osallistujakenttiä tilaukselle, joka ei ole Tampere 2026 -tilaus, kentät piilotetaan kokonaan sähköposteista ja WooCommerce-administa.
 - Uusilta Store API -tilauksilta poistetaan ylimääräisten osallistujien lisäkenttämetat, jos WooCommerce Blocks on tallentanut tyhjiä checkbox-arvoja.
 - Osallistujatiedot näytetään myös WooCommerce-adminissa tilauksen yhteydessä.
 - Osallistujatyyppi puretaan tilauksen rivien variaatioista samassa järjestyksessä kuin osallistujakohtaiset checkout-kentät.
@@ -69,3 +70,4 @@ Osallistujatyyppi (`Aikuinen` tai `Lapsi 3-12 vuotta`) tulee tuotteen variaatios
 - Tee testitilaus loppuun
 - Varmista administa, että molemmat osallistujat näkyvät tilauksella luettavasti osallistujatyypin, ruokarajoitteen ja buffet-valinnan kanssa
 - Varmista, ettei osallistujien 3-10 tyhjiä kenttiä näytetä tilausvahvistuksessa, sähköpostissa tai adminissa
+- Tee ei-Tampere-testitilaus ja varmista, ettei sen sähköpostissa tai WooCommerce-adminin tilausnäkymässä näy Tampere 2026 -osallistujien tyhjiä buffet-kenttiä

--- a/wp-content/themes/rytkoset-theme/front-page.php
+++ b/wp-content/themes/rytkoset-theme/front-page.php
@@ -178,7 +178,7 @@
           Rytkösten sukuseura perustettiin 18.8.1963 Iisalmessa Runnin Terveyskylpylällä.
           Perustamisen puuhamiehenä oli maanviljelijä Viljo Rytkönen, jonka kiinnostus
           sukututkimukseen loi pohjan seuran toiminnalle. Vanhat valokuvat ja asiakirjat
-          kertovat, keitä olemme — sukuseura kokoaa ja tallentaa Rytkösten vaiheita sukupolvelta
+          kertovat, keitä olemme. Sukuseura kokoaa ja tallentaa Rytkösten vaiheita sukupolvelta
           toiselle, jotta tarinat eivät unohdu.
         </p>
         <a href="<?php echo esc_url( home_url('/sukuseura') ); ?>" class="home-block__link">

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-tampere-2026.php
@@ -966,6 +966,23 @@ function rytkoset_theme_get_tampere_2026_order_participant_quantity( $order ) {
 }
 
 /**
+ * Returns the highest Tampere 2026 participant field index that should be shown for an order.
+ *
+ * Non-Tampere orders can still contain stale hidden Store API checkbox meta. Those
+ * participant fields are not relevant for the order and should never be displayed.
+ *
+ * @param WC_Order|null $order WooCommerce order object.
+ * @return int
+ */
+function rytkoset_theme_get_tampere_2026_visible_participant_field_limit( $order ) {
+	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+		return 0;
+	}
+
+	return rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+}
+
+/**
  * Returns the Tampere 2026 participant field IDs for a participant index.
  *
  * @param int $index Participant index.
@@ -1057,11 +1074,7 @@ function rytkoset_theme_filter_tampere_2026_order_confirmation_fields( $show, $f
 
 	$order = isset( $context['order'] ) && $context['order'] instanceof WC_Order ? $context['order'] : null;
 
-	if ( ! $order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
-		return $show;
-	}
-
-	return $show && $index <= rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+	return $show && $index <= rytkoset_theme_get_tampere_2026_visible_participant_field_limit( $order );
 }
 add_filter( 'woocommerce_filter_fields_for_order_confirmation', 'rytkoset_theme_filter_tampere_2026_order_confirmation_fields', 10, 4 );
 
@@ -1073,11 +1086,11 @@ add_filter( 'woocommerce_filter_fields_for_order_confirmation', 'rytkoset_theme_
  * @return array<string, mixed>
  */
 function rytkoset_theme_filter_tampere_2026_admin_order_fields( $fields, $order = null ) {
-	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+	if ( ! $order instanceof WC_Order ) {
 		return $fields;
 	}
 
-	$participant_quantity = rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+	$participant_quantity = rytkoset_theme_get_tampere_2026_visible_participant_field_limit( $order );
 
 	foreach ( $fields as $field_key => $field ) {
 		$field_id = is_array( $field ) && isset( $field['id'] ) ? (string) $field['id'] : (string) $field_key;
@@ -1099,11 +1112,11 @@ add_filter( 'woocommerce_admin_shipping_fields', 'rytkoset_theme_filter_tampere_
  * @return void
  */
 function rytkoset_theme_cleanup_tampere_2026_extra_participant_order_meta( $order ) {
-	if ( ! $order instanceof WC_Order || ! rytkoset_theme_is_tampere_2026_registration_order( $order ) ) {
+	if ( ! $order instanceof WC_Order ) {
 		return;
 	}
 
-	$participant_quantity = rytkoset_theme_get_tampere_2026_order_participant_quantity( $order );
+	$participant_quantity = rytkoset_theme_get_tampere_2026_visible_participant_field_limit( $order );
 	$max_participants     = rytkoset_theme_get_tampere_2026_max_participants();
 	$deleted_meta         = false;
 


### PR DESCRIPTION
Korjaa #314.

## Mitä muuttui

- Piilotetaan Tampere 2026 `rytkoset/participant_*` -lisäkentät kokonaan tilauksilta, jotka eivät ole Tampere 2026 -tilauksia.
- Rajataan Tampere 2026 -tilauksilla osallistujakenttien näkyvyys ostetun osallistujamäärän mukaan.
- Sama logiikka koskee:
  - asiakassähköposteja
  - order confirmation -näkymiä
  - WooCommerce Adminin tilausnäkymää
- Store API -tilausten cleanup poistaa jatkossa myös ei-Tampere-tilauksille vahingossa tallentuneet participant-metat.
- Päivitetty changelog, WooCommerce Tampere 2026 -dokumentaatio ja agenttien tekninen konteksti.

## Testaus

- `docker compose exec -T wordpress sh -c "find /var/www/html/wp-content/themes/rytkoset-theme -name '*.php' -print0 | xargs -0 -n1 php -l"`
- Bootstrapattu WordPress-tarkistus:
  - ei-Tampere-tilauksella participant-kenttä piilotetaan
  - uutiskirjevalinta jää näkyviin
  - WooCommerce Adminin kenttälistasta poistuu vain participant-kenttä

## Huomio

Paikallisessa työpuussa oli ennestään erillinen muutos tiedostossa `front-page.php`; tämä PR ei liity siihen.