### PR TITLE
fix(digilehdet): jäsenyys-CTA kirjautuneelle ei-jäsenelle

### DIFF
--- a/wp-content/themes/rytkoset-theme/template-parts/digital-magazine-locked.php
+++ b/wp-content/themes/rytkoset-theme/template-parts/digital-magazine-locked.php
@@ -22,13 +22,27 @@ $rytkoset_secondary_url   = '';
 $rytkoset_secondary_label = '';
 
 if ( 'members_only' === $rytkoset_locked_mode ) {
-	$rytkoset_locked_heading  = __( 'Digilehti on jäsenille', 'rytkoset-theme' );
-	$rytkoset_locked_message  = __(
-		'Aktiiviset jäsenet voivat lukea tämän digilehden kirjautumisen jälkeen. Jos et ole jäsen, voit tutustua jäsenyyteen.',
-		'rytkoset-theme'
-	);
-	$rytkoset_secondary_url   = $rytkoset_membership_url;
-	$rytkoset_secondary_label = __( 'Tutustu jäsenyyteen', 'rytkoset-theme' );
+	$rytkoset_locked_heading = __( 'Digilehti on jäsenille', 'rytkoset-theme' );
+
+	if ( is_user_logged_in() ) {
+		// Already logged in but not an active member: point straight to membership.
+		$rytkoset_locked_message  = __(
+			'Tämä digilehti on tarkoitettu seuran jäsenille. Tutustu jäsenyyteen, niin saat lehden luettavaksi.',
+			'rytkoset-theme'
+		);
+		$rytkoset_primary_url     = $rytkoset_membership_url;
+		$rytkoset_primary_label   = __( 'Tutustu jäsenyyteen', 'rytkoset-theme' );
+		$rytkoset_secondary_url   = '';
+		$rytkoset_secondary_label = '';
+	} else {
+		// Logged out: log in first, membership info as secondary action.
+		$rytkoset_locked_message  = __(
+			'Aktiiviset jäsenet voivat lukea tämän digilehden kirjautumisen jälkeen. Jos et ole jäsen, voit tutustua jäsenyyteen.',
+			'rytkoset-theme'
+		);
+		$rytkoset_secondary_url   = $rytkoset_membership_url;
+		$rytkoset_secondary_label = __( 'Tutustu jäsenyyteen', 'rytkoset-theme' );
+	}
 } elseif ( 'member_and_regular' === $rytkoset_locked_mode ) {
 	$rytkoset_locked_heading  = __( 'Digilehti vaatii oston', 'rytkoset-theme' );
 	$rytkoset_locked_message  = __(


### PR DESCRIPTION
## Yhteenveto

Pieni UX-korjaus digilehden lukkonäkymään (`members_only`-tila): kirjautunut
ei-jäsen sai aiemmin epäluontevan "Kirjaudu sisään" -pää-CTA:n, vaikka oli jo
sisällä. Nyt hänelle näytetään suoraan "Tutustu jäsenyyteen" sopivalla viestillä.

Löytyi koodikatselmuksessa, jossa varmistettiin tiketin #200 toteutuksen
asiallisuus — kaikki muut hyväksymiskriteerit täyttyivät jo ennestään.

## Muutos

`template-parts/digital-magazine-locked.php` (vain `members_only`-haara):

- **Kirjautumaton** (ennallaan): primary = "Kirjaudu sisään", secondary =
  "Tutustu jäsenyyteen".
- **Kirjautunut ei-jäsen** (uusi): primary = "Tutustu jäsenyyteen", ei
  secondaryä. Viesti vaihtuu: *"Tämä digilehti on tarkoitettu seuran
  jäsenille. Tutustu jäsenyyteen, niin saat lehden luettavaksi."*

`member_and_regular` ja `paid` säilyvät ennallaan — niissä on kyse ostosta,
ei kirjautumistilasta. Käyttöoikeustarkistus
(`rytkoset_theme_user_can_read_digital_magazine`) ei muutu.

## Validointi

- [x] `php -l` puhdas
- [ ] Manuaalinen selaintesti kirjautuneella ei-jäsenellä lukitulla
      `members_only`-lehdellä
- [ ] Manuaalinen selaintesti kirjautumattomalla samalla lehdellä

## Liittyvät tiketit

Jatkoa: #200 (digilehden käyttöoikeustarkistus, jo mergetty PR #419:ssä).