### PR TITLE
fix(events): show price text for free events with a Hintateksti value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 
 ## [Unreleased]
 
+### Fixed
+- `inc/events.php` / `tests/EventDisplayTest.php`: maksuttoman tapahtuman hintateksti näkyy nyt tapahtumasivun HINTA-rivillä (#464). `rytkoset_theme_get_event_fee_display()` näytti maksuttomalle tapahtumalle (`Maksullisuus = Maksuton`) aina kovakoodatun "Maksuton"-tekstin `Hintateksti`-kentän sisällöstä riippumatta — esim. Tampereen sukujuhlien bussikyydin ehdollista jälkikäteisveloitusta ("45 € (maksetaan myöhemmin, jos ilmoittautuneita on vähintään 20)") ei saanut näkyviin ilman, että samalla piti vaihtaa Maksullisuus tilaan "Ei määritelty" — mikä puolestaan piilotti vapaan ilmoittautumislomakkeen kokonaan (`rytkoset_theme_event_can_show_free_registration_form()` vaatii `fee_type === 'free'`). Korjattu niin, että `free`-tapahtuma näyttää `price_text`-kentän (muotoiltuna kuten `paid`-haarassa) kun se on asetettu, ja palaa oletustekstiin "Maksuton" vain kun kenttä on tyhjä; ilmoittautumislomakkeen näyttöehto ei muuttunut. Lisätty 1 PHPUnit-testi. php -l + phpcs + 362 PHPUnit-testiä vihreät (#464).
+
 ## [1.1.0] - 2026-06-29
 
 Jäsenyys ja jäsenedut (EPIC 10) sekä digilehdet (EPIC 9): manuaalinen ja WooCommerce-tilauksesta automaattinen jäsenyysstatus jaetulla aktiivisuusportilla, vain jäsenille -sivut ja -alennuskuponki, porrastettu digilehtien käyttöoikeus kahden tuotteen jäsen-/normaalihintamallilla sekä manuaaliset käyttöoikeudet. Lisäksi uudelleenkäytettävä tapahtumailmoittautumisen lisäkenttäkonfiguraatio (Tampere 2026 -bussikyyti), lainmukainen itsepalvelutilausperuutus, schema.org/JSON-LD-strukturoitu data, tietoturva- ja tietosuojakovennukset sekä uusi tietokannaton PHPUnit-harness ja WordPress Coding Standards kovina CI-portteina.

--- a/docs/woocommerce-tampere-2026-bussikyyti.md
+++ b/docs/woocommerce-tampere-2026-bussikyyti.md
@@ -13,7 +13,7 @@ Tämä dokumentti kuvaa tiketin `#450` toimintamallin: bussikyydin (esim. Savo�
 ## Vaihe 1 — Bussikyytitapahtuman luonti (ylläpito)
 
 1. **Tapahtumat → Lisää uusi.** Anna otsikko (esim. *Bussikyyti Tampereen sukujuhliin*), kuvaus ja ajankohta.
-2. **Tapahtuman tiedot** -laatikko: aseta **Maksullisuus = Maksuton**. (Bussikyyti kerätään maksuttomalla lomakkeella; varsinainen maksu hoidetaan myöhemmin erikseen.) Poista tarvittaessa valinta **Kysy ruokavaliorajoitteet ja allergiat** — bussikyydissä ei ole tarjoiluita.
+2. **Tapahtuman tiedot** -laatikko: aseta **Maksullisuus = Maksuton**. (Bussikyyti kerätään maksuttomalla lomakkeella; varsinainen maksu hoidetaan myöhemmin erikseen.) Poista tarvittaessa valinta **Kysy ruokavaliorajoitteet ja allergiat** — bussikyydissä ei ole tarjoiluita. Kirjoita **Hintateksti**-kenttään ehdollinen maksuselite, esim. `45 € (maksetaan myöhemmin, jos ilmoittautuneita on vähintään 20)` — teksti näkyy tapahtumasivun HINTA-rivillä "Maksuton"-tekstin sijaan (#464).
 3. **Ilmoittautumisen lisävalinta** -laatikko:
    - Rastita **Lisää valintalista ilmoittautumislomakkeelle**.
    - **Kentän nimi**: `Lähtöpaikka`.

--- a/tests/EventDisplayTest.php
+++ b/tests/EventDisplayTest.php
@@ -23,6 +23,13 @@ final class EventDisplayTest extends Rytkoset_Theme_Test_Case {
 		$this->assertSame( 'Maksuton', rytkoset_theme_get_event_fee_display( 10 ) );
 	}
 
+	public function test_free_event_with_price_text_shows_formatted_price_text(): void {
+		update_post_meta( 10, $this->keys()['fee_type'], 'free' );
+		update_post_meta( 10, $this->keys()['price_text'], '45' );
+
+		$this->assertSame( '45 €', rytkoset_theme_get_event_fee_display( 10 ) );
+	}
+
 	public function test_paid_event_with_price_is_formatted(): void {
 		update_post_meta( 10, $this->keys()['fee_type'], 'paid' );
 		update_post_meta( 10, $this->keys()['price_text'], '12,50' );

--- a/wp-content/themes/rytkoset-theme/inc/events.php
+++ b/wp-content/themes/rytkoset-theme/inc/events.php
@@ -395,6 +395,10 @@ function rytkoset_theme_get_event_fee_display( $event_id ) {
 	$fee_type   = rytkoset_theme_get_event_fee_type( $event_id );
 	$price_text = rytkoset_theme_get_event_price_text( $event_id );
 
+	if ( 'free' === $fee_type && '' !== $price_text ) {
+		return rytkoset_theme_format_event_price_text( $price_text );
+	}
+
 	if ( 'free' === $fee_type ) {
 		return __( 'Maksuton', 'rytkoset-theme' );
 	}


### PR DESCRIPTION
## Summary

- Hotfix (#464), cherry-picked from `dev` (commit `62cc3f8`) to `main` **on its own**, without the rest of `dev`'s history (which still includes the unfinished AI support chat feature, #461, not ready for production).
- Free events now show the configured `Hintateksti` price note instead of a hardcoded "Maksuton" label, so a conditional after-the-fact charge (e.g. the bus trip's "45 € if ≥20 sign up") can be communicated without disabling the free registration form.

## Changes

- `wp-content/themes/rytkoset-theme/inc/events.php`: `rytkoset_theme_get_event_fee_display()` now returns the formatted `price_text` for `free`-type events when one is set, falling back to the previous hardcoded "Maksuton" only when it's empty. Registration-form visibility logic (`inc/event-registrations.php`) is untouched.
- `tests/EventDisplayTest.php`: added `test_free_event_with_price_text_shows_formatted_price_text`.
- `docs/woocommerce-tampere-2026-bussikyyti.md`: documented that the Hintateksti field can now carry the conditional charge note for free events.
- `CHANGELOG.md`: entry under `[Unreleased] / Fixed`.

## Testing

- `php -l` — no syntax errors.
- `composer run lint` (phpcs / WPCS) — clean.
- `composer run test` (PHPUnit) — 310 tests, all green (this branch's smaller suite matches `main`, plus the 1 new test).

## Notes

- This branch is `main` + only this one commit (verified via `git diff main --stat`) — it intentionally does **not** include the chat feature or anything else from `dev`.
- `dev` still has its own PR/branch (#464 → `dev`) for the normal integration flow; this is a separate, parallel hotfix path straight to `main` so the fix can ship to production immediately.