### PR TITLE
fix(chat): estä AI-tukichatin videohallusinaatio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Kaikki merkittävät muutokset tähän projektiin kirjataan tähän tiedostoon.
 
 ## [Unreleased]
 
+### Fixed
+- `inc/chat.php` / `tests/ChatProxyTest.php` / `CLAUDE.md`: korjattu AI-tukichatin videohallusinaatio. Tuotannossa chatti vastasi kysymykseen "Onko sivustolla videoita?" väittämällä, ettei sivustolla ole videoita — vaikka albumisivuilla on oma "Videot"-osio upotetuille YouTube-videoille ja tapahtumasivun sisältöön voidaan upottaa tallenne. Pysyvä sivustokonteksti (`rytkoset_theme_chat_get_stable_site_context()`) ei maininnut tätä lainkaan, joten malli päätteli asian väärin. Lisätty rivi, joka kertoo videoiden olemassaolosta ja kieltää väittämästä, ettei niitä ole. 2 uutta assertiota olemassa olevaan testiin. `php -l` + phpcs + PHPUnit vihreät.
+
 ## [1.2.0] - 2026-07-03
 
 AI-tukichatti (EPIC 11): palvelinpuolen REST-välityskerros Mistraliin, kelluva chat-widget, Customizer-asetukset, ajantasainen tietolohko (tapahtumat, jäsenyystuotteet, kaupan tuotekatalogi) ja käyttötilastot wp-adminin Dashboard-widgetiin. Lisäksi asiakkaan tilausnäkymään näkyvä maksun jatkamisen/uudelleenyrityksen polku (#462), digilehtien kassalle lisätty nimenomainen suostumus peruuttamisoikeuden menettämisestä (#477, KSL 6:15 § 2 mom / 6:24 § 2 mom) sekä maksu- ja toimitusehtojen ja rekisteriselosteen versioitujen lähdekopioiden viimeistely (#476).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,12 @@ Chat knowledge guardrail: `inc/chat.php` includes a stable site context helper,
 `rytkoset_theme_chat_stable_site_context`), in every system prompt. It locks in
 site basics that must not be left to model inference: Finnish store/account
 paths (`/kauppa/`, `/oma-tili/tilaukset/`), the album gallery at `/albumit/`
-(with an explicit denial of the nonexistent `/kuvat/`), forum availability,
-blog-submission handling via maintainers, social links, digital magazines as
-HTML content rather than PDFs, sukukirja library borrowing, the published
+(with an explicit denial of the nonexistent `/kuvat/`), the fact that album
+pages can embed YouTube videos in their own "Videot" section and event pages
+can embed a recording (added after production claimed the site had no videos
+at all, contradicting album/event pages that do embed them), forum
+availability, blog-submission handling via maintainers, social links, digital
+magazines as HTML content rather than PDFs, sukukirja library borrowing, the published
 `Rytkösten sukulainen nro 9` product, the board page and full 2023-2026 board
 member list, and conditional payment retry wording. A dynamically built sitemap
 block (`rytkoset_theme_chat_get_sitemap_context()`) additionally lists all

--- a/tests/ChatProxyTest.php
+++ b/tests/ChatProxyTest.php
@@ -199,6 +199,8 @@ final class ChatProxyTest extends Rytkoset_Theme_Test_Case {
 		$this->assertStringContainsString( 'äläkä lisää muita nimiä', $context );
 		$this->assertStringNotContainsString( 'Jari Rytkönen', $context );
 		$this->assertStringContainsString( 'Maksa / yritä uudelleen -painike', $context );
+		$this->assertStringContainsString( 'upotettuja YouTube-videoita omassa Videot-osiossaan', $context );
+		$this->assertStringContainsString( 'Älä väitä, ettei sivustolla ole videoita', $context );
 	}
 
 	public function test_system_prompt_includes_stable_site_context(): void {

--- a/wp-content/themes/rytkoset-theme/inc/chat.php
+++ b/wp-content/themes/rytkoset-theme/inc/chat.php
@@ -1260,6 +1260,7 @@ if ( ! function_exists( 'rytkoset_theme_chat_get_stable_site_context' ) ) {
 			'- Verkkokauppa: /kauppa/. Ostoskori: /ostoskori/. Kassa: /kassa/. Oma tili: /oma-tili/. Tilaukset: /oma-tili/tilaukset/.',
 			'- Tapahtumat: /tapahtumat/. Kuvat ja albumit: /albumit/. Foorumi: /foorumi/. Blogi: /blogi/. Digilehdet: /digilehdet/.',
 			'- Kuvagalleria on osoitteessa /albumit/ — sivustolla ei ole /kuvat/- eikä /galleria/-osoitetta.',
+			'- Osalla albumisivuista on upotettuja YouTube-videoita omassa Videot-osiossaan, ja tapahtumasivun sisältöön voidaan upottaa tallenteen video. Älä väitä, ettei sivustolla ole videoita — jos et tiedä onko tietyllä albumilla tai tapahtumalla videota, ohjaa albumi- tai tapahtumasivulle tarkistettavaksi.',
 			'- Foorumi on käytössä sivustolla. Kirjautunut käyttäjä voi aloittaa keskustelun, jos hänellä on foorumin julkaisuoikeus. Älä väitä foorumia suljetuksi vain siksi, että viimeisin viesti on vanha.',
 			'- Blogi näyttää julkaistut kirjoitukset. Blogikirjoituksia voi ehdottaa tai lähettää ylläpidolle sähköpostitse; julkaisu tehdään ylläpidon kautta. Älä väitä, ettei blogitekstejä oteta vastaan.',
 			'- Blogikirjoituksissa ja albumeissa voi olla kommentointi käytössä; kommentit moderoidaan ennen julkaisua.',


### PR DESCRIPTION
## Yhteenveto

- Käyttäjä havaitsi tuotannon AI-tukichatin väittävän kysyttäessä "Onko sivustolla videoita?", ettei sivustolla ole videoita — vain YouTube-kanava mainittiin. Todellisuudessa albumisivuilla on oma "Videot"-osio upotetuille YouTube-videoille ja tapahtumasivun sisältöön voidaan upottaa tallenne.
- Pysyvä sivustokonteksti (`rytkoset_theme_chat_get_stable_site_context()`) ei maininnut videoita lainkaan, joten malli päätteli asian väärin — sama hallusinaatioluokka kuin aiemmat #480/#482.
- Lisätty pysyvään sivustokontekstiin rivi, joka kertoo albumien/tapahtumien videoista ja kieltää väittämästä ettei niitä olisi.

Closes #485

## Muutokset

- `inc/chat.php`: uusi rivi `rytkoset_theme_chat_get_stable_site_context()`-funktiossa.
- `tests/ChatProxyTest.php`: 2 uutta assertiota.
- `CLAUDE.md`: chat-guardrail-kappale päivitetty.
- `CHANGELOG.md`: Fixed-merkintä Unreleased-osioon.

## Test plan

- [x] `php -l` koko teemalle — ei virheitä
- [x] `composer run lint` (phpcs) `inc/chat.php`:lle — ei virheitä
- [x] PHPUnit (413 testiä) — kaikki vihreät
- [ ] Manuaalinen savutesti dev-ympäristössä chat-widgetillä kysymyksellä "Onko sivustolla videoita?"