### PR TITLE
Claude/user registration spam v1qkwe

### DIFF
--- a/wp-content/themes/rytkoset-theme/inc/security.php
+++ b/wp-content/themes/rytkoset-theme/inc/security.php
@@ -331,6 +331,23 @@ if ( ! function_exists( 'rytkoset_theme_filter_registration_spam' ) ) {
 			return $errors;
 		}
 
+		$email  = strtolower( $user_email );
+		$at     = strrpos( $email, '@' );
+		$local  = false !== $at ? substr( $email, 0, $at ) : $email;
+		$domain = false !== $at ? substr( $email, $at + 1 ) : $email;
+
+		// RFC 5321: paikallisosa ei saa päättyä pisteeseen.
+		if ( str_ends_with( $local, '.' ) ) {
+			$errors->add( 'rytkoset_blocked_email', __( 'Tällä sähköpostiosoitteella ei voi rekisteröityä.', 'rytkoset-theme' ) );
+			return $errors;
+		}
+
+		// Yli 6 pistettä paikallisosassa on botti-signaali (normaali nimi ei käytä niitä näin paljon).
+		if ( substr_count( $local, '.' ) > 6 ) {
+			$errors->add( 'rytkoset_blocked_email', __( 'Tällä sähköpostiosoitteella ei voi rekisteröityä.', 'rytkoset-theme' ) );
+			return $errors;
+		}
+
 		/**
 		 * Suodata estetyt sähköpostidomainin päätteet (esim. `.casino`).
 		 * Vertailu tehdään domainin loppuosaan.
@@ -341,10 +358,6 @@ if ( ! function_exists( 'rytkoset_theme_filter_registration_spam' ) ) {
 			'rytkoset_theme_blocked_registration_email_patterns',
 			array( '.casino', '.bet', '.poker' )
 		);
-
-		$email  = strtolower( $user_email );
-		$at     = strrpos( $email, '@' );
-		$domain = false !== $at ? substr( $email, $at + 1 ) : $email;
 
 		foreach ( $blocked as $pattern ) {
 			$pattern = strtolower( (string) $pattern );


### PR DESCRIPTION
## Yhteenveto

Parannetaan rekisteröitymislomakkeen roskasuodatusta kahdella lisätarkistuksella `inc/security.php`:ssä (`rytkoset_theme_filter_registration_spam`).

## Muutokset

- **Piste paikallisosan lopussa** — hylkää sähköpostit, joiden paikallisosa päättyy pisteeseen ennen `@`-merkkiä (esim. `ks888.@gmail.com`). RFC 5321 -vastainen, ei koskaan aito osoite.
- **Yli 6 pistettä paikallisosassa** — hylkää sähköpostit, joissa paikallisosassa on enemmän kuin 6 pistettä. Normaali ihminen ei käytä näin montaa pistettä sähköpostinimessä; tyypillinen botti-signaali.

## Tausta

Laukaisijana roskarekisteröityminen (`bivfrow` / `b.i.vi.to.n.ly.f.re.ndli.ch.t.i.m.e.w.o.r.ks888.@gmail.com`), joka läpäisi honeypot-tarkistuksen ja TLD-eston, koska domain oli `gmail.com`. Molemmat uudet tarkistukset olisivat hylänneet sen.

## Validointi

- PHP-syntaksivalidointi (`php -l`) läpäisty
- Olemassa olevat rekisteröintiestojen rakenteet säilyvät ennallaan