### PR TITLE
feat(search): add search results template and fix mobile search overf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- `search.php`: hakutulossivu tuloslistalla (tyyppi, päivämäärä, otsikko, katkelma), tulosmäärällä ja tyhjän haun lomakkeella (#323).
+
+### Fixed
+- Mobiilihakuformi (≤920px) vuosi viewportin yli vasemmalle, koska formi oli positioitu suhteessa pieneen hakupainikkeeseen. Formi positioituu nyt `.site-header__primary-inner` -elementtiin (`position: relative`) ja `left: 0; right: 0; box-sizing: border-box` pinssaa sen tarkasti headerin leveyteen (#323).
+
+### Added
 - `wp-content/maintenance.php`: branded maintenance page that overrides WordPress's default maintenance screen. Navy hero with gold accent, Newsreader/Manrope fonts, cream illustration card, pulsing status badge, return-time chip, and social links — matching the site's visual language. Reads `get_theme_mod()` for concept (`uudistus`/`huolto`/`talkoot`), return text, contact email, and custom logo.
 - Customizer section **Huoltotila** (in `inc/customizer-contact.php`): settings for maintenance concept and optional return-time text.
 

--- a/wp-content/themes/rytkoset-theme/assets/css/components.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/components.css
@@ -1659,3 +1659,87 @@
     margin-bottom: 0;
   }
 }
+
+/* Search results */
+.search-results-header {
+  margin-bottom: 2rem;
+}
+
+.search-results-header__title {
+  margin: 0 0 0.4rem;
+}
+
+.search-results-header__count {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.search-results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.search-result {
+  border-bottom: 1px solid var(--color-border-neutral);
+  padding: 1.5rem 0;
+}
+
+.search-result:first-child {
+  border-top: 1px solid var(--color-border-neutral);
+}
+
+.search-result__article {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.search-result__meta {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.search-result__type {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-primary);
+}
+
+.search-result__title {
+  margin: 0;
+  font-size: 1.15rem;
+  line-height: 1.3;
+}
+
+.search-result__link {
+  color: var(--color-primary-deeper);
+  text-decoration: none;
+}
+
+.search-result__link:hover,
+.search-result__link:focus-visible {
+  text-decoration: underline;
+}
+
+.search-result__excerpt {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.search-results--empty {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}

--- a/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
+++ b/wp-content/themes/rytkoset-theme/assets/css/nav.base.css
@@ -397,6 +397,28 @@
   flex: 0 0 auto;
 }
 
+/* On narrow viewports the search button sits mid-header, so the form
+   (right: 0 relative to the button) overflows the left viewport edge.
+   Promote the full-width primary-inner to be the positioning context so
+   the form drops below the entire nav bar and spans the container. */
+@media (max-width: 920px) {
+  .site-header__primary-inner {
+    position: relative;
+  }
+
+  .site-header__search {
+    position: static;
+  }
+
+  .site-header__search-form {
+    top: 100%;
+    left: 0;
+    right: 0;
+    width: auto;
+    box-sizing: border-box;
+  }
+}
+
 /* Accessible screen reader text + skip link */
 .screen-reader-text {
   position: absolute;

--- a/wp-content/themes/rytkoset-theme/search.php
+++ b/wp-content/themes/rytkoset-theme/search.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Hakutulosten sivupohja.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_header();
+?>
+
+<main id="primary" class="site-main" tabindex="-1">
+<section class="section">
+	<div class="container section__narrow">
+
+		<header class="search-results-header">
+			<h1 class="search-results-header__title">
+				<?php
+				printf(
+					/* translators: %s: search query */
+					esc_html__( 'Hakutulokset: "%s"', 'rytkoset-theme' ),
+					get_search_query()
+				);
+				?>
+			</h1>
+			<?php if ( have_posts() ) : ?>
+				<p class="search-results-header__count">
+					<?php
+					printf(
+						/* translators: %d: number of results */
+						esc_html( _n( '%d tulos', '%d tulosta', (int) $wp_query->found_posts, 'rytkoset-theme' ) ),
+						(int) $wp_query->found_posts
+					);
+					?>
+				</p>
+			<?php endif; ?>
+		</header>
+
+		<?php if ( have_posts() ) : ?>
+
+			<ol class="search-results" role="list">
+				<?php
+				while ( have_posts() ) :
+					the_post();
+					?>
+					<li class="search-result">
+						<article class="search-result__article">
+							<p class="search-result__meta">
+								<span class="search-result__type"><?php echo esc_html( get_post_type_object( get_post_type() )->labels->singular_name ); ?></span>
+								<time class="search-result__date" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>"><?php echo esc_html( get_the_date() ); ?></time>
+							</p>
+							<h2 class="search-result__title">
+								<a class="search-result__link" href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+							</h2>
+							<?php if ( has_excerpt() || get_the_excerpt() ) : ?>
+								<p class="search-result__excerpt"><?php echo esc_html( wp_strip_all_tags( get_the_excerpt() ) ); ?></p>
+							<?php endif; ?>
+						</article>
+					</li>
+				<?php endwhile; ?>
+			</ol>
+
+			<?php the_posts_pagination( array( 'mid_size' => 2 ) ); ?>
+
+		<?php else : ?>
+
+			<div class="search-results--empty">
+				<p><?php esc_html_e( 'Haullasi ei löytynyt tuloksia. Kokeile eri hakusanaa.', 'rytkoset-theme' ); ?></p>
+				<?php get_search_form(); ?>
+			</div>
+
+		<?php endif; ?>
+
+	</div>
+</section>
+</main>
+
+<?php get_footer(); ?>


### PR DESCRIPTION
## Hakutulosten sivu ja mobiili-hakuformin korjaus (#323)

Lisätään puuttuva hakutulossivu ja korjataan mobiilissa hakuformin ylivuoto.

### Muutokset

- **Uusi templaatti** `search.php`: hakutulosten listasivu tulostyypillä (TAPAHTUMA, SIVU, BLOGI), päivämäärällä, otsikolla ja katkelulla. Näyttää tulosmäärän ja tyhjän haun lomakkeen, jos tuloksia ei löydy.
- **CSS** (`components.css`): `.search-results*` -tyylittelyt tuloslistalle, metadatalle, niille ja katkelmoille.
- **Mobiili-korjaus** (`nav.base.css`): Hakuformi ylivuotoi vasemmalle pienillä näytöillä, koska se positioitui suhteessa hakupainikkeeseen. Nyt:
  - `.site-header__primary-inner` saa `position: relative` (laajempi ankkuri)
  - `.site-header__search` saa `position: static` (poistuu välistä)
  - Formi pinnataan `left: 0; right: 0; box-sizing: border-box` (täyttää headerin leveyden ilman ylivuotoa)

### Testaus

- Mobiili (≤920px): avaa haku, varmista että formi sopii näytölle
- Hakutulos: etsi "tapahtuma", tarkista että tulokset näkyvät oikein tyypillä ja metadatalla
- Tyhjä haku: etsi mitä tahansa keksimää sanaa, tarkista tyhjä tila

### Linkit

Fixes #323

### Tarkistuslista

- [x] Templaatti luotu
- [x] CSS lisätty
- [x] Mobiili-korjaus testattu (fits: true 390px viewportissa)
- [x] CHANGELOG päivitetty
