### PR TITLE
fix(nav): käytä wp_login_url() työpöydän Kirjaudu-linkissä

### DIFF
--- a/wp-content/themes/rytkoset-theme/functions.php
+++ b/wp-content/themes/rytkoset-theme/functions.php
@@ -401,8 +401,7 @@ function rytkoset_theme_account_menu_logged_in_fallback() {
 function rytkoset_theme_account_menu_logged_out_fallback() {
 	echo '<ul class="account-nav__list">';
 	echo '<li class="menu-item">';
-	$login_url = function_exists( 'rytkoset_theme_get_my_account_url' ) ? rytkoset_theme_get_my_account_url() : wp_login_url();
-	echo '<a href="' . esc_url( $login_url ) . '">';
+	echo '<a href="' . esc_url( wp_login_url() ) . '">';
 	echo esc_html__( 'Kirjaudu', 'rytkoset-theme' );
 	echo '</a>';
 	echo '</li>';


### PR DESCRIPTION
## Summary

- Korjaa uloskirjautuneen käyttäjän työpöytä-headerin "Kirjaudu"-napin, joka vei WooCommercen `/oma-tili/`-sivulle teemalle tehdyn oman `wp-login.php`-kirjautumisnäkymän sijaan

## Changes

- `functions.php`: `rytkoset_theme_account_menu_logged_out_fallback()` käyttää nyt suoraan `wp_login_url()`:ta aiemman `rytkoset_theme_get_my_account_url()`-fallbackin sijaan
- Ei muutoksia kirjautuneen käyttäjän "Oma tili" -linkkeihin (#462) eikä mobiilivalikkoon, jotka käyttivät jo oikeita osoitteita

## Testing

- `php -l` (Docker) — ei syntaksivirheitä
- `composer run lint` (phpcs/WPCS, Docker) — läpi ilman virheitä
- `composer run test` (phpunit, Docker) — 430 testiä, 745 assertiota, kaikki läpi
- Manuaalista selaintestausta ei tehty tässä kierroksessa; suositellaan varmistamaan dev-ympäristössä, että työpöytä-headerin "Kirjaudu" vie `wp-login.php`-näkymään uloskirjautuneena

## Notes

- Fixes #494
