### PR TITLE
feat(woo): add variable product sync support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Added
+- `inc/woocommerce-product-sync.php`: WooCommerce-tuotesynkka tukee nyt `variable`-tuotteiden vientiä, dry-run-esikatselua ja tuontia parent-SKU:n sekä variaatio-SKU:iden perusteella; puuttuvat `pa_*`-termit luodaan olemassa olevaan taksonomiaan ja SKU:ttomat variaatiot estetään (#240).
 - `inc/email.php`: teeman lähettämien `wp_mail()`-viestien (tapahtumailmoittautumiset, järjestäjäilmoitukset, osallistujaviestintä) oletuslähettäjäksi `Rytkösten sukuseura ry` / `rytkoset_theme_get_contact_email()` (`info@rytkoset.net`). Suodattimet korvaavat vain WordPressin oletuslähettäjän (`WordPress <wordpress@…>`), joten WooCommercen omat tilausviestit ja AcyMailing säilyvät koskemattomina.
 - `search.php`: hakutulossivu tuloslistalla (tyyppi, päivämäärä, otsikko, katkelma), tulosmäärällä ja tyhjän haun lomakkeella (#323).
 

--- a/docs/woocommerce-product-sync.md
+++ b/docs/woocommerce-product-sync.md
@@ -25,7 +25,7 @@ ZIP-paketti sisältää:
 - `products.json` — tuotteet rakenteisena JSON-listana
 - `files/` — downloadable-tuotteiden tiedostot (jos tuotteilla on ladattavia tiedostoja)
 
-Tuotteilta joilta puuttuu SKU **ei viedä** — SKU on pakollinen tunniste.
+Tuotteilta joilta puuttuu SKU **ei viedä** — SKU on pakollinen tunniste. Variaatiotuotteilla myös jokaisella variaatiolla pitää olla oma SKU. Jos yksikin valitun variaatiotuotteen variaatio on ilman SKU:ta, vienti estetään selkeällä virheilmoituksella.
 
 ### 2. Tuonti (kohdeympäristö, esim. dev)
 
@@ -42,9 +42,9 @@ Tuotteilta joilta puuttuu SKU **ei viedä** — SKU on pakollinen tunniste.
 | **Uusi** | SKU:ta ei ole kohdeympäristössä — tuote luodaan | päällä |
 | **Päivitetään** | SKU löytyy, kentissä eroja — muuttuvat kentät listataan | päällä |
 | **Identtinen** | SKU löytyy, ei eroja — tuonti ei tee mitään | pois |
-| **VIRHE** | Esim. downloadable-tiedosto puuttuu paketista — tuontia ei sallita | pois (lukittu) |
+| **VIRHE** | Esim. downloadable-tiedosto puuttuu paketista, variaatiolta puuttuu SKU tai `pa_*`-attribuuttitaksonomia puuttuu kohteesta — tuontia ei sallita | pois (lukittu) |
 
-Päivitettävillä tuotteilla esikatselu näyttää kenttäkohtaisen diffin (`vanha → uusi`), joten korvattavat arvot näkee ennen tuontia.
+Päivitettävillä tuotteilla esikatselu näyttää kenttäkohtaisen diffin (`vanha → uusi`), joten korvattavat arvot näkee ennen tuontia. Variaatiotuotteilla esikatselu näyttää lisäksi variaatiokohtaisesti uudet ja päivittyvät variaatiot, niiden attribuuttiarvot sekä hinnan muutokset.
 
 ## Tunnistus: SKU
 
@@ -59,6 +59,23 @@ Tuotteet tunnistetaan **SKU:n** perusteella, ei WordPressin post ID:n. Tämä ta
 Ydinkentät: nimi, slug, status, tuotetyyppi, normaali- ja alennushinta, lyhyt kuvaus ja kuvaus, `Virtual`, `Downloadable`, kategoriat ja tagit.
 
 Kategoriat ja tagit siirretään slugilla. Jos kohdeympäristöstä puuttuu kategoria, se luodaan automaattisesti.
+
+### Variaatiotuotteet
+
+Formaatti `1.1` tukee WooCommercen `variable`-tuotteita. Parent-tuotteelta siirtyvät:
+
+- attribuuttimääritykset (`pa_*`-taksonomia-attribuutit ja custom-attribuutit)
+- oletusattribuutit
+- variaatiot listana: SKU, status, attribuuttiarvot, normaali hinta ja alennushinta
+
+Tuonti luo `WC_Product_Variable`-tuotteen, kun `type` on `variable`. Olemassa oleva parent-tuote tunnistetaan SKU:lla. Variaatiot tunnistetaan ja päivitetään omalla SKU:lla; puuttuvat variaatiot luodaan parentin alle.
+
+Turvallisuusrajaukset:
+
+- Kohteessa olevia mutta paketista puuttuvia variaatioita ei poisteta eikä arkistoida.
+- Puuttuvat termit luodaan olemassa olevaan `pa_*`-taksonomiaan.
+- Puuttuvaa globaalia WooCommerce-attribuuttitaksonomiaa ei luoda automaattisesti; esikatselu näyttää virheen.
+- SKU:ttomia variaatioita ei viedä eikä tuoda, koska päivitystä ei voi tehdä turvallisesti SKU-pohjaisesti.
 
 ### Custom product meta -avaimet
 
@@ -92,7 +109,6 @@ Downloadable-tuotteiden tiedostot pakataan ZIP:in `files/`-hakemistoon. Tuonniss
 
 Työkalu **ei** tällä hetkellä:
 
-- siirrä variable productseja (vaihtelevia tuotteita) — vain `simple`-tuotteet
 - siirrä tilauksia, käyttäjiä, sivuja tai muuta post-dataa
 - tee automaattista ajastettua synkkausta — siirto on aina manuaalinen
 - toimi kaksisuuntaisesti — siirto on push-tyyppinen (lähde → kohde)
@@ -105,3 +121,5 @@ Työkalu **ei** tällä hetkellä:
 - Downloadable-tuote siirtyy tiedostoineen; puuttuva tiedosto estää tuonnin `VIRHE`-tilalla.
 - Puuttuva kategoria luodaan kohdeympäristöön automaattisesti.
 - Custom meta -avaimet (`_rytkoset_membership_*`, `_rytkoset_registration_*`) säilyvät siirrossa.
+- Variaatiotuote voidaan viedä ja tuoda parent-SKU:n sekä variaatio-SKU:iden perusteella.
+- Variaation hinnan muutos näkyy esikatselussa variaatiokohtaisena muutoksena.

--- a/wp-content/themes/rytkoset-theme/inc/woocommerce-product-sync.php
+++ b/wp-content/themes/rytkoset-theme/inc/woocommerce-product-sync.php
@@ -46,7 +46,7 @@ function rytkoset_theme_product_sync_get_temp_base_dir() {
  * Vienti-formaatti versio. Bumppaa jos JSON-rakenne muuttuu.
  */
 function rytkoset_theme_product_sync_get_format_version() {
-	return '1.0';
+	return '1.1';
 }
 
 /**
@@ -119,6 +119,59 @@ function rytkoset_theme_product_sync_render_page() {
 		?>
 	</div>
 	<?php
+}
+
+/**
+ * Renderöi variaatiokohtaiset preview-muutokset.
+ *
+ * @param array<int, array> $variation_changes Variaatiodiffit.
+ * @return void
+ */
+function rytkoset_theme_product_sync_render_variation_changes( $variation_changes ) {
+	foreach ( $variation_changes as $variation_change ) {
+		if ( ! is_array( $variation_change ) ) {
+			continue;
+		}
+
+		$status = isset( $variation_change['status'] ) ? (string) $variation_change['status'] : '';
+		if ( 'identical' === $status ) {
+			continue;
+		}
+
+		$sku        = (string) ( $variation_change['sku'] ?? '' );
+		$attributes = (string) ( $variation_change['attributes'] ?? '' );
+		$changed    = isset( $variation_change['changed'] ) && is_array( $variation_change['changed'] ) ? $variation_change['changed'] : array();
+		?>
+		<li>
+			<code><?php echo esc_html( 'variation:' . $sku ); ?></code>
+			<?php if ( 'new' === $status ) : ?>
+				<?php esc_html_e( 'uusi variaatio', 'rytkoset-theme' ); ?>
+				<?php if ( '' !== $attributes ) : ?>
+					(<?php echo esc_html( $attributes ); ?>)
+				<?php endif; ?>
+			<?php else : ?>
+				<?php if ( '' !== $attributes ) : ?>
+					<?php echo esc_html( $attributes ); ?>:
+				<?php endif; ?>
+				<?php
+				$parts = array();
+				foreach ( $changed as $change ) {
+					if ( ! is_array( $change ) ) {
+						continue;
+					}
+					$parts[] = sprintf(
+						'%1$s: %2$s -> %3$s',
+						(string) ( $change['field'] ?? '' ),
+						(string) ( $change['from'] ?? '' ),
+						(string) ( $change['to'] ?? '' )
+					);
+				}
+				echo esc_html( implode( '; ', $parts ) );
+				?>
+			<?php endif; ?>
+		</li>
+		<?php
+	}
 }
 
 /* ============================================================================
@@ -232,6 +285,7 @@ function rytkoset_theme_product_sync_handle_export() {
 
 	$products_data = array();
 	$files_to_add  = array();
+	$export_errors = array();
 
 	foreach ( $product_ids as $product_id ) {
 		$product = wc_get_product( $product_id );
@@ -240,6 +294,16 @@ function rytkoset_theme_product_sync_handle_export() {
 		}
 
 		$serialized = rytkoset_theme_product_sync_serialize_product( $product );
+		if ( is_wp_error( $serialized ) ) {
+			$export_errors[] = sprintf(
+				'%1$s (%2$s): %3$s',
+				$product->get_name(),
+				$product->get_sku(),
+				$serialized->get_error_message()
+			);
+			continue;
+		}
+
 		if ( null === $serialized ) {
 			continue;
 		}
@@ -248,6 +312,16 @@ function rytkoset_theme_product_sync_handle_export() {
 		foreach ( $serialized['files'] as $filename => $abs_path ) {
 			$files_to_add[ $filename ] = $abs_path;
 		}
+	}
+
+	if ( ! empty( $export_errors ) ) {
+		wp_die(
+			wp_kses_post(
+				'<p>' . esc_html__( 'Vienti estettiin seuraavien tuotekohtaisten virheiden vuoksi:', 'rytkoset-theme' ) . '</p><ul><li>'
+				. implode( '</li><li>', array_map( 'esc_html', $export_errors ) )
+				. '</li></ul>'
+			)
+		);
 	}
 
 	if ( empty( $products_data ) ) {
@@ -297,7 +371,7 @@ add_action( 'admin_post_rytkoset_product_sync_export', 'rytkoset_theme_product_s
  * Serialisoi WC_Product siirtoformaattiin.
  *
  * @param WC_Product $product Tuote.
- * @return array{data: array, files: array<string, string>}|null
+ * @return array{data: array, files: array<string, string>}|WP_Error|null
  */
 function rytkoset_theme_product_sync_serialize_product( $product ) {
 	$sku = (string) $product->get_sku();
@@ -376,10 +450,114 @@ function rytkoset_theme_product_sync_serialize_product( $product ) {
 		'downloadable_files' => $downloads,
 	);
 
+	if ( $product instanceof WC_Product_Variable ) {
+		$variable_data = rytkoset_theme_product_sync_serialize_variable_product_data( $product );
+		if ( is_wp_error( $variable_data ) ) {
+			return $variable_data;
+		}
+
+		$data['attributes']         = $variable_data['attributes'];
+		$data['default_attributes'] = $variable_data['default_attributes'];
+		$data['variations']         = $variable_data['variations'];
+	}
+
 	return array(
 		'data'  => $data,
 		'files' => $files_to_add,
 	);
+}
+
+/**
+ * Serialisoi variable-tuotteen attribuutit ja variaatiot.
+ *
+ * @param WC_Product_Variable $product Variable-tuote.
+ * @return array{attributes: array<int, array>, default_attributes: array<string, string>, variations: array<int, array>}|WP_Error
+ */
+function rytkoset_theme_product_sync_serialize_variable_product_data( $product ) {
+	$attributes = array();
+
+	foreach ( $product->get_attributes() as $attribute ) {
+		if ( ! ( $attribute instanceof WC_Product_Attribute ) ) {
+			continue;
+		}
+
+		$options = array();
+		if ( $attribute->is_taxonomy() ) {
+			foreach ( $attribute->get_options() as $term_id ) {
+				$term = get_term( (int) $term_id, $attribute->get_name() );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$options[] = $term->slug;
+				}
+			}
+		} else {
+			$options = array_map( 'strval', $attribute->get_options() );
+		}
+
+		$attributes[] = array(
+			'name'      => (string) $attribute->get_name(),
+			'taxonomy'  => (bool) $attribute->is_taxonomy(),
+			'position'  => (int) $attribute->get_position(),
+			'visible'   => (bool) $attribute->get_visible(),
+			'variation' => (bool) $attribute->get_variation(),
+			'options'   => $options,
+		);
+	}
+
+	$variations = array();
+	foreach ( $product->get_children() as $variation_id ) {
+		$variation = wc_get_product( (int) $variation_id );
+		if ( ! ( $variation instanceof WC_Product_Variation ) ) {
+			continue;
+		}
+
+		$variation_sku = (string) $variation->get_sku();
+		if ( '' === $variation_sku ) {
+			return new WP_Error(
+				'rytkoset_psync_missing_variation_sku',
+				sprintf(
+					/* translators: %d: variation post ID */
+					__( 'Variaatiolta %d puuttuu SKU. Variaatiotuotteita ei voi synkronoida turvallisesti ilman variaatio-SKU:ta.', 'rytkoset-theme' ),
+					(int) $variation_id
+				)
+			);
+		}
+
+		$variations[] = array(
+			'sku'           => $variation_sku,
+			'status'        => (string) $variation->get_status(),
+			'attributes'    => rytkoset_theme_product_sync_normalize_variation_attributes( $variation->get_variation_attributes() ),
+			'regular_price' => (string) $variation->get_regular_price(),
+			'sale_price'    => (string) $variation->get_sale_price(),
+		);
+	}
+
+	return array(
+		'attributes'         => $attributes,
+		'default_attributes' => array_map( 'strval', $product->get_default_attributes() ),
+		'variations'         => $variations,
+	);
+}
+
+/**
+ * Normalisoi variaatioattribuutit ilman WooCommercen tallennusprefixiä.
+ *
+ * @param array<string, string> $attributes Attribuutit.
+ * @return array<string, string>
+ */
+function rytkoset_theme_product_sync_normalize_variation_attributes( $attributes ) {
+	$normalized = array();
+
+	foreach ( $attributes as $name => $value ) {
+		$name = preg_replace( '/^attribute_/', '', (string) $name );
+		if ( '' === $name ) {
+			continue;
+		}
+		$normalized[ $name ] = (string) $value;
+	}
+
+	ksort( $normalized );
+
+	return $normalized;
 }
 
 /* ============================================================================
@@ -489,9 +667,9 @@ function rytkoset_theme_product_sync_handle_upload() {
 	}
 
 	$version = isset( $manifest['version'] ) ? (string) $manifest['version'] : '';
-	if ( '1.0' !== $version ) {
+	if ( ! in_array( $version, array( '1.0', '1.1' ), true ) ) {
 		rytkoset_theme_product_sync_rrmdir( $session_dir );
-		wp_die( sprintf( esc_html__( 'Tuntematon manifestin versio: %s. Tuetut versiot: 1.0', 'rytkoset-theme' ), esc_html( $version ) ) );
+		wp_die( sprintf( esc_html__( 'Tuntematon manifestin versio: %s. Tuetut versiot: 1.0, 1.1', 'rytkoset-theme' ), esc_html( $version ) ) );
 	}
 
 	$diffs = array();
@@ -536,13 +714,16 @@ add_action( 'admin_post_rytkoset_product_sync_upload', 'rytkoset_theme_product_s
  */
 function rytkoset_theme_product_sync_compute_diff( $incoming, $session_dir ) {
 	$sku           = (string) $incoming['sku'];
+	$type          = isset( $incoming['type'] ) ? (string) $incoming['type'] : 'simple';
 	$existing_id   = wc_get_product_id_by_sku( $sku );
 	$existing      = $existing_id ? wc_get_product( $existing_id ) : null;
 	$status        = $existing ? 'update' : 'new';
 	$changed       = array();
 	$missing_files = array();
+	$errors        = array();
+	$variation_changes = array();
 
-	if ( ! empty( $incoming['downloadable'] ) && ! empty( $incoming['downloadable_files'] ) && is_array( $incoming['downloadable_files'] ) ) {
+	if ( 'variable' !== $type && ! empty( $incoming['downloadable'] ) && ! empty( $incoming['downloadable_files'] ) && is_array( $incoming['downloadable_files'] ) ) {
 		foreach ( $incoming['downloadable_files'] as $file ) {
 			if ( empty( $file['filename'] ) ) {
 				continue;
@@ -555,10 +736,44 @@ function rytkoset_theme_product_sync_compute_diff( $incoming, $session_dir ) {
 	}
 
 	if ( ! empty( $missing_files ) ) {
+		$errors[] = sprintf(
+			/* translators: %s: comma-separated filenames */
+			__( 'Puuttuvat tiedostot: %s', 'rytkoset-theme' ),
+			implode( ', ', $missing_files )
+		);
+	}
+
+	if ( 'variable' === $type ) {
+		$errors = array_merge( $errors, rytkoset_theme_product_sync_validate_variable_import_data( $incoming ) );
+
+		if ( $existing && ! ( $existing instanceof WC_Product_Variable ) ) {
+			$errors[] = __( 'Kohteessa samalla parent-SKU:lla oleva tuote ei ole variaatiotuote.', 'rytkoset-theme' );
+		}
+
+		if ( $existing instanceof WC_Product_Variable ) {
+			$variation_changes = rytkoset_theme_product_sync_compare_variations( $existing, $incoming );
+		} elseif ( ! empty( $incoming['variations'] ) && is_array( $incoming['variations'] ) ) {
+			foreach ( $incoming['variations'] as $variation ) {
+				if ( ! is_array( $variation ) ) {
+					continue;
+				}
+				$variation_changes[] = array(
+					'sku'        => (string) ( $variation['sku'] ?? '' ),
+					'status'     => 'new',
+					'attributes' => rytkoset_theme_product_sync_format_variation_attributes_for_display( isset( $variation['attributes'] ) && is_array( $variation['attributes'] ) ? $variation['attributes'] : array() ),
+					'changed'    => array(),
+				);
+			}
+		}
+	} elseif ( $existing instanceof WC_Product_Variable ) {
+		$errors[] = __( 'Kohteessa samalla SKU:lla oleva tuote on variaatiotuote, mutta tuontidata ei ole.', 'rytkoset-theme' );
+	}
+
+	if ( ! empty( $errors ) ) {
 		$status = 'error';
 	} elseif ( $existing ) {
 		$changed = rytkoset_theme_product_sync_compare_fields( $existing, $incoming );
-		if ( empty( $changed ) ) {
+		if ( empty( $changed ) && ! rytkoset_theme_product_sync_has_variation_changes( $variation_changes ) ) {
 			$status = 'identical';
 		}
 	}
@@ -569,8 +784,189 @@ function rytkoset_theme_product_sync_compute_diff( $incoming, $session_dir ) {
 		'status'        => $status,
 		'changed'       => $changed,
 		'missing_files' => $missing_files,
+		'errors'        => $errors,
+		'variation_changes' => $variation_changes,
 		'existing_id'   => $existing_id,
 	);
+}
+
+/**
+ * Tarkistaa variable-tuonnin ehdot ennen preview/import-vaihetta.
+ *
+ * @param array $incoming Tuleva tuotedata.
+ * @return array<int, string>
+ */
+function rytkoset_theme_product_sync_validate_variable_import_data( $incoming ) {
+	$errors = array();
+
+	$attributes = isset( $incoming['attributes'] ) && is_array( $incoming['attributes'] ) ? $incoming['attributes'] : array();
+	foreach ( $attributes as $attribute ) {
+		if ( ! is_array( $attribute ) || empty( $attribute['name'] ) || empty( $attribute['taxonomy'] ) ) {
+			continue;
+		}
+
+		$taxonomy = sanitize_key( (string) $attribute['name'] );
+		if ( 0 === strpos( $taxonomy, 'pa_' ) && ! taxonomy_exists( $taxonomy ) ) {
+			$errors[] = sprintf(
+				/* translators: %s: product attribute taxonomy */
+				__( 'Attribuuttitaksonomia puuttuu kohteesta: %s.', 'rytkoset-theme' ),
+				$taxonomy
+			);
+		}
+	}
+
+	$variations = isset( $incoming['variations'] ) && is_array( $incoming['variations'] ) ? $incoming['variations'] : array();
+	foreach ( $variations as $variation ) {
+		if ( ! is_array( $variation ) ) {
+			continue;
+		}
+
+		$variation_sku = trim( (string) ( $variation['sku'] ?? '' ) );
+		if ( '' === $variation_sku ) {
+			$errors[] = __( 'Variaatiolta puuttuu SKU.', 'rytkoset-theme' );
+		}
+
+		$variation_attributes = isset( $variation['attributes'] ) && is_array( $variation['attributes'] ) ? $variation['attributes'] : array();
+		foreach ( $variation_attributes as $name => $value ) {
+			$taxonomy = sanitize_key( preg_replace( '/^attribute_/', '', (string) $name ) );
+			if ( 0 === strpos( $taxonomy, 'pa_' ) && ! taxonomy_exists( $taxonomy ) ) {
+				$errors[] = sprintf(
+					/* translators: %s: product attribute taxonomy */
+					__( 'Attribuuttitaksonomia puuttuu kohteesta: %s.', 'rytkoset-theme' ),
+					$taxonomy
+				);
+			}
+		}
+	}
+
+	return array_values( array_unique( $errors ) );
+}
+
+/**
+ * Vertaa olemassa olevan variable-tuotteen variaatioita tulevaan dataan.
+ *
+ * @param WC_Product_Variable $existing Olemassa oleva parent-tuote.
+ * @param array               $incoming Tuleva tuotedata.
+ * @return array<int, array>
+ */
+function rytkoset_theme_product_sync_compare_variations( $existing, $incoming ) {
+	$changes         = array();
+	$existing_by_sku = rytkoset_theme_product_sync_get_child_variations_by_sku( $existing );
+	$variations      = isset( $incoming['variations'] ) && is_array( $incoming['variations'] ) ? $incoming['variations'] : array();
+
+	foreach ( $variations as $variation ) {
+		if ( ! is_array( $variation ) ) {
+			continue;
+		}
+
+		$sku        = (string) ( $variation['sku'] ?? '' );
+		$attributes = isset( $variation['attributes'] ) && is_array( $variation['attributes'] ) ? rytkoset_theme_product_sync_normalize_variation_attributes( $variation['attributes'] ) : array();
+		$row        = array(
+			'sku'        => $sku,
+			'status'     => 'new',
+			'attributes' => rytkoset_theme_product_sync_format_variation_attributes_for_display( $attributes ),
+			'changed'    => array(),
+		);
+
+		if ( '' === $sku || ! isset( $existing_by_sku[ $sku ] ) ) {
+			$changes[] = $row;
+			continue;
+		}
+
+		$existing_variation = $existing_by_sku[ $sku ];
+		$current_attrs      = rytkoset_theme_product_sync_normalize_variation_attributes( $existing_variation->get_variation_attributes() );
+
+		if ( $current_attrs !== $attributes ) {
+			$row['changed'][] = array(
+				'field' => 'attributes',
+				'from'  => rytkoset_theme_product_sync_format_variation_attributes_for_display( $current_attrs ),
+				'to'    => rytkoset_theme_product_sync_format_variation_attributes_for_display( $attributes ),
+			);
+		}
+
+		$price_map = array(
+			'status'        => 'get_status',
+			'regular_price' => 'get_regular_price',
+			'sale_price'    => 'get_sale_price',
+		);
+		foreach ( $price_map as $field => $getter ) {
+			$current = (string) $existing_variation->$getter();
+			$next    = (string) ( $variation[ $field ] ?? '' );
+			if ( $current !== $next ) {
+				$row['changed'][] = array(
+					'field' => $field,
+					'from'  => $current,
+					'to'    => $next,
+				);
+			}
+		}
+
+		$row['status'] = empty( $row['changed'] ) ? 'identical' : 'update';
+		$changes[]     = $row;
+	}
+
+	return $changes;
+}
+
+/**
+ * Palauttaa variable-tuotteen lapsivariaatiot SKU:n mukaan.
+ *
+ * @param WC_Product_Variable $product Parent-tuote.
+ * @return array<string, WC_Product_Variation>
+ */
+function rytkoset_theme_product_sync_get_child_variations_by_sku( $product ) {
+	$variations = array();
+
+	foreach ( $product->get_children() as $variation_id ) {
+		$variation = wc_get_product( (int) $variation_id );
+		if ( ! ( $variation instanceof WC_Product_Variation ) ) {
+			continue;
+		}
+
+		$sku = (string) $variation->get_sku();
+		if ( '' !== $sku ) {
+			$variations[ $sku ] = $variation;
+		}
+	}
+
+	return $variations;
+}
+
+/**
+ * Tarkistaa onko variaatiolistassa tuontia vaativia muutoksia.
+ *
+ * @param array<int, array> $variation_changes Variaatiodiffit.
+ * @return bool
+ */
+function rytkoset_theme_product_sync_has_variation_changes( $variation_changes ) {
+	foreach ( $variation_changes as $change ) {
+		$status = isset( $change['status'] ) ? (string) $change['status'] : '';
+		if ( in_array( $status, array( 'new', 'update', 'error' ), true ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Muotoilee variaatioattribuutit tiiviiksi tekstiksi.
+ *
+ * @param array<string, string> $attributes Attribuutit.
+ * @return string
+ */
+function rytkoset_theme_product_sync_format_variation_attributes_for_display( $attributes ) {
+	if ( empty( $attributes ) ) {
+		return '';
+	}
+
+	ksort( $attributes );
+	$parts = array();
+	foreach ( $attributes as $name => $value ) {
+		$parts[] = $name . '=' . $value;
+	}
+
+	return implode( ', ', $parts );
 }
 
 /**
@@ -587,11 +983,22 @@ function rytkoset_theme_product_sync_compare_fields( $existing, $incoming ) {
 		'name'              => 'get_name',
 		'slug'              => 'get_slug',
 		'status'            => 'get_status',
-		'regular_price'     => 'get_regular_price',
-		'sale_price'        => 'get_sale_price',
 		'short_description' => 'get_short_description',
 		'description'       => 'get_description',
 	);
+
+	if ( 'variable' !== (string) ( $incoming['type'] ?? '' ) ) {
+		$scalar_map['regular_price'] = 'get_regular_price';
+		$scalar_map['sale_price']    = 'get_sale_price';
+	}
+
+	if ( (string) $existing->get_type() !== (string) ( $incoming['type'] ?? 'simple' ) ) {
+		$changes[] = array(
+			'field' => 'type',
+			'from'  => (string) $existing->get_type(),
+			'to'    => (string) ( $incoming['type'] ?? 'simple' ),
+		);
+	}
 
 	foreach ( $scalar_map as $field => $getter ) {
 		$current = (string) $existing->$getter();
@@ -654,7 +1061,117 @@ function rytkoset_theme_product_sync_compare_fields( $existing, $incoming ) {
 		}
 	}
 
+	if ( 'variable' === (string) ( $incoming['type'] ?? '' ) && $existing instanceof WC_Product_Variable ) {
+		$current_attributes = rytkoset_theme_product_sync_normalize_product_attributes_for_compare( $existing->get_attributes() );
+		$next_attributes    = rytkoset_theme_product_sync_normalize_incoming_product_attributes_for_compare( isset( $incoming['attributes'] ) && is_array( $incoming['attributes'] ) ? $incoming['attributes'] : array() );
+
+		if ( $current_attributes !== $next_attributes ) {
+			$changes[] = array(
+				'field' => 'attributes',
+				'from'  => wp_json_encode( $current_attributes, JSON_UNESCAPED_UNICODE ),
+				'to'    => wp_json_encode( $next_attributes, JSON_UNESCAPED_UNICODE ),
+			);
+		}
+
+		$current_default_attributes = array_map( 'strval', $existing->get_default_attributes() );
+		$next_default_attributes    = isset( $incoming['default_attributes'] ) && is_array( $incoming['default_attributes'] ) ? array_map( 'strval', $incoming['default_attributes'] ) : array();
+		ksort( $current_default_attributes );
+		ksort( $next_default_attributes );
+
+		if ( $current_default_attributes !== $next_default_attributes ) {
+			$changes[] = array(
+				'field' => 'default_attributes',
+				'from'  => wp_json_encode( $current_default_attributes, JSON_UNESCAPED_UNICODE ),
+				'to'    => wp_json_encode( $next_default_attributes, JSON_UNESCAPED_UNICODE ),
+			);
+		}
+	}
+
 	return $changes;
+}
+
+/**
+ * Normalisoi olemassa olevat parent-attribuutit vertailua varten.
+ *
+ * @param array<string, WC_Product_Attribute> $attributes Tuoteattribuutit.
+ * @return array<int, array>
+ */
+function rytkoset_theme_product_sync_normalize_product_attributes_for_compare( $attributes ) {
+	$normalized = array();
+
+	foreach ( $attributes as $attribute ) {
+		if ( ! ( $attribute instanceof WC_Product_Attribute ) ) {
+			continue;
+		}
+
+		$options = array();
+		if ( $attribute->is_taxonomy() ) {
+			foreach ( $attribute->get_options() as $term_id ) {
+				$term = get_term( (int) $term_id, $attribute->get_name() );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$options[] = $term->slug;
+				}
+			}
+		} else {
+			$options = array_map( 'strval', $attribute->get_options() );
+		}
+		sort( $options );
+
+		$normalized[] = array(
+			'name'      => (string) $attribute->get_name(),
+			'taxonomy'  => (bool) $attribute->is_taxonomy(),
+			'position'  => (int) $attribute->get_position(),
+			'visible'   => (bool) $attribute->get_visible(),
+			'variation' => (bool) $attribute->get_variation(),
+			'options'   => $options,
+		);
+	}
+
+	usort(
+		$normalized,
+		function ( $a, $b ) {
+			return strcmp( (string) $a['name'], (string) $b['name'] );
+		}
+	);
+
+	return $normalized;
+}
+
+/**
+ * Normalisoi tuontidatan parent-attribuutit vertailua varten.
+ *
+ * @param array<int, array> $attributes Tuontiattribuutit.
+ * @return array<int, array>
+ */
+function rytkoset_theme_product_sync_normalize_incoming_product_attributes_for_compare( $attributes ) {
+	$normalized = array();
+
+	foreach ( $attributes as $attribute ) {
+		if ( ! is_array( $attribute ) || empty( $attribute['name'] ) ) {
+			continue;
+		}
+
+		$options = isset( $attribute['options'] ) && is_array( $attribute['options'] ) ? array_map( 'strval', $attribute['options'] ) : array();
+		sort( $options );
+
+		$normalized[] = array(
+			'name'      => (string) $attribute['name'],
+			'taxonomy'  => ! empty( $attribute['taxonomy'] ),
+			'position'  => (int) ( $attribute['position'] ?? 0 ),
+			'visible'   => ! empty( $attribute['visible'] ),
+			'variation' => ! empty( $attribute['variation'] ),
+			'options'   => $options,
+		);
+	}
+
+	usort(
+		$normalized,
+		function ( $a, $b ) {
+			return strcmp( (string) $a['name'], (string) $b['name'] );
+		}
+	);
+
+	return $normalized;
 }
 
 /**
@@ -748,19 +1265,15 @@ function rytkoset_theme_product_sync_render_preview( $token, $preview ) {
 						<td><code><?php echo esc_html( $d['sku'] ); ?></code></td>
 						<td><?php echo esc_html( $status_label ); ?></td>
 						<td>
-							<?php if ( 'error' === $status && ! empty( $d['missing_files'] ) ) : ?>
+							<?php if ( 'error' === $status && ( ! empty( $d['errors'] ) || ! empty( $d['missing_files'] ) ) ) : ?>
 								<span style="color:#b32d2e;">
 									<?php
-									printf(
-										/* translators: %s: comma-separated filenames */
-										esc_html__( 'Puuttuvat tiedostot: %s', 'rytkoset-theme' ),
-										esc_html( implode( ', ', $d['missing_files'] ) )
-									);
+									echo esc_html( implode( ' ', isset( $d['errors'] ) && is_array( $d['errors'] ) ? $d['errors'] : array() ) );
 									?>
 								</span>
-							<?php elseif ( 'update' === $status && ! empty( $d['changed'] ) ) : ?>
+							<?php elseif ( 'update' === $status && ( ! empty( $d['changed'] ) || ! empty( $d['variation_changes'] ) ) ) : ?>
 								<ul style="margin:0;padding-left:1rem;">
-									<?php foreach ( $d['changed'] as $change ) : ?>
+									<?php foreach ( isset( $d['changed'] ) && is_array( $d['changed'] ) ? $d['changed'] : array() as $change ) : ?>
 										<li>
 											<code><?php echo esc_html( $change['field'] ); ?></code>:
 											<?php echo esc_html( $change['from'] ); ?>
@@ -768,9 +1281,15 @@ function rytkoset_theme_product_sync_render_preview( $token, $preview ) {
 											<?php echo esc_html( $change['to'] ); ?>
 										</li>
 									<?php endforeach; ?>
+									<?php rytkoset_theme_product_sync_render_variation_changes( isset( $d['variation_changes'] ) && is_array( $d['variation_changes'] ) ? $d['variation_changes'] : array() ); ?>
 								</ul>
 							<?php elseif ( 'new' === $status ) : ?>
 								<em><?php esc_html_e( 'Luodaan uusi tuote', 'rytkoset-theme' ); ?></em>
+								<?php if ( ! empty( $d['variation_changes'] ) ) : ?>
+									<ul style="margin:.25rem 0 0;padding-left:1rem;">
+										<?php rytkoset_theme_product_sync_render_variation_changes( isset( $d['variation_changes'] ) && is_array( $d['variation_changes'] ) ? $d['variation_changes'] : array() ); ?>
+									</ul>
+								<?php endif; ?>
 							<?php else : ?>
 								—
 							<?php endif; ?>
@@ -884,18 +1403,25 @@ add_action( 'admin_post_rytkoset_product_sync_import', 'rytkoset_theme_product_s
  * @return string|WP_Error 'created' | 'updated' | WP_Error.
  */
 function rytkoset_theme_product_sync_import_product( $incoming, $session_dir ) {
-	$sku = (string) $incoming['sku'];
+	$sku  = (string) $incoming['sku'];
+	$type = isset( $incoming['type'] ) ? (string) $incoming['type'] : 'simple';
 
 	$existing_id = wc_get_product_id_by_sku( $sku );
 	if ( $existing_id ) {
 		$product = wc_get_product( $existing_id );
 		$action  = 'updated';
+		if ( 'variable' === $type && ! ( $product instanceof WC_Product_Variable ) ) {
+			return new WP_Error( 'rytkoset_psync_type_mismatch', __( 'Kohteessa samalla parent-SKU:lla oleva tuote ei ole variaatiotuote.', 'rytkoset-theme' ) );
+		}
+		if ( 'variable' !== $type && $product instanceof WC_Product_Variable ) {
+			return new WP_Error( 'rytkoset_psync_type_mismatch', __( 'Kohteessa samalla SKU:lla oleva tuote on variaatiotuote, mutta tuontidata ei ole.', 'rytkoset-theme' ) );
+		}
 	} else {
-		$product = new WC_Product_Simple();
+		$product = 'variable' === $type ? new WC_Product_Variable() : new WC_Product_Simple();
 		$action  = 'created';
 	}
 
-	if ( ! $product instanceof WC_Product ) {
+	if ( ! ( $product instanceof WC_Product ) ) {
 		return new WP_Error( 'rytkoset_psync_invalid_product', __( 'Tuoteobjektin luonti epäonnistui.', 'rytkoset-theme' ) );
 	}
 
@@ -907,10 +1433,12 @@ function rytkoset_theme_product_sync_import_product( $incoming, $session_dir ) {
 	}
 
 	$product->set_status( (string) ( $incoming['status'] ?? 'publish' ) );
-	$product->set_regular_price( (string) ( $incoming['regular_price'] ?? '' ) );
-	$product->set_sale_price( (string) ( $incoming['sale_price'] ?? '' ) );
-	$product->set_virtual( ! empty( $incoming['virtual'] ) );
-	$product->set_downloadable( ! empty( $incoming['downloadable'] ) );
+	if ( 'variable' !== $type ) {
+		$product->set_regular_price( (string) ( $incoming['regular_price'] ?? '' ) );
+		$product->set_sale_price( (string) ( $incoming['sale_price'] ?? '' ) );
+		$product->set_virtual( ! empty( $incoming['virtual'] ) );
+		$product->set_downloadable( ! empty( $incoming['downloadable'] ) );
+	}
 	$product->set_short_description( (string) ( $incoming['short_description'] ?? '' ) );
 	$product->set_description( (string) ( $incoming['description'] ?? '' ) );
 
@@ -958,6 +1486,21 @@ function rytkoset_theme_product_sync_import_product( $incoming, $session_dir ) {
 	}
 	$product->set_tag_ids( $tag_ids );
 
+	if ( 'variable' === $type ) {
+		$validation_errors = rytkoset_theme_product_sync_validate_variable_import_data( $incoming );
+		if ( ! empty( $validation_errors ) ) {
+			return new WP_Error( 'rytkoset_psync_invalid_variable', implode( ' ', $validation_errors ) );
+		}
+
+		$attributes = rytkoset_theme_product_sync_build_product_attributes( isset( $incoming['attributes'] ) && is_array( $incoming['attributes'] ) ? $incoming['attributes'] : array() );
+		if ( is_wp_error( $attributes ) ) {
+			return $attributes;
+		}
+
+		$product->set_attributes( $attributes );
+		$product->set_default_attributes( rytkoset_theme_product_sync_prepare_default_attributes( isset( $incoming['default_attributes'] ) && is_array( $incoming['default_attributes'] ) ? $incoming['default_attributes'] : array() ) );
+	}
+
 	// Custom metat — kopioi vain whitelistatut avaimet.
 	$incoming_meta = isset( $incoming['meta'] ) && is_array( $incoming['meta'] ) ? $incoming['meta'] : array();
 	foreach ( rytkoset_theme_product_sync_get_meta_keys() as $key ) {
@@ -969,7 +1512,7 @@ function rytkoset_theme_product_sync_import_product( $incoming, $session_dir ) {
 	}
 
 	// Downloadable: kopioi tiedostot uploads/woocommerce_uploads/-hakemistoon.
-	if ( ! empty( $incoming['downloadable'] ) && ! empty( $incoming['downloadable_files'] ) && is_array( $incoming['downloadable_files'] ) ) {
+	if ( 'variable' !== $type && ! empty( $incoming['downloadable'] ) && ! empty( $incoming['downloadable_files'] ) && is_array( $incoming['downloadable_files'] ) ) {
 		$downloads = array();
 		foreach ( $incoming['downloadable_files'] as $file ) {
 			if ( empty( $file['filename'] ) ) {
@@ -994,7 +1537,7 @@ function rytkoset_theme_product_sync_import_product( $incoming, $session_dir ) {
 			$downloads[] = $download;
 		}
 		$product->set_downloads( $downloads );
-	} elseif ( empty( $incoming['downloadable'] ) ) {
+	} elseif ( 'variable' !== $type && empty( $incoming['downloadable'] ) ) {
 		$product->set_downloads( array() );
 	}
 
@@ -1003,7 +1546,250 @@ function rytkoset_theme_product_sync_import_product( $incoming, $session_dir ) {
 		return new WP_Error( 'rytkoset_psync_save_failed', __( 'Tuotteen tallennus epäonnistui.', 'rytkoset-theme' ) );
 	}
 
+	if ( 'variable' === $type ) {
+		$variation_result = rytkoset_theme_product_sync_import_variations( $product, isset( $incoming['variations'] ) && is_array( $incoming['variations'] ) ? $incoming['variations'] : array() );
+		if ( is_wp_error( $variation_result ) ) {
+			return $variation_result;
+		}
+	}
+
 	return $action;
+}
+
+/**
+ * Rakentaa WooCommercen parent-attribuutit tuontidatasta.
+ *
+ * @param array<int, array> $incoming_attributes Tuontiattribuutit.
+ * @return array<string, WC_Product_Attribute>|WP_Error
+ */
+function rytkoset_theme_product_sync_build_product_attributes( $incoming_attributes ) {
+	$attributes = array();
+
+	foreach ( $incoming_attributes as $incoming_attribute ) {
+		if ( ! is_array( $incoming_attribute ) || empty( $incoming_attribute['name'] ) ) {
+			continue;
+		}
+
+		$is_taxonomy = ! empty( $incoming_attribute['taxonomy'] );
+		$name        = $is_taxonomy ? sanitize_key( (string) $incoming_attribute['name'] ) : sanitize_text_field( (string) $incoming_attribute['name'] );
+		$options_raw = isset( $incoming_attribute['options'] ) && is_array( $incoming_attribute['options'] ) ? $incoming_attribute['options'] : array();
+
+		if ( '' === $name ) {
+			continue;
+		}
+
+		$options = array();
+		if ( $is_taxonomy ) {
+			if ( ! taxonomy_exists( $name ) ) {
+				return new WP_Error(
+					'rytkoset_psync_missing_attribute_taxonomy',
+					sprintf(
+						/* translators: %s: product attribute taxonomy */
+						__( 'Attribuuttitaksonomia puuttuu kohteesta: %s.', 'rytkoset-theme' ),
+						$name
+					)
+				);
+			}
+
+			foreach ( $options_raw as $option ) {
+				$term_id = rytkoset_theme_product_sync_ensure_attribute_term( $name, (string) $option );
+				if ( is_wp_error( $term_id ) ) {
+					return $term_id;
+				}
+				$options[] = $term_id;
+			}
+		} else {
+			$options = array_map( 'strval', $options_raw );
+		}
+
+		$attribute = new WC_Product_Attribute();
+		$attribute->set_id( $is_taxonomy ? rytkoset_theme_product_sync_get_attribute_taxonomy_id( $name ) : 0 );
+		$attribute->set_name( $name );
+		$attribute->set_options( $options );
+		$attribute->set_position( (int) ( $incoming_attribute['position'] ?? 0 ) );
+		$attribute->set_visible( ! empty( $incoming_attribute['visible'] ) );
+		$attribute->set_variation( ! empty( $incoming_attribute['variation'] ) );
+
+		$attributes[ $name ] = $attribute;
+	}
+
+	return $attributes;
+}
+
+/**
+ * Palauttaa WooCommercen globaalin attribuutin ID:n taksonomianimestä.
+ *
+ * @param string $taxonomy Attribuuttitaksonomia, esim. pa_color.
+ * @return int
+ */
+function rytkoset_theme_product_sync_get_attribute_taxonomy_id( $taxonomy ) {
+	if ( ! function_exists( 'wc_attribute_taxonomy_id_by_name' ) ) {
+		return 0;
+	}
+
+	return (int) wc_attribute_taxonomy_id_by_name( preg_replace( '/^pa_/', '', $taxonomy ) );
+}
+
+/**
+ * Luo puuttuvan attribuuttitermin olemassa olevaan taksonomiaan.
+ *
+ * @param string $taxonomy Attribuuttitaksonomia.
+ * @param string $value    Termiarvo tai slug.
+ * @return int|WP_Error
+ */
+function rytkoset_theme_product_sync_ensure_attribute_term( $taxonomy, $value ) {
+	$slug = sanitize_title( $value );
+	if ( '' === $slug ) {
+		return new WP_Error( 'rytkoset_psync_empty_attribute_term', __( 'Attribuuttitermin arvo puuttuu.', 'rytkoset-theme' ) );
+	}
+
+	$term = get_term_by( 'slug', $slug, $taxonomy );
+	if ( $term && ! is_wp_error( $term ) ) {
+		return (int) $term->term_id;
+	}
+
+	$created = wp_insert_term( $value, $taxonomy, array( 'slug' => $slug ) );
+	if ( is_wp_error( $created ) ) {
+		return $created;
+	}
+
+	return (int) $created['term_id'];
+}
+
+/**
+ * Valmistelee parent-tuotteen oletusattribuutit.
+ *
+ * @param array<string, string> $default_attributes Oletusattribuutit.
+ * @return array<string, string>
+ */
+function rytkoset_theme_product_sync_prepare_default_attributes( $default_attributes ) {
+	$prepared = array();
+
+	foreach ( $default_attributes as $name => $value ) {
+		$name = sanitize_key( preg_replace( '/^attribute_/', '', (string) $name ) );
+		if ( '' === $name ) {
+			continue;
+		}
+
+		$prepared[ $name ] = 0 === strpos( $name, 'pa_' ) ? sanitize_title( (string) $value ) : (string) $value;
+	}
+
+	return $prepared;
+}
+
+/**
+ * Luo tai päivittää variable-tuotteen variaatiot SKU-pohjaisesti.
+ *
+ * @param WC_Product $product    Parent-tuote.
+ * @param array      $variations Tuontivariaatiot.
+ * @return true|WP_Error
+ */
+function rytkoset_theme_product_sync_import_variations( $product, $variations ) {
+	if ( ! ( $product instanceof WC_Product_Variable ) ) {
+		return new WP_Error( 'rytkoset_psync_invalid_parent', __( 'Variaatioita voi tuoda vain variaatiotuotteelle.', 'rytkoset-theme' ) );
+	}
+
+	$parent_id       = (int) $product->get_id();
+	$existing_by_sku = rytkoset_theme_product_sync_get_child_variations_by_sku( $product );
+
+	foreach ( $variations as $incoming_variation ) {
+		if ( ! is_array( $incoming_variation ) ) {
+			continue;
+		}
+
+		$sku = trim( (string) ( $incoming_variation['sku'] ?? '' ) );
+		if ( '' === $sku ) {
+			return new WP_Error( 'rytkoset_psync_missing_variation_sku', __( 'Variaatiolta puuttuu SKU.', 'rytkoset-theme' ) );
+		}
+
+		if ( isset( $existing_by_sku[ $sku ] ) ) {
+			$variation = $existing_by_sku[ $sku ];
+		} else {
+			$global_id = wc_get_product_id_by_sku( $sku );
+			if ( $global_id ) {
+				return new WP_Error(
+					'rytkoset_psync_variation_sku_conflict',
+					sprintf(
+						/* translators: %s: variation SKU */
+						__( 'Variaatio-SKU on jo käytössä toisen tuotteen alla: %s.', 'rytkoset-theme' ),
+						$sku
+					)
+				);
+			}
+
+			$variation = new WC_Product_Variation();
+			$variation->set_parent_id( $parent_id );
+		}
+
+		$attributes = rytkoset_theme_product_sync_prepare_variation_attributes( isset( $incoming_variation['attributes'] ) && is_array( $incoming_variation['attributes'] ) ? $incoming_variation['attributes'] : array() );
+		if ( is_wp_error( $attributes ) ) {
+			return $attributes;
+		}
+
+		$variation->set_sku( $sku );
+		$variation->set_status( (string) ( $incoming_variation['status'] ?? 'publish' ) );
+		$variation->set_attributes( $attributes );
+		$variation->set_regular_price( (string) ( $incoming_variation['regular_price'] ?? '' ) );
+		$variation->set_sale_price( (string) ( $incoming_variation['sale_price'] ?? '' ) );
+
+		$saved = $variation->save();
+		if ( ! $saved ) {
+			return new WP_Error(
+				'rytkoset_psync_variation_save_failed',
+				sprintf(
+					/* translators: %s: variation SKU */
+					__( 'Variaation tallennus epäonnistui: %s.', 'rytkoset-theme' ),
+					$sku
+				)
+			);
+		}
+	}
+
+	WC_Product_Variable::sync( $parent_id );
+	wc_delete_product_transients( $parent_id );
+
+	return true;
+}
+
+/**
+ * Valmistelee variaation attribuutit ja luo puuttuvat termit.
+ *
+ * @param array<string, string> $attributes Tuontiattribuutit.
+ * @return array<string, string>|WP_Error
+ */
+function rytkoset_theme_product_sync_prepare_variation_attributes( $attributes ) {
+	$prepared = array();
+
+	foreach ( rytkoset_theme_product_sync_normalize_variation_attributes( $attributes ) as $name => $value ) {
+		$name = sanitize_key( $name );
+		if ( '' === $name ) {
+			continue;
+		}
+
+		if ( 0 === strpos( $name, 'pa_' ) ) {
+			if ( ! taxonomy_exists( $name ) ) {
+				return new WP_Error(
+					'rytkoset_psync_missing_attribute_taxonomy',
+					sprintf(
+						/* translators: %s: product attribute taxonomy */
+						__( 'Attribuuttitaksonomia puuttuu kohteesta: %s.', 'rytkoset-theme' ),
+						$name
+					)
+				);
+			}
+
+			$term_id = rytkoset_theme_product_sync_ensure_attribute_term( $name, (string) $value );
+			if ( is_wp_error( $term_id ) ) {
+				return $term_id;
+			}
+
+			$prepared[ $name ] = sanitize_title( (string) $value );
+		} else {
+			$prepared[ $name ] = (string) $value;
+		}
+	}
+
+	return $prepared;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add WooCommerce product sync support for `variable` products
- Export/import parent attributes, default attributes, and child variations by SKU
- Show variation-level changes in dry-run preview
- Document the new variable product sync behavior and safety limits

## Testing
- `git diff --check`
- Not run: `php -l` because `php`/`docker` were not available in this environment
- Not run: WP admin export/import smoke test; requires local WordPress runtime