### PR TITLE
fix(woocommerce-tampere-2026): investigate missing organizer notifica…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- `inc/email.php`: teeman lähettämien `wp_mail()`-viestien (tapahtumailmoittautumiset, järjestäjäilmoitukset, osallistujaviestintä) oletuslähettäjäksi `Rytkösten sukuseura ry` / `rytkoset_theme_get_contact_email()` (`info@rytkoset.net`). Suodattimet korvaavat vain WordPressin oletuslähettäjän (`WordPress <wordpress@…>`), joten WooCommercen omat tilausviestit ja AcyMailing säilyvät koskemattomina.
 - `search.php`: hakutulossivu tuloslistalla (tyyppi, päivämäärä, otsikko, katkelma), tulosmäärällä ja tyhjän haun lomakkeella (#323).
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Footer (Footer C, #278): `footer.php` renders a pre-footer newsletter band above
 | `inc/gallery-albums.php`               | Gallery Album CPT and gallery stack logic                                                                                                                      |
 | `inc/media-library.php`                | Media library ordering by album                                                                                                                                |
 | `inc/digital-magazines.php`            | Digital magazine download pages                                                                                                                                |
+| `inc/email.php`                        | Default mail sender (`Rytkösten sukuseura ry` / `rytkoset_theme_get_contact_email()`) for theme-sent `wp_mail()`; overrides only WordPress's default sender via `wp_mail_from`/`wp_mail_from_name`             |
 | `inc/icons.php`                        | Inline SVG icon helper (`rytkoset_theme_inline_icon`) — reads `currentColor` glyphs from `assets/icons/{social,ui}/`                                           |
 | `inc/share.php`                        | Share buttons (Facebook, X, WhatsApp); icons via `rytkoset_theme_inline_icon`                                                                                  |
 | `inc/social-links.php`                 | Social media links in header/footer; icons inlined via `rytkoset_theme_inline_icon`                                                                            |

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -28,6 +28,7 @@ require_once get_template_directory() . '/inc/woocommerce-membership.php';
 require_once get_template_directory() . '/inc/woocommerce-tampere-2026.php';
 require_once get_template_directory() . '/inc/woocommerce-product-sync.php';
 require_once get_template_directory() . '/inc/customizer-contact.php';
+require_once get_template_directory() . '/inc/email.php';
 require_once get_template_directory() . '/inc/coming-soon.php';
 
 /**

--- a/wp-content/themes/rytkoset-theme/inc/email.php
+++ b/wp-content/themes/rytkoset-theme/inc/email.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Sähköpostin oletuslähettäjä teeman lähettämille viesteille.
+ *
+ * Korvaa WordPressin ruman oletuslähettäjän (WordPress <wordpress@domain>)
+ * yhdistyksen nimellä ja yhteysosoitteella. Suodattimet vaikuttavat VAIN
+ * silloin, kun arvo on WordPressin oletus — WooCommercen omat tilausviestit
+ * ja AcyMailing asettavat oman lähettäjänsä, eikä niihin kosketa.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Palauttaa teeman lähettämien viestien lähettäjänimen.
+ *
+ * @return string
+ */
+if ( ! function_exists( 'rytkoset_theme_get_mail_from_name' ) ) {
+	function rytkoset_theme_get_mail_from_name() {
+		/**
+		 * Suodattaa teeman sähköpostien lähettäjänimen.
+		 *
+		 * @param string $name Lähettäjänimi.
+		 */
+		return apply_filters( 'rytkoset_theme_mail_from_name', 'Rytkösten sukuseura ry' );
+	}
+}
+
+/**
+ * Korvaa WordPressin oletuslähettäjäosoitteen yhteysosoitteella.
+ *
+ * @param string $from_email Nykyinen lähettäjäosoite.
+ * @return string
+ */
+if ( ! function_exists( 'rytkoset_theme_filter_mail_from' ) ) {
+	function rytkoset_theme_filter_mail_from( $from_email ) {
+		// Korvaa vain WordPressin oletus (wordpress@...), jotta WooCommercen
+		// ja muiden lisäosien omat lähettäjät säilyvät.
+		if ( is_string( $from_email ) && 0 === strpos( $from_email, 'wordpress@' ) ) {
+			return rytkoset_theme_get_contact_email();
+		}
+
+		return $from_email;
+	}
+}
+add_filter( 'wp_mail_from', 'rytkoset_theme_filter_mail_from' );
+
+/**
+ * Korvaa WordPressin oletuslähettäjänimen ("WordPress") yhdistyksen nimellä.
+ *
+ * @param string $from_name Nykyinen lähettäjänimi.
+ * @return string
+ */
+if ( ! function_exists( 'rytkoset_theme_filter_mail_from_name' ) ) {
+	function rytkoset_theme_filter_mail_from_name( $from_name ) {
+		if ( 'WordPress' === $from_name ) {
+			return rytkoset_theme_get_mail_from_name();
+		}
+
+		return $from_name;
+	}
+}
+add_filter( 'wp_mail_from_name', 'rytkoset_theme_filter_mail_from_name' );


### PR DESCRIPTION
## Yhteenveto

Lisää `inc/email.php`-moduuli, joka asettaa teeman lähettämien `wp_mail()`-viestien
oletuslähettäjäksi `Rytkösten sukuseura ry` / `info@rytkoset.net` WordPressin
ruman oletuksen (`WordPress <wordpress@domain>`) sijaan.

## Muutokset

- **`inc/email.php`** (uusi): `wp_mail_from`- ja `wp_mail_from_name`-suodattimet, 
  jotka korvaavat **vain** WordPressin oletuslähettäjän. WooCommercen omat
  tilausviestit ja AcyMailing asettavat oman lähettäjänsä — niihin ei kosketa.
- **`functions.php`**: `require_once` uudelle moduulille.
- **`CLAUDE.md`** / **`CHANGELOG.md`**: dokumentaatiopäivitykset.

## Vaikutus

Ennen: tapahtumailmoittautumiset, järjestäjäilmoitukset ja osallistujaviestit
näkyivät vastaanottajalle lähettäjänä `WordPress <wordpress@rytkoset.net>`.

Jälkeen: `Rytkösten sukuseura ry <info@rytkoset.net>`.

WooCommercen ja AcyMailingin sähköpostit eivät muutu.

## Testaus

- [ ] Lähetä testisähköposti wp_mail()-funktiolla (esim. ilmoittautumislomake)
- [ ] Tarkista lähettäjänimi ja -osoite sähköpostiohjelmassa
- [ ] Varmista, että WooCommercen tilausvahvistuksen lähettäjä ei muutu
