### PR TITLE
317 fixwoo yhtenäistä ostoskorin tuotesuositusten napit kaupan kanssa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Customizer section **Huoltotila** (in `inc/customizer-contact.php`): settings for maintenance concept and optional return-time text.
 
 ### Fixed
+- Ostoskorin tyhjän korin `Uutta kaupassa` -tuotesuositusten napit yhtenäistettiin kaupan etusivun keltaiseen CTA-tyyliin ja tasattiin samaan riviin (#317).
 - Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 
 ### Fixed
 - Ostoskorin tyhjän korin `Uutta kaupassa` -tuotesuositusten napit yhtenäistettiin kaupan etusivun keltaiseen CTA-tyyliin ja tasattiin samaan riviin (#317).
+- WooCommerce-ilmoitusten tumman teeman värit vakioitiin, jotta ostoskoriin lisäyksen ilmoitusteksti säilyy luettavana (#317).
 - Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Ostoskorin tyhjän korin `Uutta kaupassa` -tuotesuositusten napit yhtenäistettiin kaupan etusivun keltaiseen CTA-tyyliin ja tasattiin samaan riviin (#317).
 - WooCommerce-ilmoitusten tumman teeman värit vakioitiin, jotta ostoskoriin lisäyksen ilmoitusteksti säilyy luettavana (#317).
 - WooCommerce-tuotesivuilta poistettiin geneerisen yksittäissivupohjan julkaisupäivämäärä (#317).
+- Mollien kassamaksutapojen ja luottokorttikenttien englanninkielisiä tekstejä suomennettiin (#317).
+- Mollie Componentsin locale pakotetaan suomeksi, kun WordPressin locale on `fi`, jotta korttikenttien iframe ei putoa englanniksi (#317).
 - Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - Mollien kassamaksutapojen ja luottokorttikenttien englanninkielisiä tekstejä suomennettiin (#317).
 - Mollie Componentsin locale pakotetaan suomeksi, kun WordPressin locale on `fi`, jotta korttikenttien iframe ei putoa englanniksi (#317).
 - Maksun epäonnistumisen kassailmoitus suomennettiin (#317).
+- Mollien tilisiirto- ja verkkopankkitilauksille lisättiin asiakasohje, joka kertoo suomalaisten pankkien RF-viitteen käytöstä ilman väliviivoja (#317).
 - Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ### Fixed
 - Ostoskorin tyhjän korin `Uutta kaupassa` -tuotesuositusten napit yhtenäistettiin kaupan etusivun keltaiseen CTA-tyyliin ja tasattiin samaan riviin (#317).
 - WooCommerce-ilmoitusten tumman teeman värit vakioitiin, jotta ostoskoriin lisäyksen ilmoitusteksti säilyy luettavana (#317).
+- WooCommerce-tuotesivuilta poistettiin geneerisen yksittäissivupohjan julkaisupäivämäärä (#317).
 - Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - WooCommerce-tuotesivuilta poistettiin geneerisen yksittäissivupohjan julkaisupäivämäärä (#317).
 - Mollien kassamaksutapojen ja luottokorttikenttien englanninkielisiä tekstejä suomennettiin (#317).
 - Mollie Componentsin locale pakotetaan suomeksi, kun WordPressin locale on `fi`, jotta korttikenttien iframe ei putoa englanniksi (#317).
+- Maksun epäonnistumisen kassailmoitus suomennettiin (#317).
 - Tampere 2026 -osallistujakenttien tyhjät `buffet: Ei` -rivit piilotetaan myös ei-Tampere-tilauksilta WooCommerce Adminissa ja asiakassähköposteissa (#314).
 
 ---

--- a/wp-content/themes/rytkoset-theme/assets/css/shop.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/shop.css
@@ -25,7 +25,8 @@
 .woocommerce-page a.button,
 .woocommerce-page button.button,
 .woocommerce-page input.button,
-.woocommerce-page #respond input#submit {
+.woocommerce-page #respond input#submit,
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .wp-block-button__link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -56,7 +57,8 @@
 .woocommerce-page a.button:hover,
 .woocommerce-page button.button:hover,
 .woocommerce-page input.button:hover,
-.woocommerce-page #respond input#submit:hover {
+.woocommerce-page #respond input#submit:hover,
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .wp-block-button__link:hover {
   background: var(--color-accent-hover);
   color: var(--color-primary-deeper);
   text-decoration: none;
@@ -204,7 +206,8 @@ body.woocommerce-cart .wc-block-cart__submit-container .wc-block-components-butt
 .woocommerce-page a.button:focus-visible,
 .woocommerce-page button.button:focus-visible,
 .woocommerce-page input.button:focus-visible,
-.woocommerce-page #respond input#submit:focus-visible {
+.woocommerce-page #respond input#submit:focus-visible,
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .wp-block-button__link:focus-visible {
   outline: none;
   box-shadow: var(--shop-focus-ring);
 }
@@ -221,7 +224,8 @@ body.woocommerce-cart .wc-block-cart__submit-container .wc-block-components-butt
 .woocommerce a.button.product_type_external,
 .woocommerce-page a.button.product_type_variable,
 .woocommerce-page a.button.product_type_grouped,
-.woocommerce-page a.button.product_type_external {
+.woocommerce-page a.button.product_type_external,
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .add_to_cart_button:not(.ajax_add_to_cart) {
   background: var(--color-surface);
   border-color: var(--color-primary);
   color: var(--color-primary);
@@ -233,7 +237,9 @@ body.woocommerce-cart .wc-block-cart__submit-container .wc-block-components-butt
 .woocommerce a.button.product_type_external:hover,
 .woocommerce-page a.button.product_type_variable:hover,
 .woocommerce-page a.button.product_type_grouped:hover,
-.woocommerce-page a.button.product_type_external:hover {
+.woocommerce-page a.button.product_type_external:hover,
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .add_to_cart_button:not(.ajax_add_to_cart):hover,
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .add_to_cart_button:not(.ajax_add_to_cart):focus-visible {
   background: var(--color-primary);
   border-color: var(--color-primary);
   color: var(--color-text-inverted);
@@ -463,6 +469,75 @@ body.woocommerce-cart .wc-block-components-quantity-selector__input::-webkit-inn
 body.woocommerce-cart .wc-block-components-quantity-selector:focus-within {
   border-color: var(--color-primary);
   box-shadow: var(--shop-focus-ring);
+}
+
+body.woocommerce-cart .wc-block-grid__products {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 3rem 2rem;
+}
+
+body.woocommerce-cart .wc-block-grid__products .wc-block-grid__product {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  width: auto;
+  max-width: none;
+  min-width: 0;
+  margin: 0;
+}
+
+body.woocommerce-cart .wc-block-grid__product-link {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+}
+
+body.woocommerce-cart .wc-block-grid__product-image {
+  margin: 0 0 1.25rem;
+}
+
+body.woocommerce-cart .wc-block-grid__product-image img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  margin: 0;
+  background: var(--color-surface-alt);
+}
+
+body.woocommerce-cart .wc-block-grid__product-title {
+  min-height: 3.2em;
+  color: var(--color-primary-deeper);
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1.2;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+body.woocommerce-cart .wc-block-grid__product-price {
+  min-height: 1.5em;
+  margin: 0 0 1.2rem;
+  color: var(--color-primary);
+}
+
+body.woocommerce-cart .wc-block-grid__product-add-to-cart {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  min-width: 9.75rem;
+  max-width: 100%;
+  margin-top: auto;
+}
+
+body.woocommerce-cart .wc-block-grid__product-add-to-cart .wp-block-button__link {
+  width: auto;
+  min-width: 9.75rem;
+  max-width: 100%;
+  text-align: center;
 }
 
 .woocommerce ul.products,
@@ -767,7 +842,8 @@ body.woocommerce-cart .wc-block-components-quantity-selector:focus-within {
   }
 
   .woocommerce ul.products,
-  .woocommerce-page ul.products {
+  .woocommerce-page ul.products,
+  body.woocommerce-cart .wc-block-grid__products {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 2rem 1rem;
   }
@@ -775,7 +851,8 @@ body.woocommerce-cart .wc-block-components-quantity-selector:focus-within {
 
 @media (max-width: 560px) {
   .woocommerce ul.products,
-  .woocommerce-page ul.products {
+  .woocommerce-page ul.products,
+  body.woocommerce-cart .wc-block-grid__products {
     grid-template-columns: 1fr;
   }
 }

--- a/wp-content/themes/rytkoset-theme/assets/css/shop.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/shop.css
@@ -7,6 +7,9 @@
   --shop-popover-shadow: 0 1px 0 rgba(15, 23, 42, 0.04),
     0 18px 40px rgba(8, 37, 74, 0.18);
   --shop-accent-soft: #fef3c7;
+  --shop-notice-bg: #f6f5f8;
+  --shop-notice-success: #8fae1b;
+  --shop-notice-error: #b91c1c;
 }
 
 :root[data-theme="dark"] .woocommerce,
@@ -16,6 +19,54 @@
   --shop-popover-shadow: 0 1px 0 rgba(255, 255, 255, 0.06),
     0 18px 40px rgba(0, 0, 0, 0.34);
   --shop-accent-soft: rgba(251, 191, 36, 0.18);
+  --shop-notice-bg: var(--color-surface-alt);
+  --shop-notice-success: #a3c72b;
+  --shop-notice-error: #f87171;
+}
+
+.woocommerce .woocommerce-message,
+.woocommerce .woocommerce-info,
+.woocommerce .woocommerce-error,
+.woocommerce-page .woocommerce-message,
+.woocommerce-page .woocommerce-info,
+.woocommerce-page .woocommerce-error {
+  border-top-color: var(--shop-notice-success);
+  background: var(--shop-notice-bg);
+  color: var(--color-text);
+}
+
+.woocommerce .woocommerce-info,
+.woocommerce-page .woocommerce-info {
+  border-top-color: var(--color-primary);
+}
+
+.woocommerce .woocommerce-error,
+.woocommerce-page .woocommerce-error {
+  border-top-color: var(--shop-notice-error);
+}
+
+.woocommerce .woocommerce-message::before,
+.woocommerce-page .woocommerce-message::before {
+  color: var(--shop-notice-success);
+}
+
+.woocommerce .woocommerce-info::before,
+.woocommerce-page .woocommerce-info::before {
+  color: var(--color-primary);
+}
+
+.woocommerce .woocommerce-error::before,
+.woocommerce-page .woocommerce-error::before {
+  color: var(--shop-notice-error);
+}
+
+.woocommerce .woocommerce-message a:not(.button),
+.woocommerce .woocommerce-info a:not(.button),
+.woocommerce .woocommerce-error a:not(.button),
+.woocommerce-page .woocommerce-message a:not(.button),
+.woocommerce-page .woocommerce-info a:not(.button),
+.woocommerce-page .woocommerce-error a:not(.button) {
+  color: var(--color-primary);
 }
 
 .woocommerce a.button,

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -421,11 +421,14 @@ function rytkoset_theme_scripts() {
 		function_exists( 'is_woocommerce' )
 		&& ( is_woocommerce() || is_cart() || is_checkout() )
 	) {
+		$shop_style_path    = get_template_directory() . '/assets/css/shop.css';
+		$shop_style_version = file_exists( $shop_style_path ) ? (string) filemtime( $shop_style_path ) : $theme_version;
+
 		wp_enqueue_style(
 			'rytkoset-theme-shop',
 			get_template_directory_uri() . '/assets/css/shop.css',
 			array( 'rytkoset-theme-style' ),
-			$theme_version
+			$shop_style_version
 		);
 
 		wp_enqueue_script(

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string
  */
 function rytkoset_theme_mollie_finnish_strings( $translated, $original, $domain ) {
-	if ( 'mollie-payments-for-woocommerce' !== $domain ) {
+	if ( ! in_array( $domain, array( 'mollie-payments-for-woocommerce', 'woocommerce', 'woocommerce-payments' ), true ) ) {
 		return $translated;
 	}
 
@@ -28,6 +28,7 @@ function rytkoset_theme_mollie_finnish_strings( $translated, $original, $domain 
 
 	$map = array(
 		', payment pending.' => ', maksu odottaa vahvistusta.',
+		'Your payment was not successful. Please complete your order with a different payment method.' => 'Maksu ei onnistunut. Viimeistele tilaus valitsemalla toinen maksutapa.',
 		'Please complete your payment by transferring the total amount to the following bank account:' => 'Viimeistele maksu siirtämällä koko summa seuraavalle pankkitilille:',
 		'Beneficiary: %s' => 'Saaja: %s',
 		'Payment reference: %s' => 'Viite: %s',

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
@@ -34,6 +34,12 @@ function rytkoset_theme_mollie_finnish_strings( $translated, $original, $domain 
 		'Please provide the payment reference <strong>%s</strong>' => 'Käytä maksussa viitettä <strong>%s</strong>',
 		'The payment will expire on <strong>%s</strong>.' => 'Maksu vanhenee <strong>%s</strong>.',
 		'The payment will expire on <strong>%s</strong>. Please make sure you transfer the total amount before this date.' => 'Maksu vanhenee <strong>%s</strong>. Varmista, että siirrät koko summan ennen tätä päivää.',
+		'Pay by Bank' => 'Verkkopankkimaksu',
+		'Name on card' => 'Kortinhaltijan nimi',
+		'Card number' => 'Kortin numero',
+		'Expiry date' => 'Voimassaoloaika',
+		'Secure payments provided by' => 'Turvallisen maksun tarjoaa',
+		'%1$s Secure payments provided by %2$s' => '%1$s Turvallisen maksun tarjoaa %2$s',
 		'Payment completed by <strong>%1$s</strong> (IBAN (last 4 digits): %2$s, BIC: %3$s)' => 'Maksu suoritettu tililtä <strong>%1$s</strong> (IBAN, 4 viimeistä merkkiä: %2$s, BIC: %3$s)',
 		'%1$s payment pending (%2$s).' => '%1$s: maksu odottaa vahvistusta (%2$s).',
 		'%1$s payment still pending (%2$s) but customer already returned to the store. Status should be updated automatically in the future, if it doesn\'t this might indicate a communication issue between the site and Mollie.' => '%1$s: maksu odottaa edelleen vahvistusta (%2$s), vaikka asiakas on jo palannut kauppaan. Tilan pitäisi päivittyä automaattisesti myöhemmin. Jos näin ei käy, sivuston ja Mollien välillä voi olla yhteysongelma.',
@@ -47,6 +53,57 @@ function rytkoset_theme_mollie_finnish_strings( $translated, $original, $domain 
 	return $translated;
 }
 add_filter( 'gettext', 'rytkoset_theme_mollie_finnish_strings', 10, 3 );
+
+/**
+ * Keeps selected Mollie gateway titles understandable for Finnish checkout users.
+ *
+ * @param string $title      Payment gateway title.
+ * @param string $gateway_id Payment gateway ID.
+ * @return string
+ */
+function rytkoset_theme_mollie_gateway_title( $title, $gateway_id ) {
+	$locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+
+	if ( 0 !== strpos( (string) $locale, 'fi' ) ) {
+		return $title;
+	}
+
+	if ( 'mollie_wc_gateway_paybybank' === $gateway_id ) {
+		return __( 'Verkkopankkimaksu', 'rytkoset-theme' );
+	}
+
+	return $title;
+}
+add_filter( 'woocommerce_gateway_title', 'rytkoset_theme_mollie_gateway_title', 10, 2 );
+
+/**
+ * Forces Mollie Components to use Finnish locale when WordPress reports plain "fi".
+ *
+ * Mollie Components accepts "fi_FI", while WordPress can store the Finnish site
+ * locale as "fi". Without this adapter the card input iframe falls back to en_US.
+ *
+ * @return void
+ */
+function rytkoset_theme_mollie_components_finnish_locale() {
+	if ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
+		return;
+	}
+
+	$locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+
+	if ( 0 !== strpos( (string) $locale, 'fi' ) ) {
+		return;
+	}
+
+	$script = <<<'JS'
+if (window.mollieServerData && window.mollieServerData.componentData && window.mollieServerData.componentData.options) {
+	window.mollieServerData.componentData.options.locale = 'fi_FI';
+}
+JS;
+
+	wp_add_inline_script( 'mollie_block_index', $script, 'before' );
+}
+add_action( 'wp_enqueue_scripts', 'rytkoset_theme_mollie_components_finnish_locale', 20 );
 
 /**
  * Returns true when the order uses a Mollie payment method with RF instructions.

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
@@ -303,13 +303,144 @@ function rytkoset_theme_end_mollie_email_instruction_buffer( $order, $sent_to_ad
 	rytkoset_theme_end_mollie_instruction_buffer( 'email', $order );
 }
 
+/**
+ * Extracts a normalized RF reference from saved Mollie instructions.
+ *
+ * @param WC_Order|mixed $order WooCommerce order object.
+ * @return string
+ */
+function rytkoset_theme_get_mollie_rf_reference( $order ) {
+	if ( ! rytkoset_theme_is_mollie_rf_reference_order( $order ) ) {
+		return '';
+	}
+
+	$instructions = $order->get_meta( '_mollie_payment_instructions', true );
+
+	if ( ! is_string( $instructions ) || '' === $instructions ) {
+		return '';
+	}
+
+	$normalized = rytkoset_theme_normalize_mollie_rf_references( $instructions );
+
+	if ( preg_match( '/\bRF\d{2}[A-Z0-9]{5,}\b/i', $normalized, $matches ) ) {
+		return strtoupper( $matches[0] );
+	}
+
+	return '';
+}
+
+/**
+ * Renders a Finnish bank transfer note for Mollie RF references.
+ *
+ * Mollie's own bank transfer email is sent outside WordPress, so show the
+ * Finnish bank-specific guidance in WooCommerce-controlled customer views.
+ *
+ * @param WC_Order|mixed $order      WooCommerce order object.
+ * @param string         $context    Render context.
+ * @param bool           $plain_text Whether the output is plain text email.
+ * @return void
+ */
+function rytkoset_theme_render_mollie_rf_reference_notice( $order, $context = 'screen', $plain_text = false ) {
+	static $rendered = array();
+
+	if ( ! rytkoset_theme_is_mollie_rf_reference_order( $order ) ) {
+		return;
+	}
+
+	$key = $context . ':' . $order->get_id();
+
+	if ( isset( $rendered[ $key ] ) ) {
+		return;
+	}
+
+	$rendered[ $key ] = true;
+
+	$reference      = rytkoset_theme_get_mollie_rf_reference( $order );
+	$example_source = 'RF98-1937-5848-0918';
+	$example_target = rytkoset_theme_normalize_mollie_rf_references( $example_source );
+
+	if ( '' !== $reference ) {
+		$reference_instruction = sprintf(
+			/* translators: %s: normalized RF payment reference. */
+			__( 'Käytä pankissa viitettä %s.', 'rytkoset-theme' ),
+			$reference
+		);
+	} else {
+		$reference_instruction = sprintf(
+			/* translators: 1: formatted RF reference, 2: normalized RF reference. */
+			__( 'Esimerkiksi %1$s kirjoitetaan pankkiin muodossa %2$s.', 'rytkoset-theme' ),
+			$example_source,
+			$example_target
+		);
+	}
+
+	$message = sprintf(
+		/* translators: %s: RF reference instruction. */
+		__( 'Jos Mollien maksusähköpostissa viite näkyy väliviivoilla, poista väliviivat ennen kuin syötät viitteen suomalaiseen verkkopankkiin. %s Syötä RF-viite maksun viitenumeroksi, jos pankki hyväksyy RF-viitteen.', 'rytkoset-theme' ),
+		$reference_instruction
+	);
+
+	if ( $plain_text ) {
+		echo "\n" . esc_html__( 'Tärkeää suomalaisissa pankeissa:', 'rytkoset-theme' ) . "\n";
+		echo esc_html( $message ) . "\n";
+		return;
+	}
+
+	$style = 'margin:16px 0;padding:16px 20px;background:#f6f5f8;border-top:3px solid #8fae1b;color:#1d2327;';
+
+	echo '<div class="woocommerce-info rytkoset-mollie-rf-notice" style="' . esc_attr( $style ) . '">';
+	echo '<strong>' . esc_html__( 'Tärkeää suomalaisissa pankeissa:', 'rytkoset-theme' ) . '</strong> ';
+	echo esc_html( $message );
+	echo '</div>';
+}
+
+/**
+ * Renders the RF reference notice on Mollie thank-you pages.
+ *
+ * @param int $order_id WooCommerce order ID.
+ * @return void
+ */
+function rytkoset_theme_render_mollie_thankyou_rf_reference_notice( $order_id ) {
+	rytkoset_theme_render_mollie_rf_reference_notice( wc_get_order( $order_id ), 'thankyou' );
+}
+
+/**
+ * Renders the RF reference notice on customer order detail pages.
+ *
+ * @param WC_Order|mixed $order WooCommerce order object.
+ * @return void
+ */
+function rytkoset_theme_render_mollie_order_details_rf_reference_notice( $order ) {
+	rytkoset_theme_render_mollie_rf_reference_notice( $order, 'order-details' );
+}
+
+/**
+ * Renders the RF reference notice in customer emails.
+ *
+ * @param WC_Order|mixed $order         WooCommerce order object.
+ * @param bool           $sent_to_admin Whether the email targets admin.
+ * @param bool           $plain_text    Whether the email is plain text.
+ * @return void
+ */
+function rytkoset_theme_render_mollie_email_rf_reference_notice( $order, $sent_to_admin, $plain_text ) {
+	if ( $sent_to_admin ) {
+		return;
+	}
+
+	rytkoset_theme_render_mollie_rf_reference_notice( $order, 'email', $plain_text );
+}
+
 add_action( 'woocommerce_thankyou_mollie_wc_gateway_banktransfer', 'rytkoset_theme_start_mollie_thankyou_instruction_buffer', 9 );
 add_action( 'woocommerce_thankyou_mollie_wc_gateway_banktransfer', 'rytkoset_theme_end_mollie_thankyou_instruction_buffer', 11 );
+add_action( 'woocommerce_thankyou_mollie_wc_gateway_banktransfer', 'rytkoset_theme_render_mollie_thankyou_rf_reference_notice', 12 );
 add_action( 'woocommerce_thankyou_mollie_wc_gateway_paybybank', 'rytkoset_theme_start_mollie_thankyou_instruction_buffer', 9 );
 add_action( 'woocommerce_thankyou_mollie_wc_gateway_paybybank', 'rytkoset_theme_end_mollie_thankyou_instruction_buffer', 11 );
+add_action( 'woocommerce_thankyou_mollie_wc_gateway_paybybank', 'rytkoset_theme_render_mollie_thankyou_rf_reference_notice', 12 );
 add_action( 'woocommerce_order_details_after_order_table', 'rytkoset_theme_start_mollie_order_details_instruction_buffer', 9 );
 add_action( 'woocommerce_order_details_after_order_table', 'rytkoset_theme_end_mollie_order_details_instruction_buffer', 11 );
+add_action( 'woocommerce_order_details_after_order_table', 'rytkoset_theme_render_mollie_order_details_rf_reference_notice', 12 );
 add_action( 'woocommerce_email_after_order_table', 'rytkoset_theme_start_mollie_email_instruction_buffer', 9, 3 );
 add_action( 'woocommerce_email_after_order_table', 'rytkoset_theme_end_mollie_email_instruction_buffer', 11, 3 );
+add_action( 'woocommerce_email_after_order_table', 'rytkoset_theme_render_mollie_email_rf_reference_notice', 12, 3 );
 add_action( 'woocommerce_email_order_meta', 'rytkoset_theme_start_mollie_email_instruction_buffer', 9, 3 );
 add_action( 'woocommerce_email_order_meta', 'rytkoset_theme_end_mollie_email_instruction_buffer', 11, 3 );

--- a/wp-content/themes/rytkoset-theme/single.php
+++ b/wp-content/themes/rytkoset-theme/single.php
@@ -22,7 +22,9 @@ get_header();
 					?>
 					<article <?php post_class( 'article' ); ?>>
 						<header class="article__header">
-							<p class="article__meta"><?php echo esc_html( get_the_date() ); ?></p>
+							<?php if ( 'product' !== get_post_type() ) : ?>
+								<p class="article__meta"><?php echo esc_html( get_the_date() ); ?></p>
+							<?php endif; ?>
 							<h1 class="article__title"><?php the_title(); ?></h1>
 						</header>
 


### PR DESCRIPTION
## Mitä

Mollie-integraation suomalaistaminen: käyttöliittymätekstit, kassatekstit, virheilmoitukset ja RF-viiteopastus.

Closes #317

## Muutokset

### Suomennokset ja tekstit
- Mollien kassamaksutapojen ja luottokorttikenttien englanninkieliset tekstit käännetty suomeksi
- Mollie Components -iframen locale pakotetaan `fi`:ksi, kun WordPressin locale on `fi` — estää korttikenttien putoamisen englanniksi
- Maksun epäonnistumisen kassailmoitus suomennettiin

### Kassanäkymä ja UX
- Kauppa-, kassa- ja tuotesivujen tyylihienosäätöjä
- Ostoskori-painikkeiden ja tumman teeeman ilmoitusten asettelu korjattu

### RF-viiteopastus (#317 laajennos)
- Tilisiirto- ja verkkopankkitilauksille lisätty asiakasohje RF-viitteen käytöstä suomalaisissa pankeissa
- Ohje näytetään kolmessa paikassa: kiitos-sivu, tilauksen tietosivulla ja asiakassähköpostissa
- Jos viite on tallennettu tilaukselle, ohje näyttää normalisoidun viitteen (väliviivat poistettu); muuten yleinen esimerkki
- Viitteen normalisointi käyttää olemassa olevaa `rytkoset_theme_normalize_mollie_rf_references()`-funktiota
- Duplikaattiesto `static $rendered`-taulukolla kontekstikohtaisesti

## Testaus

- [ ] Tilisiirtomaksun kiitos-sivu näyttää RF-viiteohjeen
- [ ] Verkkopankkimaksun kiitos-sivu näyttää RF-viiteohjeen
- [ ] Tilauksen tietosivulla ohje näkyy asiakkaalle (ei adminille)
- [ ] Asiakassähköpostissa ohje näkyy sekä HTML- että plain text -muodossa
- [ ] Administraattorille menevässä sähköpostissa ohje ei näy
- [ ] Korttikenttien locale on suomi (ei englanti) kun WP locale = fi
