### PR TITLE
fix(security): aja author enumeration -esto ennen redirect_canonicalia (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 - `search.php`: hakutulossivu tuloslistalla (tyyppi, päivämäärä, otsikko, katkelma), tulosmäärällä ja tyhjän haun lomakkeella (#323).
 
 ### Fixed
+- `inc/security.php`: author enumeration -esto (`?author=N`) ei käytännössä estänyt kirjautumisnimen paljastumista, koska se oli kytketty `template_redirect`-koukkuun coren `redirect_canonical()`:n kanssa samalla oletusprioriteetilla (10) mutta rekisteröitynä sen jälkeen. Core ehti ohjata `/author/<slug>/`-osoitteeseen (301) ja paljastaa kirjautumisnimen ennen estoa kaikille tekijöille, joilla on julkaistuja postauksia. Esto ajetaan nyt prioriteetilla 0, ennen corea (#336).
 - Mollien maksusähköpostin aiheen englanninkielinen `Order ####` suomennettiin muotoon `Tilaus ####`: `inc/woocommerce-mollie.php` käsittelee `gettext_with_context`-suodattimella Mollie-lisäosan maksukuvauksen lähdetekstin `Order {orderNumber}` ja kääntää sen `Tilaus {orderNumber}`, jolloin Mollien lähettämän maksusähköpostin aiheeksi tulee esim. `Maksutiedot tilauksestasi "Tilaus 1093"` (#324).
 - Mobiilihakuformi (≤920px) vuosi viewportin yli vasemmalle, koska formi oli positioitu suhteessa pieneen hakupainikkeeseen. Formi positioituu nyt `.site-header__primary-inner` -elementtiin (`position: relative`) ja `left: 0; right: 0; box-sizing: border-box` pinssaa sen tarkasti headerin leveyteen (#323).
 

--- a/wp-content/themes/rytkoset-theme/inc/security.php
+++ b/wp-content/themes/rytkoset-theme/inc/security.php
@@ -94,7 +94,10 @@ if ( ! function_exists( 'rytkoset_theme_block_author_enumeration' ) ) {
 		exit;
 	}
 }
-add_action( 'template_redirect', 'rytkoset_theme_block_author_enumeration' );
+// Prioriteetti 0 ajaa eston ennen coren redirect_canonical()-funktiota
+// (template_redirect, prioriteetti 10), joka muutoin ohjaisi `?author=N` ->
+// `/author/<slug>/` ja paljastaisi kirjautumisnimen jo ennen tätä estoa.
+add_action( 'template_redirect', 'rytkoset_theme_block_author_enumeration', 0 );
 
 if ( ! function_exists( 'rytkoset_theme_xmlrpc_disabled' ) ) {
 	/**


### PR DESCRIPTION
## Mitä

Korjaa author enumeration -eston ([#339](https://github.com/Alpine78/rytkoset-wp/issues/339)), joka ei käytännössä estänyt kirjautumisnimen paljastumista.

`rytkoset_theme_block_author_enumeration` oli kytketty `template_redirect`-koukkuun oletusprioriteetilla 10 — samalla kuin coren `redirect_canonical()`, mutta rekisteröitynä sen jälkeen. Samalla prioriteetilla callbackit ajetaan rekisteröintijärjestyksessä, joten core ajettiin ensin: se ohjasi `?author=N` -> `/author/<slug>/` (301) ja kutsui `exit` ennen teeman estoa kaikille tekijöille, joilla on julkaistuja postauksia → kirjautumisnimi (nicename) vuoti edelleen.

## Korjaus

- `inc/security.php`: esto rekisteröidään prioriteetilla `0`, jolloin se ajetaan ennen corea. Funktio lukee vain `$_GET['author']`-arvoa, joten se toimii prioriteetilla 0.
- Lisätty selittävä kommentti prioriteetin syystä.
- `CHANGELOG.md`: merkintä `[Unreleased] → Fixed`.

## Testaus (dev)

- Uloskirjautuneena `/?author=1` → ohjaa etusivulle (ei `/author/<slug>/`).
- `/author/<slug>/` (suora slug) → toimii edelleen normaalisti.
- Kirjautuneena admin/editor-toiminta (esim. blokkieditorin tekijävalinta) ennallaan.

Closes #339 · liittyy #336
