### PR TITLE
324 selvitä mollien maksusähköpostin aiheen muokkaus suomenkieliseksi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - `search.php`: hakutulossivu tuloslistalla (tyyppi, päivämäärä, otsikko, katkelma), tulosmäärällä ja tyhjän haun lomakkeella (#323).
 
 ### Fixed
+- Mollien maksusähköpostin aiheen englanninkielinen `Order ####` suomennettiin muotoon `Tilaus ####`: `inc/woocommerce-mollie.php` käsittelee `gettext_with_context`-suodattimella Mollie-lisäosan maksukuvauksen lähdetekstin `Order {orderNumber}` ja kääntää sen `Tilaus {orderNumber}`, jolloin Mollien lähettämän maksusähköpostin aiheeksi tulee esim. `Maksutiedot tilauksestasi "Tilaus 1093"` (#324).
 - Mobiilihakuformi (≤920px) vuosi viewportin yli vasemmalle, koska formi oli positioitu suhteessa pieneen hakupainikkeeseen. Formi positioituu nyt `.site-header__primary-inner` -elementtiin (`position: relative`) ja `left: 0; right: 0; box-sizing: border-box` pinssaa sen tarkasti headerin leveyteen (#323).
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- `inc/email.php`: teeman lähettämien `wp_mail()`-viestien (tapahtumailmoittautumiset, järjestäjäilmoitukset, osallistujaviestintä) oletuslähettäjäksi `Rytkösten sukuseura ry` / `rytkoset_theme_get_contact_email()` (`info@rytkoset.net`). Suodattimet korvaavat vain WordPressin oletuslähettäjän (`WordPress <wordpress@…>`), joten WooCommercen omat tilausviestit ja AcyMailing säilyvät koskemattomina.
 - `search.php`: hakutulossivu tuloslistalla (tyyppi, päivämäärä, otsikko, katkelma), tulosmäärällä ja tyhjän haun lomakkeella (#323).
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Footer (Footer C, #278): `footer.php` renders a pre-footer newsletter band above
 | `inc/gallery-albums.php`               | Gallery Album CPT and gallery stack logic                                                                                                                      |
 | `inc/media-library.php`                | Media library ordering by album                                                                                                                                |
 | `inc/digital-magazines.php`            | Digital magazine download pages                                                                                                                                |
+| `inc/email.php`                        | Default mail sender (`Rytkösten sukuseura ry` / `rytkoset_theme_get_contact_email()`) for theme-sent `wp_mail()`; overrides only WordPress's default sender via `wp_mail_from`/`wp_mail_from_name`             |
 | `inc/icons.php`                        | Inline SVG icon helper (`rytkoset_theme_inline_icon`) — reads `currentColor` glyphs from `assets/icons/{social,ui}/`                                           |
 | `inc/share.php`                        | Share buttons (Facebook, X, WhatsApp); icons via `rytkoset_theme_inline_icon`                                                                                  |
 | `inc/social-links.php`                 | Social media links in header/footer; icons inlined via `rytkoset_theme_inline_icon`                                                                            |

--- a/docs/woocommerce-mollie-payments.md
+++ b/docs/woocommerce-mollie-payments.md
@@ -103,6 +103,32 @@ Tämä ei tarkoita, että WooCommerce-checkout tai Mollie-lisäosan paikallinen 
 
 Localhost-ympäristössä `Store coming soon` -tila voi estää vierailijakassan näkyvyyden. Jos kassaa testataan ilman kirjautumista, tila pitää kytkeä paikallisesti väliaikaisesti pois ja palauttaa testin jälkeen.
 
+## Maksusähköpostin aihe (#324)
+
+Mollien lähettämän tilisiirron maksusähköpostin (`noreply@mollie.com`) aiheessa näkyi
+englanninkielinen tilausviittaus, esim. `Maksutiedot tilauksestasi "Order 1093"`.
+
+Aiheen lainattu osa on **maksun kuvaus**, jonka Mollie-lisäosa lähettää Mollien API:lle.
+Kuvaus muodostetaan lisäosan `PaymentDescriptionMiddleware`-luokassa asetuksesta
+`WooCommerce → Settings → Mollie Settings → Advanced → API Payment Description`,
+jonka oletusarvo on `{orderNumber}`. Tällä oletusarvolla lisäosa käyttää käännettävää
+lähdetekstiä `_x( 'Order {orderNumber}', 'Payment description for {orderNumber}', 'mollie-payments-for-woocommerce' )`,
+josta englanninkielinen "Order" tulee.
+
+**Ratkaisu (toteutettu koodissa):** `inc/woocommerce-mollie.php` lisää `gettext_with_context`-suodattimen
+(`rytkoset_theme_mollie_finnish_contexts`), joka kääntää tämän lähdetekstin suomeksi
+`Tilaus {orderNumber}`, kun WordPressin locale on `fi`. Mollie korvaa `{orderNumber}`-paikkamerkin
+tilausnumerolla, joten aiheeksi tulee `Maksutiedot tilauksestasi "Tilaus 1093"`.
+
+Ratkaisu pidettiin teemassa (versionhallinnassa) eikä WooCommerce-asetuksessa, jotta se
+toimii automaattisesti jokaisessa ympäristössä eikä häviä asetusten resetoituessa.
+Käännös vaikuttaa, kun "API Payment Description" -asetus on oletusarvossa `{orderNumber}`;
+jos asetukseen syötetään oma kuvausteksti, se ohittaa käännöksen.
+
+Vaihtoehtoinen koodittomuus: saman lopputuloksen saa myös asettamalla "API Payment Description"
+-kenttään arvon `Tilaus {orderNumber}`, mutta tämä asetus elää tietokannassa ja pitäisi tehdä
+erikseen jokaiseen ympäristöön.
+
 ## Lähteet
 
 - Mollie WooCommerce plugin: https://wordpress.org/plugins/mollie-payments-for-woocommerce/

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -28,6 +28,7 @@ require_once get_template_directory() . '/inc/woocommerce-membership.php';
 require_once get_template_directory() . '/inc/woocommerce-tampere-2026.php';
 require_once get_template_directory() . '/inc/woocommerce-product-sync.php';
 require_once get_template_directory() . '/inc/customizer-contact.php';
+require_once get_template_directory() . '/inc/email.php';
 require_once get_template_directory() . '/inc/coming-soon.php';
 
 /**

--- a/wp-content/themes/rytkoset-theme/inc/email.php
+++ b/wp-content/themes/rytkoset-theme/inc/email.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Sähköpostin oletuslähettäjä teeman lähettämille viesteille.
+ *
+ * Korvaa WordPressin ruman oletuslähettäjän (WordPress <wordpress@domain>)
+ * yhdistyksen nimellä ja yhteysosoitteella. Suodattimet vaikuttavat VAIN
+ * silloin, kun arvo on WordPressin oletus — WooCommercen omat tilausviestit
+ * ja AcyMailing asettavat oman lähettäjänsä, eikä niihin kosketa.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Palauttaa teeman lähettämien viestien lähettäjänimen.
+ *
+ * @return string
+ */
+if ( ! function_exists( 'rytkoset_theme_get_mail_from_name' ) ) {
+	function rytkoset_theme_get_mail_from_name() {
+		/**
+		 * Suodattaa teeman sähköpostien lähettäjänimen.
+		 *
+		 * @param string $name Lähettäjänimi.
+		 */
+		return apply_filters( 'rytkoset_theme_mail_from_name', 'Rytkösten sukuseura ry' );
+	}
+}
+
+/**
+ * Korvaa WordPressin oletuslähettäjäosoitteen yhteysosoitteella.
+ *
+ * @param string $from_email Nykyinen lähettäjäosoite.
+ * @return string
+ */
+if ( ! function_exists( 'rytkoset_theme_filter_mail_from' ) ) {
+	function rytkoset_theme_filter_mail_from( $from_email ) {
+		// Korvaa vain WordPressin oletus (wordpress@...), jotta WooCommercen
+		// ja muiden lisäosien omat lähettäjät säilyvät.
+		if ( is_string( $from_email ) && 0 === strpos( $from_email, 'wordpress@' ) ) {
+			return rytkoset_theme_get_contact_email();
+		}
+
+		return $from_email;
+	}
+}
+add_filter( 'wp_mail_from', 'rytkoset_theme_filter_mail_from' );
+
+/**
+ * Korvaa WordPressin oletuslähettäjänimen ("WordPress") yhdistyksen nimellä.
+ *
+ * @param string $from_name Nykyinen lähettäjänimi.
+ * @return string
+ */
+if ( ! function_exists( 'rytkoset_theme_filter_mail_from_name' ) ) {
+	function rytkoset_theme_filter_mail_from_name( $from_name ) {
+		if ( 'WordPress' === $from_name ) {
+			return rytkoset_theme_get_mail_from_name();
+		}
+
+		return $from_name;
+	}
+}
+add_filter( 'wp_mail_from_name', 'rytkoset_theme_filter_mail_from_name' );

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-mollie.php
@@ -56,6 +56,41 @@ function rytkoset_theme_mollie_finnish_strings( $translated, $original, $domain 
 add_filter( 'gettext', 'rytkoset_theme_mollie_finnish_strings', 10, 3 );
 
 /**
+ * Suomentaa Mollien maksukuvauksen, joka näkyy Mollien maksusähköpostin aiheessa.
+ *
+ * Mollie-lisäosa lähettää maksun kuvaukseksi käännettävän merkkijonon
+ * `_x( 'Order {orderNumber}', 'Payment description for {orderNumber}', ... )`,
+ * kun "API Payment Description" -asetus on oletusarvossa `{orderNumber}`.
+ * Mollien palvelimilta lähtevä maksusähköposti käyttää tätä kuvausta aiheessaan,
+ * jolloin suomenkieliselle vastaanottajalle näkyy englanninkielinen "Order ####".
+ * Käännetään lähdeteksti suomeksi, jolloin aiheeksi tulee "Tilaus ####".
+ *
+ * @param string $translated Alkuperäinen käännös.
+ * @param string $original   Lähdeteksti.
+ * @param string $context    Käännöksen konteksti.
+ * @param string $domain     Tekstidomain.
+ * @return string
+ */
+function rytkoset_theme_mollie_finnish_contexts( $translated, $original, $context, $domain ) {
+	if ( 'mollie-payments-for-woocommerce' !== $domain ) {
+		return $translated;
+	}
+
+	$locale = function_exists( 'determine_locale' ) ? determine_locale() : get_locale();
+
+	if ( 0 !== strpos( (string) $locale, 'fi' ) ) {
+		return $translated;
+	}
+
+	if ( 'Order {orderNumber}' === $original && 'Payment description for {orderNumber}' === $context ) {
+		return 'Tilaus {orderNumber}';
+	}
+
+	return $translated;
+}
+add_filter( 'gettext_with_context', 'rytkoset_theme_mollie_finnish_contexts', 10, 4 );
+
+/**
  * Keeps selected Mollie gateway titles understandable for Finnish checkout users.
  *
  * @param string $title      Payment gateway title.


### PR DESCRIPTION
## Mitä muuttui

Mollien maksusähköpostin (`noreply@mollie.com`) aiheen englanninkielinen `Order ####` -osa suomennettiin muotoon `Tilaus ####`.

## Tausta

Mollien lähettämän tilisiirtomaksun sähköpostin aiheessa näkyi `Maksutiedot tilauksestasi "Order 1093"`. Aihe-osan lainattu teksti on maksun **kuvaus**, jonka Mollie-lisäosa lähettää Mollien API:lle tilauksen luomisen yhteydessä.

Oletusasetuksella (`{orderNumber}`) lisäosa käyttää käännettävää lähdetekstiä `_x('Order {orderNumber}', 'Payment description for {orderNumber}', ...)`, josta englanninkielinen "Order" tulee. Verifioitu Mollie-lisäosan `PaymentDescriptionMiddleware.php`:sta.

## Muutokset

- **`inc/woocommerce-mollie.php`** — lisätty `gettext_with_context`-suodatin `rytkoset_theme_mollie_finnish_contexts`, joka kääntää lähdetekstin `Order {orderNumber}` → `Tilaus {orderNumber}` fi-localella. Middlewaren paikkamerkkikorvaus muuttaa tämän `Tilaus 1093`:ksi.
- **`docs/woocommerce-mollie-payments.md`** — lisätty osio "Maksusähköpostin aihe (#324)" joka dokumentoi ongelman syyn, ratkaisun ja vaihtoehdon (asetusmuutos vs. koodi).
- **`CHANGELOG.md`** — Fixed-merkintä.

## Testaus

- PHP-syntaksivalidointi Docker-kontissa — ok
- WordPress-bootstrap + `_x()` fi-localella palauttaa `Tilaus {orderNumber}` — verifioitu
- Varsinainen sähköpostin aiheen testaus vaatii julkisen webhook-URL:n (dev/tuotanto), paikallinen localhost ei tavoita Mollien palvelimia

## Huomio

Ratkaisu elää versionhallinnassa (teemakoodi) eikä tietokannassa, joten se toimii automaattisesti kaikissa ympäristöissä. Asetus `WooCommerce → Mollie Settings → Advanced → API Payment Description` tulee pitää oletusarvossaan `{orderNumber}` (tai tyhjänä), jotta käännös vaikuttaa.
