### PR TITLE
perf(theme): replace style.css @import chain with separate enqueues (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 ## [Unreleased]
 
 ### Changed
+- `style.css` / `functions.php`: teeman CSS-moduulit ladataan nyt erillisinä `wp_enqueue_style()`-kutsuina `@import`-ketjun sijaan. `@import` lataa moduulit sarjallisesti ja renderöintiä estäen; erilliset enqueuet latautuvat rinnakkain. Kaskadijärjestys (base → layout/components → … → responsive viimeisenä) säilytetään riippuvuusketjulla, ja sivukohtaiset tyylit (shop, forum, digital-magazine, gallery) riippuvat viimeisestä moduulista kuten ennenkin. Cache-bustaus `filemtime()`-pohjaisesti. Ei build-stepiä (#343).
 - `assets/css/nav.css`: poistettu orpo tiedosto. Sitä ei ladattu mistään (ei `style.css`:n `@import`-listassa eikä `wp_enqueue_style()`-kutsussa); navigaatio ladataan moduuleina `nav.base.css`, `nav.desktop.css`, `nav.account.css` ja `nav.mobile.css`. Kuollutta koodia navigaation refaktoroinnista, ei toiminnallista vaikutusta (#341).
 - `docs/woocommerce-membership-products.md`: korjattu ainaisjäsenmaksun kassakäytön testausohje vastaamaan toteutusta; myös ainaisjäsenmaksu aktivoi jäsenrekisteriin tarvittavien tietojen muistiinpano-ohjeen (#359).
 - `README.md`: päivitetty projektin nykyinen paikallinen kehitys, branch/deploy-malli, validointi, rakenne ja dokumentaatiolinkit; poistettu vanhentunut `main` -> dev -deploy-kuvaus ja rajattu agentti-/työskentelyohjeet viittauksiksi `AGENTS.md`, `CONTRIBUTING.md` ja `CLAUDE.md` -tiedostoihin.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,22 +110,29 @@ All functions use `if ( ! function_exists('rytkoset_theme_...') )` guard and `ry
 
 ### CSS structure
 
-`style.css` imports all modules; no build step:
+No build step. `style.css` holds only the theme header — the core CSS modules are enqueued separately in `functions.php` (`rytkoset_theme_scripts`) via a `$css_modules` loop that chains each module's `deps` to the previous one, preserving cascade order (base → layout/components → … → responsive last). Page-specific styles (shop, forum, digital-magazine, gallery) depend on the last core module so they load after it. Cache-busted with `filemtime()`. The modules in cascade order:
 
 ```
+# Core modules, loaded site-wide in cascade order:
 assets/css/base.css          # Typography, color variables, base elements
 assets/css/layout.css        # Containers, grids, sections
+assets/css/hero.css          # Front page hero section (split layout with illustration)
+assets/css/home.css          # Front page content bands (alternating light/dark, feature + story)
+assets/css/404.css           # 404 page
 assets/css/components.css    # Buttons, cards, general components
 assets/css/nav.base.css      # Shared navigation styles
 assets/css/nav.desktop.css   # Desktop navigation
-assets/css/nav.mobile.css    # Mobile navigation (hamburger)
 assets/css/nav.account.css   # User/account menu
-assets/css/hero.css          # Front page hero section (split layout with illustration)
-assets/css/home.css          # Front page content bands (alternating light/dark, feature + story)
-assets/css/gallery.css       # Gallery and albums
+assets/css/nav.mobile.css    # Mobile navigation (hamburger)
 assets/css/footer.css        # Footer
-assets/css/login.css         # WP login page branding
-assets/css/responsive.css    # Media queries
+assets/css/responsive.css    # Media queries (last)
+
+# Page-specific modules, enqueued conditionally:
+assets/css/shop.css          # WooCommerce shop/cart/checkout
+assets/css/forum.css         # bbPress forum
+assets/css/digital-magazine.css  # Digital magazine pages
+assets/css/gallery.css       # Gallery and albums
+assets/css/login.css         # WP login page branding (enqueued in inc/login.php)
 ```
 
 Use CSS variables for colors and spacing. No Bootstrap dependency.

--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -432,13 +432,52 @@ add_filter( 'woocommerce_add_error', 'rytkoset_theme_deduplicate_woocommerce_err
 function rytkoset_theme_scripts() {
 	$theme_version = wp_get_theme()->get( 'Version' );
 
-    // Teeman päätyyli (style.css) – WordPress hoitaa tämän usein automaattisesti, mutta tehdään eksplisiittisesti.
+    // Teeman päätyyli (style.css) – sisältää enää teemaotsakkeen. Pidetään
+    // enqueutettuna moduuliketjun juurena (ja jotta WordPress näkee teeman tyylin).
     wp_enqueue_style(
         'rytkoset-theme-style',
         get_stylesheet_uri(),
         array(),
         $theme_version
     );
+
+    // Teeman CSS-moduulit kaskadijärjestyksessä. Korvaa style.css:n vanhan
+    // @import-ketjun erillisillä enqueueilla, jotta selain voi ladata moduulit
+    // rinnakkain. Jokainen moduuli riippuu edellisestä, joten latausjärjestys
+    // (base → layout/components → … → responsive viimeisenä) säilyy.
+    $css_modules = array(
+        'rytkoset-theme-base'        => 'base.css',
+        'rytkoset-theme-layout'      => 'layout.css',
+        'rytkoset-theme-hero'        => 'hero.css',
+        'rytkoset-theme-home'        => 'home.css',
+        'rytkoset-theme-404'         => '404.css',
+        'rytkoset-theme-components'  => 'components.css',
+        'rytkoset-theme-nav-base'    => 'nav.base.css',
+        'rytkoset-theme-nav-desktop' => 'nav.desktop.css',
+        'rytkoset-theme-nav-account' => 'nav.account.css',
+        'rytkoset-theme-nav-mobile'  => 'nav.mobile.css',
+        'rytkoset-theme-footer'      => 'footer.css',
+        'rytkoset-theme-responsive'  => 'responsive.css',
+    );
+
+    $previous_css_handle = 'rytkoset-theme-style';
+    foreach ( $css_modules as $handle => $filename ) {
+        $module_path    = get_template_directory() . '/assets/css/' . $filename;
+        $module_version = file_exists( $module_path ) ? (string) filemtime( $module_path ) : $theme_version;
+
+        wp_enqueue_style(
+            $handle,
+            get_template_directory_uri() . '/assets/css/' . $filename,
+            array( $previous_css_handle ),
+            $module_version
+        );
+
+        $previous_css_handle = $handle;
+    }
+
+    // Ehdolliset (sivukohtaiset) tyylit ladataan moduuliketjun jälkeen, jotta
+    // ne pääsevät yliajamaan perustyylit kuten ennenkin.
+    $core_css_dependency = $previous_css_handle;
 
     // Mobiilivalikon JS
     wp_enqueue_script(
@@ -470,7 +509,7 @@ function rytkoset_theme_scripts() {
 		wp_enqueue_style(
 			'rytkoset-theme-shop',
 			get_template_directory_uri() . '/assets/css/shop.css',
-			array( 'rytkoset-theme-style' ),
+			array( $core_css_dependency ),
 			$shop_style_version
 		);
 
@@ -498,7 +537,7 @@ function rytkoset_theme_scripts() {
 		wp_enqueue_style(
 			'rytkoset-theme-forum',
 			get_template_directory_uri() . '/assets/css/forum.css',
-			array( 'rytkoset-theme-style' ),
+			array( $core_css_dependency ),
 			$theme_version
 		);
 	}
@@ -507,7 +546,7 @@ function rytkoset_theme_scripts() {
 		wp_enqueue_style(
 			'rytkoset-theme-digital-magazine',
 			get_template_directory_uri() . '/assets/css/digital-magazine.css',
-			array( 'rytkoset-theme-style' ),
+			array( $core_css_dependency ),
 			$theme_version
 		);
 	}
@@ -560,7 +599,7 @@ function rytkoset_theme_scripts() {
         wp_enqueue_style(
             'rytkoset-theme-gallery',
             get_template_directory_uri() . '/assets/css/gallery.css',
-            array( 'rytkoset-theme-style' ),
+            array( $core_css_dependency ),
             $theme_version
         );
 

--- a/wp-content/themes/rytkoset-theme/style.css
+++ b/wp-content/themes/rytkoset-theme/style.css
@@ -8,33 +8,10 @@ Version: 1.0.0
 Text Domain: rytkoset-theme
 */
 
-/* Perustyylit ja värit */
-@import url("assets/css/base.css");
-
-/* Layout: containerit, sectionit, gridit */
-@import url("assets/css/layout.css");
-
-/* Hero-osio etusivulla */
-@import url("assets/css/hero.css");
-
-/* Etusivun sisältölohkot (vaalea/tumma-vuorottelu) */
-@import url("assets/css/home.css");
-
-/* 404-sivu (kadonnut oksa sukupuussa) */
-@import url("assets/css/404.css");
-
-/* Komponentit: napit, kortit jne. */
-@import url("assets/css/components.css");
-
-/* Navigaatio: header + mobiilivalikko */
-@import url("assets/css/nav.base.css");
-@import url("assets/css/nav.desktop.css");
-@import url("assets/css/nav.account.css");
-@import url("assets/css/nav.mobile.css");
-
-/* Footer */
-@import url("assets/css/footer.css?v=266-3");
-
-
-/* Media queryt */
-@import url("assets/css/responsive.css");
+/*
+ * Teeman CSS-moduulit ladataan erillisinä wp_enqueue_style()-kutsuina
+ * functions.php:ssä (rytkoset_theme_scripts), ei @import-ketjuna.
+ * @import lataa moduulit sarjallisesti ja renderöintiä estäen; erilliset
+ * enqueuet latautuvat rinnakkain. Kaskadijärjestys säilytetään
+ * riippuvuusketjulla (base → … → responsive viimeisenä).
+ */


### PR DESCRIPTION
## Summary

`style.css` latasi 12 CSS-moduulia `@import url(...)` -direktiiveillä. `@import` on
suorituskyvyn anti-pattern: selain lataa ensin `style.css`:n, löytää importit ja
lataa vasta sitten moduulit — sarjallisesti ja renderöintiä estäen. Moduulit
enqueutetaan nyt erikseen `wp_enqueue_style()`-kutsuilla, jolloin selain voi
ladata ne rinnakkain. Ei build-stepiä (linjassa "no Node tooling" -periaatteen kanssa).

## Implementation

- `style.css`: poistettu `@import`-ketju; jäljellä vain teemaotsake.
- `functions.php` (`rytkoset_theme_scripts`): `$css_modules`-silmukka enqueuettaa
  12 moduulia. Kukin moduuli listaa edellisen `deps`-riippuvuudekseen, mikä
  säilyttää kaskadijärjestyksen (base → layout/components → … → responsive
  viimeisenä).
- Sivukohtaiset tyylit (shop, forum, digital-magazine, gallery) riippuvat nyt
  viimeisestä ydinmoduulista (`$core_css_dependency`) entisen
  `rytkoset-theme-style`-handlen sijaan, joten ne latautuvat edelleen
  perustyylien jälkeen.
- Cache-bustaus `filemtime()`-pohjaisesti, fallback teeman versioon. Samalla
  poistui `footer.css`:n vanha manuaalinen `?v=266-3`-query string.
- `CLAUDE.md` (CSS structure) ja `CHANGELOG.md` päivitetty.

## Validation

- ⚠️ PHP-lintiä ei voitu ajaa paikallisesti (ei php/dockeria ympäristössä) —
  CI ajaa `php -l`.
- Latausjärjestys ja riippuvuusketju tarkistettu vastaamaan aiempaa
  `@import`-järjestystä.
- Suosittelen visuaalista tarkistusta devissä: etusivu, kauppa, galleria ja
  footer (mobiili + tumma teema + näkyvä fokus), koska muutos koskee koko
  sivuston tyylinlatausta.

## Scope

Matala prioriteetti — mitattava mutta pieni suorituskykyhyöty tällä sivumäärällä.
Ei toiminnallisia muutoksia, vain tyylinlatauksen mekanismi.
